### PR TITLE
Separate scheduling of segments flushes from time

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -67,16 +67,33 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         }
     }
 
+    private static class SynchScheduledService implements DeadLetterQueueWriter.SchedulerService {
+
+        private Runnable action;
+
+        @Override
+        public void repeatedAction(Runnable action) {
+            this.action = action;
+        }
+
+        void executeActionSynch() {
+            action.run();
+        }
+    }
+
     private Path dir;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private SynchScheduledService synchScheduler;
 
     @Before
     public void setUp() throws Exception {
         dir = temporaryFolder.newFolder().toPath();
         final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
         fakeClock = new ForwardableClock(pointInTimeFixedClock);
+        synchScheduler = new SynchScheduledService();
     }
 
     @Test
@@ -272,7 +289,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     }
 
     @Test
-    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentWriterIsStale() throws IOException, InterruptedException {
+    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentWriterIsStale() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
                 Collections.singletonMap("message", "Not so important content"));
 
@@ -298,9 +315,10 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         // move forward 3 days, so that the first segment becomes eligible to be deleted by the age retention policy
         fakeClock.forward(Duration.ofDays(3));
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, flushInterval)
+                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
+                .schedulerService(synchScheduler)
                 .build()) {
             // write an element to make head segment stale
             final Event anotherEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
@@ -308,8 +326,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
             DLQEntry entry = new DLQEntry(anotherEvent, "", "", "00002", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
             writeManager.writeEntry(entry);
 
-            // wait a cycle of flusher schedule
-            Thread.sleep(flushInterval.toMillis());
+            triggerExecutionOfFlush();
 
             // flusher should clean the expired segments
             Set<String> actual = listFileNames(dir);
@@ -317,9 +334,8 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         }
     }
 
-
     @Test
-    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException, InterruptedException {
+    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
                 Collections.singletonMap("message", "Not so important content"));
 
@@ -328,31 +344,38 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
 
         Duration retainedPeriod = Duration.ofDays(1);
-        Duration flushInterval = Duration.ofSeconds(1);
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, flushInterval)
+                .newBuilderWithoutFlusher(dir, 10 * MB, 1 * GB)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
+                .schedulerService(synchScheduler)
                 .build()) {
 
             DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
             writeManager.writeEntry(entry);
 
+            triggerExecutionOfFlush();
+
             // wait the flush interval so that the current head segment is sealed
             Awaitility.await("After the flush interval head segment is sealed and a fresh empty head is created")
-                    .atLeast(flushInterval)
-                    .atMost(Duration.ofMinutes(1))
+                    .atMost(Duration.ofSeconds(1))
                     .until(()  -> Set.of("1.log", "2.log.tmp", ".lock").equals(listFileNames(dir)));
 
             // move forward the time so that the age policy is kicked in when the current head segment is empty
             fakeClock.forward(retainedPeriod.plusMinutes(2));
 
+            triggerExecutionOfFlush();
+
             // wait the flush period
             Awaitility.await("Remains the untouched head segment while the expired is removed")
                     // wait at least the flush period
-                    .atMost(Duration.ofMinutes(1))
+                    .atMost(Duration.ofSeconds(1))
                     // check the expired sealed segment is removed
                     .until(()  -> Set.of("2.log.tmp", ".lock").equals(listFileNames(dir)));
         }
+    }
+
+    private void triggerExecutionOfFlush() {
+        synchScheduler.executeActionSynch();
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Introduces a new interface named `SchedulerService` to abstract from the `ScheduledExecutorService` to execute the DLQ flushes of segments. Abstracting from time provides a benefit in testing, where the test doesn't have to wait for things to happen, but those things could happen synchronously.

## Why is it important/What is the impact to the user?

The user in this case is the developer of test, which doesn't have to put wait conditions or sleeps in test code, resulting in more stable (less flaky tests, avoid time variability) and deterministic tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] make a run with Logstash flushing files, to be sure the old behaviour is maintained

## How to test this PR locally

The local test just assures that the existing feature works as expected.

- download Elasticsearch, unpack and run the first time. It will print the generated credentials on console, copy those somewhere for later usage.
- create and close an index:
```sh
curl --user elastic:<generated pwd> -k -XPUT "https://localhost:9200/test_index"
curl --user elastic:<generated pwd> -k -XPOST "https://localhost:9200/test_index/_close"
```
- copy the http certificates from Elasticsearch (`<es dir>/config/certs/http_ca.crt`) somewhere and make them not writeable (`chmod a-w `/tmp/http_ca.crt`)
- edit a Logstash pipeline to index data into the closed index
```
input {
  stdin {
    codec => json
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "https://localhost:9200"
    user => "elastic"
    password => "<generated pwd>"
    ssl_enabled => true
    ssl_certificate_authorities => ["/tmp/http_ca.crt"]
  }
}  
```
- enable DLQ on Logstash and modify the `flush_interval`, edit `config/logstash.yml`:
```yaml
dead_letter_queue.enable: true
dead_letter_queue.flush_interval: 10000
```
- run the pipeline:
```sh
bin/logstash -f `pwd`/dlq_pipeline.conf
```
- verify in `data/dead_letter_queue/main` that everytime a json message is typed into the LS console, then the DLQ folder  receives a new segment (it generates a new head segment with `tmp` suffix and previous head becomes a new segment) in 30 seconds.



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15594 
