### PR TITLE
Update JRuby core to 9.4.5.0 of rubyUtils.gralde

### DIFF
--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-core:9.4.2.0"
+        classpath "org.jruby:jruby-core:9.4.5.0"
     }
 }
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
We upgraded JRuby version to 9.4.5.0 and it seems `rubyUtils.gralde` was missed.

## Why is it important/What is the impact to the user?
N.A

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues
- 

## Use cases

## Screenshots

## Logs
