### PR TITLE
JDK 21 move

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -750,7 +750,7 @@ class JDKDetails {
             url += "_${arch}"
         }
         println "Retrieving JDK from catalog..."
-        def catalogMetadataUrl = new URL(url)
+        def catalogMetadataUrl = URI.create(url).toURL()
         def catalogConnection = catalogMetadataUrl.openConnection()
         catalogConnection.requestMethod = 'GET'
         assert catalogConnection.responseCode == 200

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+java.util.LinkedHashSet.remove_method(:map) rescue nil
 
 require_relative "environment"
 LogStash::Bundler.setup!({:without => [:build]})

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# The following line is needed because from starting from JDK 21 LinkedHashSet
+# The following line is a workaround needed because starting from JDK 21 LinkedHashSet
 # has a package private map method that JRuby bound as a usable method.
 # It's mainly related to Gradle opening java.base module and this interfere with
 # JRuby binding of methods. Full description at https://github.com/jruby/jruby/issues/8061#issuecomment-1908807511
+# Remove when Logstash bundle a JRuby version >= 9.4.6.0.
 java.util.LinkedHashSet.remove_method(:map) rescue nil
 
 require_relative "environment"

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -20,7 +20,7 @@
 # It's mainly related to Gradle opening java.base module and this interfere with
 # JRuby binding of methods. Full description at https://github.com/jruby/jruby/issues/8061#issuecomment-1908807511
 # Remove when Logstash bundle a JRuby version >= 9.4.6.0.
-java.util.LinkedHashSet.remove_method(:map) rescue nil
+# java.util.LinkedHashSet.remove_method(:map) rescue nil
 
 require_relative "environment"
 LogStash::Bundler.setup!({:without => [:build]})

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -14,6 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+# The following line is needed because from starting from JDK 21 LinkedHashSet
+# has a package private map method that JRuby bound as a usable method.
+# It's mainly related to Gradle opening java.base module and this interfere with
+# JRuby binding of methods. Full description at https://github.com/jruby/jruby/issues/8061#issuecomment-1908807511
 java.util.LinkedHashSet.remove_method(:map) rescue nil
 
 require_relative "environment"

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -15,12 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# The following line is a workaround needed because starting from JDK 21 LinkedHashSet
-# has a package private map method that JRuby bound as a usable method.
-# It's mainly related to Gradle opening java.base module and this interfere with
-# JRuby binding of methods. Full description at https://github.com/jruby/jruby/issues/8061#issuecomment-1908807511
-# Remove when Logstash bundle a JRuby version >= 9.4.6.0.
-# java.util.LinkedHashSet.remove_method(:map) rescue nil
 
 require_relative "environment"
 LogStash::Bundler.setup!({:without => [:build]})

--- a/lib/bootstrap/rspec.rb
+++ b/lib/bootstrap/rspec.rb
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 require_relative "environment"
 LogStash::Bundler.setup!({:without => [:build]})
 require "logstash-core"

--- a/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/jvm.rb
@@ -36,7 +36,7 @@ module LogStash module Instrument module PeriodicPoller
   class JVM < Base
     class GarbageCollectorName
       YOUNG_GC_NAMES = Set.new(["Copy", "PS Scavenge", "ParNew", "G1 Young Generation", "scavenge", "GPGC New"])
-      OLD_GC_NAMES = Set.new(["MarkSweepCompact", "PS MarkSweep", "ConcurrentMarkSweep", "G1 Old Generation", "global", "GPGC Old"])
+      OLD_GC_NAMES = Set.new(["MarkSweepCompact", "PS MarkSweep", "ConcurrentMarkSweep", "G1 Old Generation", "G1 Concurrent GC", "global", "GPGC Old"])
 
       YOUNG = :young
       OLD = :old

