### PR TITLE
[ci] Add testing phase to exhaustive tests suite

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -103,12 +103,14 @@ if __name__ == "__main__":
     structure["steps"].append({
             "group": "Compatibility / Linux",
             "key": "compatibility-linux",
+            "depends_on": "testing-phase",
             "steps": compat_linux_steps,
     })
 
     structure["steps"].append({
             "group": "Compatibility / Windows",
             "key": "compatibility-windows",
+            "depends_on": "testing-phase",
             "steps": [compat_windows_step(imagesuffix=windows_test_os)],
     })
 

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -9,6 +9,7 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
+CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 
 def slugify_bk_key(key: str) -> str:
     """
@@ -19,6 +20,10 @@ def slugify_bk_key(key: str) -> str:
     mapping_table = str.maketrans({'.': '_', ' ': '_', '/': '_'})
 
     return key.translate(mapping_table)
+
+def testing_phase_steps() -> typing.Dict[str, typing.List[typing.Any]]:
+    with open(os.path.join(CUR_PATH, "..", "..", "pull_request_pipeline.yml")) as fp:
+        return YAML().load(fp)
 
 def compat_linux_step(imagesuffix: str) -> dict[str, typing.Any]:
     linux_command = LiteralScalarString("""#!/usr/bin/env bash
@@ -88,6 +93,12 @@ if __name__ == "__main__":
     windows_test_os = WINDOWS_OS_ENV_VAR_OVERRIDE or randomized_windows_os()
 
     structure = {"steps": []}
+
+    structure["steps"].append({
+        "group": "Testing Phase",
+        "key": "testing-phase",
+        **testing_phase_steps(),
+    })
 
     structure["steps"].append({
             "group": "Compatibility / Linux",


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This is the second part of the migration of the exhaustive/main Jenkins Job to Buildkite. So far we've migrated the "compatibility phase" and this commit adds the "testing phase"[^1], which is essentially the same amount of tests that we ran on PR jobs.

For more details, refer to the sequence diagram in https://github.com/elastic/ingest-dev/issues/1722#issuecomment-1824378635

## Why is it important/What is the impact to the user?

This runs the usual set of unit + IT tests in the [exhaustive test pipeline](https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline), e.g. triggered by push events.

## How to test this PR locally

See triggered BK job: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/41#_

## Screenshots

Once triggered e.g. [in this link](https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/41#_) in the structure looks like:

![image](https://github.com/elastic/logstash/assets/1754575/d59663b4-a574-45c9-891b-40faf8efeef5)

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/1722
- Depends https://github.com/elastic/logstash/pull/15708
