### PR TITLE
Common scheduler pipeline for Buildkite

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -168,53 +168,6 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: logstash-scheduled-dra-snapshot-pipeline
-  description: 'Scheduled runs (Daily, Auto) of Logstash DRA SNAPSHOT pipeline per branch'
-  links:
-    - title: 'Scheduled runs (Daily, Auto) of Logstash DRA SNAPSHOT pipeline per branch'
-      url: https://buildkite.com/elastic/logstash-scheduled-dra-snapshot-pipeline
-spec:
-  type: buildkite-pipeline
-  owner: group:logstash
-  system: buildkite
-  implementation:
-    apiVersion: buildkite.elastic.dev/v1
-    kind: Pipeline
-    metadata:
-      name: Logstash Scheduled DRA Snapshot Pipeline
-      description: ':alarm_clock: Scheduled runs of Logstash DRA Snapshot Pipeline per eligible branch'
-    spec:
-      repository: elastic/logstash
-      pipeline_file: ".buildkite/trigger_pipelines.yml"
-      maximum_timeout_in_minutes: 120
-      schedules:
-        Daily main:
-          branch: main
-          cronline: 30 02 * * *
-          message: Daily trigger of DRA Pipeline per branch
-      skip_intermediate_builds: true
-      provider_settings:
-        trigger_mode: none
-      env:
-        PIPELINES_TO_TRIGGER: 'logstash-dra-snapshot-pipeline'
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-        SLACK_NOTIFICATIONS_CHANNEL: '#logstash'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
-      teams:
-        ingest-fp:
-          access_level: MANAGE_BUILD_AND_READ
-        logstash:
-          access_level: MANAGE_BUILD_AND_READ
-        ingest-eng-prod:
-          access_level: MANAGE_BUILD_AND_READ
-        everyone:
-          access_level: READ_ONLY
-
----
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
-apiVersion: backstage.io/v1alpha1
-kind: Resource
-metadata:
   name: logstash-dra-staging-pipeline
   description: 'Logstash DRA RELEASE (Staging) pipeline'
   links:
@@ -399,23 +352,6 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
-      schedules:
-        Weekly 7_17:
-          branch: '7.17'
-          cronline: 0 1 * * 2
-          message: Weekly Linux JDK matrix tests for 7.17
-        Weekly 8_12:
-          branch: '8.12'
-          cronline: 0 1 * * 2
-          message: Weekly Linux JDK matrix tests for 8.12
-        Weekly 8_11:
-          branch: '8.11'
-          cronline: 0 1 * * 2
-          message: Weekly Linux JDK matrix tests for 8.11
-        Daily main:
-          branch: main
-          cronline: 0 1 * * 2
-          message: Weekly Linux JDK matrix tests for main
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -458,23 +394,6 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
-      schedules:
-        Weekly 7_17:
-          branch: '7.17'
-          cronline: 0 1 * * 2
-          message: Weekly Windows JDK matrix tests for 7.17
-        Weekly 8_12:
-          branch: '8.12'
-          cronline: 0 1 * * 2
-          message: Weekly Windows JDK matrix tests for 8.12
-        Weekly 8_11:
-          branch: '8.11'
-          cronline: 0 1 * * 2
-          message: Weekly Windows JDK matrix tests for 8.11
-        Daily main:
-          branch: main
-          cronline: 0 1 * * 2
-          message: Weekly Windows JDK matrix tests for main
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -577,3 +496,66 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+# **************************************************************
+# SECTION START: Scheduler pipeline 
+# (Definitions for scheduled runs of various Logstash pipelines)
+# **************************************************************
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-pipeline-scheduler
+  description: 'Scheduled runs of Logstash pipelines per release branch'
+  links:
+    - title: 'Scheduled runs of Logstash pipelines per release branch'
+      url: https://buildkite.com/elastic/logstash-pipeline-scheduler
+spec:
+  type: buildkite-pipeline
+  owner: group:logstash
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: Logstash Pipeline Scheduler
+      description: ':alarm_clock: Scheduled runs of Logstash pipelines per release branch'
+    spec:
+      repository: elastic/logstash
+      pipeline_file: ".buildkite/trigger_pipelines.yml"
+      maximum_timeout_in_minutes: 240
+      schedules:
+        Daily Snapshot DRA:
+          branch: main
+          cronline: 30 02 * * *
+          message: Daily trigger of Snapshot DRA Pipeline per branch
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-dra-snapshot-pipeline'
+        Weekly JDK matrix:
+          branch: main
+          cronline: 0 1 * * 2
+          message: Weekly trigger of JDK matrix pipelines per branch
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-linux-jdk-matrix-pipeline,logstash-windows-jdk-matrix-pipeline'
+      skip_intermediate_builds: true
+      provider_settings:
+        trigger_mode: none
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+# *******************************
+# SECTION END: Scheduler pipeline
+# *******************************


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

As an improvement from #15668 / #15700, rather than having one dedicated side-car scheduling job per pipeline, we move to a single scheduling job. Various pipelines that need triggering with different schedules now live under each schedule in the new pipeline.

## Why is it important/What is the impact to the user?

This reduces the amount of jobs we have to maintain in yaml.

## Related issues

- Relates #15668 / #15700
- Supersedes #15704