--- a/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
+++ b/logstash-core/src/main/java/org/logstash/common/SourceWithMetadata.java
@@ -65,6 +65,7 @@ public class SourceWithMetadata implements HashableWithSource {
 
     private static final Pattern emptyString = Pattern.compile("^\\s*$");
 
+    @SuppressWarnings("this-escape")
     public SourceWithMetadata(String protocol, String id, Integer line, Integer column, String text, String metadata) throws IncompleteSourceWithMetadataException {
         this.protocol = protocol;
         this.id = id;
@@ -73,6 +74,9 @@ public class SourceWithMetadata implements HashableWithSource {
         this.text = text;
         this.metadata = metadata;
 
+        // This is the reason why of the "this-escape" suppress warning, a method (attributes) is invoked on
+        // a non completely initialized object and that could generate some errors in accessing fields.
+        // This is not the case because the method is private and not overridable in sub classes.
         List<Object> badAttributes = this.attributes().stream().filter(a -> {
             if (a == null) return true;
             if (a instanceof String) {

--- a/logstash-core/src/main/java/org/logstash/config/ir/expression/RegexValueExpression.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/expression/RegexValueExpression.java
@@ -34,7 +34,7 @@ public class RegexValueExpression extends ValueExpression {
             throw new InvalidIRException("Regex value expressions can only take strings!");
         }
 
-        this.regex = getSource();
+        this.regex = (String) value;
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/graph/Edge.java
@@ -33,6 +33,7 @@ public abstract class Edge implements SourceComponent {
 
     private Graph graph;
 
+    @SuppressWarnings("this-escape")
     protected Edge(Vertex from, Vertex to) throws InvalidIRException {
         this.from = from;
         this.to = to;
@@ -41,6 +42,9 @@ public abstract class Edge implements SourceComponent {
             throw new InvalidIRException("Cannot create a cyclic vertex! " + to);
         }
 
+        // This is the reason why of the "this-escape" suppress warning. The instance is passed to the method acceptsOutgoingEdge
+        // before the constructor completes, so could potentially reach some runtime errors due to fields not initialized.
+        // This is not the case because actually that method just does type check on reference.
         if (!this.from.acceptsOutgoingEdge(this)) {
             throw new Vertex.InvalidEdgeTypeException(String.format("Invalid outgoing edge %s for edge %s", this.from, this));
         }

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -174,7 +174,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
 
                 IRubyObject batchSize = Optional.of((RubyThread) thread)
                         .map(RubyThread::getNativeThread)
-                        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+                        // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
                         .map(Thread::getId)
                         .map(id -> batchMap.op_aref(context, context.runtime.newFixnum(id)))
                         .map(batch -> extractBatchSize(context, batch))

--- a/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/PipelineReporterExt.java
@@ -157,7 +157,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
         return result;
     }
 
-    @SuppressWarnings({"unchecked","rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
     private RubyArray workerStates(final ThreadContext context, final RubyHash batchMap) {
         final RubyArray result = context.runtime.newArray();
         ((Iterable<IRubyObject>) pipeline.callMethod(context, "worker_threads"))
@@ -174,6 +174,7 @@ public final class PipelineReporterExt extends RubyBasicObject {
 
                 IRubyObject batchSize = Optional.of((RubyThread) thread)
                         .map(RubyThread::getNativeThread)
+                        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
                         .map(Thread::getId)
                         .map(id -> batchMap.op_aref(context, context.runtime.newFixnum(id)))
                         .map(batch -> extractBatchSize(context, batch))

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -131,7 +131,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     @SuppressWarnings("deprecation")
     public void closeBatch(QueueBatch batch) throws IOException {
         batch.close();
-        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+        // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         inflightBatches.remove(Thread.currentThread().getId());
     }
 
@@ -190,7 +190,7 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     @Override
     @SuppressWarnings("deprecation")
     public void startMetrics(QueueBatch batch) {
-        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+        // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         long threadId = Thread.currentThread().getId();
         inflightBatches.put(threadId, batch);
     }

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBase.java
@@ -128,8 +128,10 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void closeBatch(QueueBatch batch) throws IOException {
         batch.close();
+        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         inflightBatches.remove(Thread.currentThread().getId());
     }
 
@@ -186,7 +188,9 @@ public abstract class QueueReadClientBase extends RubyObject implements QueueRea
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void startMetrics(QueueBatch batch) {
+        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         long threadId = Thread.currentThread().getId();
         inflightBatches.put(threadId, batch);
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -145,6 +145,7 @@ public final class HotThreadsMonitor {
      *                      stacktrace_size - max depth of stack trace
      * @return A list of ThreadReport including all selected threads
      */
+    @SuppressWarnings("deprecation")
     public static List<ThreadReport> detect(Map<String, String> options) {
         String type = "cpu";
         if (options.containsKey(ORDERED_BY)) {
@@ -164,6 +165,7 @@ public final class HotThreadsMonitor {
         Map<Long, ThreadReport> reports = new HashMap<>();
 
         for (long threadId : threadMXBean.getAllThreadIds()) {
+            // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
             if (Thread.currentThread().getId() == threadId) {
                 continue;
             }

--- a/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/monitors/HotThreadsMonitor.java
@@ -165,7 +165,7 @@ public final class HotThreadsMonitor {
         Map<Long, ThreadReport> reports = new HashMap<>();
 
         for (long threadId : threadMXBean.getAllThreadIds()) {
-            // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+            // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
             if (Thread.currentThread().getId() == threadId) {
                 continue;
             }

--- a/logstash-core/src/main/java/org/logstash/plugins/inputs/Stdin.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/inputs/Stdin.java
@@ -75,7 +75,10 @@ public class Stdin implements Input, Consumer<Map<String, Object>> {
         this(id, configuration, context, new FileInputStream(FileDescriptor.in).getChannel());
     }
 
+    @SuppressWarnings("this-escape")
     Stdin(final String id, final Configuration configuration, final Context context, FileChannel inputChannel) {
+        // This is the reason why of the "this-escape" suppress warning, but this is used just to grab the class
+        // for the logger.
         logger = context.getLogger(this);
         this.id = id;
         try {

--- a/logstash-core/src/main/java/org/logstash/util/UtilExt.java
+++ b/logstash-core/src/main/java/org/logstash/util/UtilExt.java
@@ -34,6 +34,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 public class UtilExt {
 
     @JRubyMethod(module = true)
+    @SuppressWarnings("deprecation")
     public static IRubyObject get_thread_id(final ThreadContext context, IRubyObject self, IRubyObject thread) {
         if (!(thread instanceof RubyThread)) {
             throw context.runtime.newTypeError(thread, context.runtime.getThread());
@@ -41,6 +42,7 @@ public class UtilExt {
         final Thread javaThread = ((RubyThread) thread).getNativeThread(); // weak-reference
         // even if thread is dead the RubyThread instance might stick around while the Java thread
         // instance already could have been garbage collected - let's return nil for dead meat :
+        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         return javaThread == null ? context.nil : context.runtime.newFixnum(javaThread.getId());
     }
 

--- a/logstash-core/src/main/java/org/logstash/util/UtilExt.java
+++ b/logstash-core/src/main/java/org/logstash/util/UtilExt.java
@@ -42,7 +42,7 @@ public class UtilExt {
         final Thread javaThread = ((RubyThread) thread).getNativeThread(); // weak-reference
         // even if thread is dead the RubyThread instance might stick around while the Java thread
         // instance already could have been garbage collected - let's return nil for dead meat :
-        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+        // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         return javaThread == null ? context.nil : context.runtime.newFixnum(javaThread.getId());
     }
 

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -48,7 +48,7 @@ public final class JrubyMemoryReadClientExtTest extends RubyTestBase {
         final QueueBatch batch = client.readBatch();
         final RubyHash inflight = client.rubyGetInflightBatches(context);
         assertThat(inflight.size(), is(1));
-        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
+        // JTODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         assertThat(inflight.get(Thread.currentThread().getId()), is(batch));
         client.closeBatch(batch);
         assertThat(client.rubyGetInflightBatches(context).size(), is(0));

--- a/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/ext/JrubyMemoryReadClientExtTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public final class JrubyMemoryReadClientExtTest extends RubyTestBase {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testInflightBatchesTracking() throws InterruptedException, IOException {
         final BlockingQueue<JrubyEventExtLibrary.RubyEvent> queue =
             new ArrayBlockingQueue<>(10);
@@ -47,6 +48,7 @@ public final class JrubyMemoryReadClientExtTest extends RubyTestBase {
         final QueueBatch batch = client.readBatch();
         final RubyHash inflight = client.rubyGetInflightBatches(context);
         assertThat(inflight.size(), is(1));
+        // TODO getId has been deprecated in JDK 19, when JDK 21 is the target version use threadId() instead
         assertThat(inflight.get(Thread.currentThread().getId()), is(batch));
         client.closeBatch(batch);
         assertThat(client.rubyGetInflightBatches(context).size(), is(0));

--- a/logstash-core/src/test/java/org/logstash/log/TestingDeprecationPlugin.java
+++ b/logstash-core/src/test/java/org/logstash/log/TestingDeprecationPlugin.java
@@ -40,6 +40,7 @@ public class TestingDeprecationPlugin implements Codec {
      * @param configuration Logstash Configuration
      * @param context       Logstash Context
      */
+    @SuppressWarnings("this-escape")
     public TestingDeprecationPlugin(final Configuration configuration, final Context context) {
         deprecationLogger = context.getDeprecationLogger(this);
     }

--- a/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/AliasRegistryTest.java
@@ -6,6 +6,7 @@ import org.logstash.plugins.PluginLookup.PluginType;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class AliasRegistryTest {
 
         for (AliasRegistry.PluginCoordinate alias : aliasesDefinitions.keySet()) {
             final String gemName = alias.fullName();
-            URL url = new URL("https://rubygems.org/api/v1/gems/" + gemName +".json");
+            URL url = URI.create("https://rubygems.org/api/v1/gems/" + gemName +".json").toURL();
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json");

--- a/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/SecretStoreFactoryTest.java
@@ -157,6 +157,7 @@ public class SecretStoreFactoryTest {
 
         Map<SecretIdentifier, ByteBuffer> secrets = new HashMap(1);
 
+        @SuppressWarnings("this-escape")
         public MemoryStore() {
             persistSecret(LOGSTASH_MARKER, LOGSTASH_MARKER.getKey().getBytes(StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Adaptations to run Logstash on JDK 21

## What does this PR do?

Adaptations to JDK 21:
- Java 8 support is obsolete and will be removed.
- Thread's `getId` (not final) replaced by final `threadId` https://bugs.openjdk.org/browse/JDK-8017617
- Verify the warnings "this-escape" when a constructor use other method or pass around `this` reference to other methods https://bugs.openjdk.org/browse/JDK-8015831
- URL constructor is deprecated, use `<uri_instance>.toURL()` (since JDK 20)
-  Manages new (since JDK 20) `G1 Concurrent GC` MX Bean, [ref](https://github.com/elastic/logstash/pull/15719#issuecomment-1946367785)

## Why is it important/What is the impact to the user?

As a developer I want that all the blockings to use JDK 21 are removed before effectively switching the bundled JDK to version 21

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run Buildkite JDK 21 matrix for this PR: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/136

## How to test this PR locally

Install a JDK 21 on your host, example:
```sh
sdk install java 21.0.2-tem
```
and run some testing, like
```sh
./gradlew runIntegrationTests -PrubyIntegrationSpecs="specs/mixed_codec_spec.rb" --console=plain
```

or if you would run all integration tests:
```sh
export BUILD_JAVA_HOME=/<home>/.sdkman/candidates/java/21.0.2-tem && export RUNTIME_JAVA_HOME=/<home>/.sdkman/candidates/java/21.0.2-tem && export LS_JAVA_HOME=/<home>/.sdkman/candidates/java/21.0.2-tem
ci/integration_tests.sh
```
try also a run of Logstash with `LS_JAVA_HOME` set to a JDK 21 path.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #15342 
- Requires #15707

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
