### PR TITLE
Replace Gradle's report.enabled setting to report's required property

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -132,8 +132,8 @@ tasks.register("javaTests", Test) {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
     }
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Replaces the usage of deprecated Gradle setting.
The reporting `enabled` setting flag has been deprecated by `required` property flag.

## Why is it important/What is the impact to the user?

With this change we fix a deprecation warning that would transform in an error when moving to Gradle 8.5

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run Gradle with diagnostic flags enabled and check no warning is raised:
```sh
./gradlew  assemble --warning-mode all
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

As a developer I want the upgrade to next Gradle 8.5 is smooth as possible.



## Logs

```
andrea:logstash_andsel (main) % ./gradlew clean --warning-mode all
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.5/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build

> Configure project :logstash-core
The Report.enabled property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the required property instead. See https://docs.gradle.org/7.5/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled for more details.
        at build_dwhxvsfe5dt0ygbnkvdwypvks$_run_closure11$_closure24.doCall(/Users/andrea/workspace/logstash_andsel/logstash-core/build.gradle:135)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```