### PR TITLE
[ci] Allow schedule to trigger several pipelines

### DIFF
--- a/.buildkite/trigger_pipelines.yml
+++ b/.buildkite/trigger_pipelines.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 steps:
-  - label: ":pipeline: Generate trigger steps for $PIPELINE_TO_TRIGGER"
+  - label: ":pipeline: Generate trigger steps for $PIPELINES_TO_TRIGGER"
     command: ".buildkite/scripts/common/trigger-pipeline-generate-steps.sh"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -185,7 +185,7 @@ spec:
       description: ':alarm_clock: Scheduled runs of Logstash DRA Snapshot Pipeline per eligible branch'
     spec:
       repository: elastic/logstash
-      pipeline_file: ".buildkite/trigger_pipeline.yml"
+      pipeline_file: ".buildkite/trigger_pipelines.yml"
       maximum_timeout_in_minutes: 120
       schedules:
         Daily main:
@@ -196,7 +196,7 @@ spec:
       provider_settings:
         trigger_mode: none
       env:
-        PIPELINE_TO_TRIGGER: 'logstash-dra-snapshot-pipeline'
+        PIPELINES_TO_TRIGGER: 'logstash-dra-snapshot-pipeline'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit enhances the functionality introduced in #15668 and #15700 by allowing a single Buildkite scheduling job to trigger several pipelines, in addition to multiple branches which it already does.

We rename the env var PIPELINE_TO_TRIGGER to PIPELINES_TO_TRIGGER which now supports comma separate values.

## Why is it important/What is the impact to the user?

This enhancement can be useful for pipelines like JDK matrix which have variants (Linux and Windows) that we want to trigger with a single scheduling job, thus reducing unnecessary entries in catalog-info.

## Related issues

- Relates #15668 #15700 
