### PR TITLE
Pin `childprocess` gem to major version `4`

### DIFF
--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_development_dependency 'elasticsearch'
-  s.add_development_dependency 'childprocess', '-> 4'
+  s.add_development_dependency 'childprocess', '~> 4'
   s.add_development_dependency 'rspec-wait'
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud', '~> 0.0.22'

--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_development_dependency 'elasticsearch'
-  s.add_development_dependency 'childprocess', '~> 4'
+  s.add_development_dependency 'childprocess', '~> 4' # https://github.com/enkessler/childprocess/pull/175 landed in 5.0.0 and seems to have broken JRuby support for spawning processes. sticking to 4.x.
   s.add_development_dependency 'rspec-wait'
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud', '~> 0.0.22'

--- a/qa/integration/integration_tests.gemspec
+++ b/qa/integration/integration_tests.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_development_dependency 'elasticsearch'
-  s.add_development_dependency 'childprocess'
+  s.add_development_dependency 'childprocess', '-> 4'
   s.add_development_dependency 'rspec-wait'
   s.add_development_dependency 'manticore'
   s.add_development_dependency 'stud', '~> 0.0.22'


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit pins the `childprocess` gem for integration tests to major version `4`.

## Related issues

- Closes https://github.com/elastic/logstash/issues/15757

Co-authored-by: Joao Duarte <jsvduarte@gmail.com>