### PR TITLE
Don't block triggered JDK matrix Buildkite jobs

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -69,7 +69,7 @@ steps:
             value: "zulu_11"
 
   - wait: ~
-    if: build.source != "schedule"
+    if: build.source != "schedule" && build.source != "trigger_job"
 
   - command: |
       set -euo pipefail

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -49,7 +49,7 @@ steps:
             value: "zulu_11"
 
   - wait: ~
-    if: build.source != "schedule"
+    if: build.source != "schedule" && build.source != "trigger_job"
 
   - command: |
       set -euo pipefail


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

The recent PRs #15668 and #15705 refactored jobs with a custom schedule to leverage a centralized trigger job.

An unexpected sideffect of this is that the conditional for the wait step doesn't work anymore.

This commit skips the wait step when the JDK matrix pipelines get triggered from another pipeline.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- #15668
- #15705
