### PR TITLE
Buildkite annotations for rspec output in CI

### DIFF
--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -8,6 +8,15 @@ export JRUBY_OPTS="-J-Xmx1g"
 export GRADLE_OPTS="-Xmx2g -Dorg.gradle.jvmargs=-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
 export SPEC_OPTS="--order rand --format documentation"
+
+if [[ $BUILDKITE == true ]]; then
+  # Buildkite annotations for rspec: https://github.com/buildkite/rspec-buildkite
+  cat >>Gemfile.template <<@EOF
+gem "rspec-buildkite", "~> 0.1", :group => :development
+@EOF
+  export SPEC_OPTS="--order rand --color --require spec_helper --format documentation --format RSpec::Buildkite::AnnotationFormatter"
+fi
+
 export CI=true
 
 if [ -n "$BUILD_JAVA_HOME" ]; then

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -17,6 +17,14 @@ if [ -n "$BUILD_JAVA_HOME" ]; then
   GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
 fi
 
+if [[ $BUILDKITE == true ]]; then
+  # Buildkite annotations for rspec: https://github.com/buildkite/rspec-buildkite
+  cat >>Gemfile.template <<@EOF
+gem "rspec-buildkite", "~> 0.1", :group => :development
+@EOF
+  export SPEC_OPTS="--order rand --color --require spec_helper --format documentation --format RSpec::Buildkite::AnnotationFormatter"
+fi
+
 SELECTED_TEST_SUITE=$1
 
 if [[ $SELECTED_TEST_SUITE == $"java" ]]; then

--- a/logstash-core/spec/logstash/util/safe_uri_spec.rb
+++ b/logstash-core/spec/logstash/util/safe_uri_spec.rb
@@ -26,7 +26,7 @@ module LogStash module Util
         cloned_safe_uri = subject.clone
         cloned_safe_uri.path = "/cloned"
         cloned_safe_uri.query = "a=b"
-        expect(subject.path).to eq("/uri")
+        expect(subject.path).to eq("/uriDELIBERATEBUG")
         expect(subject.query).to eq("q=s")
         expect(cloned_safe_uri.path).to eq("/cloned")
         expect(cloned_safe_uri.query).to eq("a=b")

--- a/x-pack/ci/integration_tests.sh
+++ b/x-pack/ci/integration_tests.sh
@@ -12,6 +12,14 @@ export JRUBY_OPTS="-J-Xmx1g"
 export GRADLE_OPTS="-Xmx4g -Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
 export CI=true
 
+if [[ $BUILDKITE == true ]]; then
+  # Buildkite annotations for rspec: https://github.com/buildkite/rspec-buildkite
+  cat >>Gemfile.template <<@EOF
+gem "rspec-buildkite", "~> 0.1", :group => :development
+@EOF
+  export SPEC_OPTS="--order rand --color --require spec_helper --format documentation --format RSpec::Buildkite::AnnotationFormatter"
+fi
+
 if [ -n "$BUILD_JAVA_HOME" ]; then
   GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
   export LS_JAVA_HOME="$BUILD_JAVA_HOME"


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

As a follow up to #15741 this commit adds Buildkite annotations for CI scripts that produce rspec style output.

## How to test this PR locally

## Related issues

- Relates #15741

## Screenshots
