### PR TITLE
Add new 8.12 branch to CI

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -370,6 +370,10 @@ spec:
           branch: '7.17'
           cronline: 0 1 * * 2
           message: Weekly Linux JDK matrix tests for 7.17
+        Weekly 8_12:
+          branch: '8.12'
+          cronline: 0 1 * * 2
+          message: Weekly Linux JDK matrix tests for 8.12
         Weekly 8_11:
           branch: '8.11'
           cronline: 0 1 * * 2
@@ -425,6 +429,10 @@ spec:
           branch: '7.17'
           cronline: 0 1 * * 2
           message: Weekly Windows JDK matrix tests for 7.17
+        Weekly 8_12:
+          branch: '8.12'
+          cronline: 0 1 * * 2
+          message: Weekly Windows JDK matrix tests for 8.12
         Weekly 8_11:
           branch: '8.11'
           cronline: 0 1 * * 2

--- a/ci/branches.json
+++ b/ci/branches.json
@@ -5,6 +5,9 @@
         "branch": "main"
       },
       {
+        "branch": "8.12"
+      },
+      {
         "branch": "8.11"
       },
       {


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Now that we have a new 8.12 branch[^1], add it to CI definitions.

[^1]: https://github.com/elastic/logstash/tree/8.12
