### PR TITLE
[ci] No Slack alerts for pipeline scheduling job

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -543,8 +543,8 @@ spec:
       provider_settings:
         trigger_mode: none
       env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-        SLACK_NOTIFICATIONS_CHANNEL: '#logstash'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       teams:
         ingest-fp:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

As a follow up to #15705, this commit shushes Slack alerts for the common Buildkite scheduling pipeline.
While at it, we also change the target slack channel to the proper one, in case we want to re-enable alerts in the future.

## Why is it important/What is the impact to the user?

 This is because the pipeline scheduler just triggers other pipelines which have their own dedicated alerts setup, therefore we want to avoid duplicate alerts when there is a failure with one of the triggered pipelines. An example of this kind of situation can be seen in [slack](https://elastic.slack.com/archives/C0D8VG3ND/p1704025480123649).
