### PR TITLE
Skip input step when triggering JDK matrix jobs

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -6,7 +6,7 @@ env:
 
 steps:
   - input: "Test Parameters"
-    if: build.source != "schedule"
+    if: build.source != "schedule" && build.source != "trigger_job"
     fields:
       - select: "Operating System"
         key: "matrix-os"

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -6,7 +6,7 @@ env:
 
 steps:
   - input: "Test Parameters"
-    if: build.source != "schedule"
+    if: build.source != "schedule" && build.source != "trigger_job"
     fields:
       - select: "Operating System"
         key: "matrix-os"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit also skips the input step when the job is triggered from the scheduler pipeline.

## Why is it important/What is the impact to the user?

PR#15729 missed the input step. As a result when the job is triggered the steps are executed, but the pause icon still shows in the job requiring manual unblock[^1]

## Related issues

[^1] https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/86
