### PR TITLE
Bug fix for trigger pipeline Buildkite pipeline

### DIFF
--- a/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
+++ b/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
@@ -47,11 +47,9 @@ for BRANCH in $BRANCHES; do
     cat >>pipeline_steps.yaml <<EOF
   - trigger: $PIPELINE_TO_TRIGGER
     label: ":testexecute: Triggering ${PIPELINE_TO_TRIGGER} / ${BRANCH}"
-    branches: "main"
-    async: true
     build:
       branch: "$BRANCH"
-      message: ":testexecute: Triggering ${PIPELINE_TO_TRIGGER} / ${BRANCH}"
+      message: ":testexecute: Scheduled build for ${BRANCH}"
 EOF
 done
 
@@ -59,4 +57,4 @@ echo "--- Printing generated steps"
 yq . pipeline_steps.yaml
 
 echo "--- Uploading steps to buildkite"
-cat pipeline_steps.yml | buildkite-agent pipeline upload
+cat pipeline_steps.yaml | buildkite-agent pipeline upload

--- a/.buildkite/trigger_pipeline.yml
+++ b/.buildkite/trigger_pipeline.yml
@@ -2,4 +2,4 @@
 
 steps:
   - label: ":pipeline: Generate trigger steps for $PIPELINE_TO_TRIGGER"
-    command: ".buildkite/scripts/trigger-pipeline-generate-steps.sh"
+    command: ".buildkite/scripts/common/trigger-pipeline-generate-steps.sh"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit fixes a bug introduced in #15668 related to the path of the script triggered by the trigger pipeline pipeline.

## Related issues

- https://github.com/elastic/logstash/pull/15668
