### PR TITLE
JUnit result annotation for Buildkite PR jobs

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -47,6 +47,8 @@ steps:
 
       source .buildkite/scripts/common/container-agent.sh
       ci/unit_tests.sh java
+    artifact_paths:
+      - "**/build/test-results/javaTests/TEST-*.xml"
 
   - label: ":lab_coat: Integration Tests / part 1"
     key: "integration-tests-part-1"
@@ -139,3 +141,17 @@ steps:
 
       source .buildkite/scripts/common/container-agent.sh
       x-pack/ci/integration_tests.sh
+
+  - wait: ~
+    continue_on_failure: true
+
+  - label: "🏁 Test results"
+    # the plugin requires docker run, hence the use of a VM
+    agents:
+      provider: gcp
+      imageProject: elastic-images-prod
+      image: family/platform-ingest-logstash-ubuntu-2204
+      machineType: "n2-standard-2"
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: "**/TEST-*.xml"

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -145,7 +145,7 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: "🏁 Test results"
+  - label: "🏁 Annotate JUnit results"
     # the plugin requires docker run, hence the use of a VM
     agents:
       provider: gcp

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/CheckpointTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/CheckpointTest.java
@@ -32,7 +32,7 @@ public class CheckpointTest {
     public void newInstance() {
         Checkpoint checkpoint = new Checkpoint(1, 2, 3, 4, 5);
 
-        assertThat(checkpoint.getPageNum(), is(equalTo(2)));
+        assertThat(checkpoint.getPageNum(), is(equalTo(1)));
         assertThat(checkpoint.getFirstUnackedPageNum(), is(equalTo(2)));
         assertThat(checkpoint.getFirstUnackedSeqNum(), is(equalTo(3L)));
         assertThat(checkpoint.getMinSeqNum(), is(equalTo(4L)));

--- a/logstash-core/src/test/java/org/logstash/ackedqueue/CheckpointTest.java
+++ b/logstash-core/src/test/java/org/logstash/ackedqueue/CheckpointTest.java
@@ -32,7 +32,7 @@ public class CheckpointTest {
     public void newInstance() {
         Checkpoint checkpoint = new Checkpoint(1, 2, 3, 4, 5);
 
-        assertThat(checkpoint.getPageNum(), is(equalTo(1)));
+        assertThat(checkpoint.getPageNum(), is(equalTo(2)));
         assertThat(checkpoint.getFirstUnackedPageNum(), is(equalTo(2)));
         assertThat(checkpoint.getFirstUnackedSeqNum(), is(equalTo(3L)));
         assertThat(checkpoint.getMinSeqNum(), is(equalTo(4L)));


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds annotations for Java unit tests (in the pull request pipeline) allowing quickly scanning for failures.

## Reproduction

An example of how annotations look can be seen in https://buildkite.com/elastic/logstash-pull-request-pipeline/builds/617 (I introduced a deliberate bug in https://github.com/elastic/logstash/pull/15741/commits/ad4041629206f938a1ef81b466f7fd83681de509 to trigger it)

Otherwise, successful builds look like: https://buildkite.com/elastic/logstash-pull-request-pipeline/builds/619

## Future improvements

In a follow up PR we can duplicate the functionality for other pipelines that run the java unit tests (e.g. JDK matrix).
We'll also explore doing something similar with tests producing RSpec style output (e.g. Ruby tests); https://github.com/buildkite/rspec-buildkite may be useful.