### PR TITLE
Check PR failures with current 8.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For information about building the documentation, see the README in https://gith
 ## Downloads
 
 You can download officially released Logstash binaries, as well as debian/rpm packages for the
-supported platforms, from [downloads page](https://www.elastic.co/downloads/logstash).
+supported platforms, from the [downloads page](https://www.elastic.co/downloads/logstash).
 
 ## Need Help?
 


### PR DESCRIPTION
Seeing weird failures (unrelated) with the Vagrant removal PR backport to 8.12: https://github.com/elastic/logstash/pull/15751

raising this PR to quickly test current status of PR tests
