### PR TITLE
Package `elastic_integration` plugin.

### DIFF
--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -25,12 +25,7 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
   def execute
     signal_error("File #{LogStash::Environment::GEMFILE_PATH} does not exist or is not writable, aborting") unless File.writable?(LogStash::Environment::GEMFILE_PATH)
 
-    ##
-    # Need to setup the bundler status to enable uninstall of plugins
-    # installed as local_gems, otherwise gem:specification is not
-    # finding the plugins
-    ##
-    LogStash::Bundler.setup!({:without => [:build, :development]})
+    LogStash::Bundler.prepare({:without => [:build, :development]})
 
     if LogStash::PluginManager::ALIASES.has_key?(plugin)
       unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
@@ -49,9 +44,22 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
       signal_error("This plugin is already provided by '#{integration_plugin.name}' so it can't be removed individually")
     end
 
-    # make sure this is an installed plugin and present in Gemfile.
-    # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
-    signal_error("This plugin has not been previously installed") unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+    not_installed_message = "This plugin has not been previously installed"
+    plugin_gem_spec = LogStash::PluginManager.find_plugins_gem_specs(plugin).any?
+    if plugin_gem_spec
+      # make sure this is an installed plugin and present in Gemfile.
+      # it is not possible to uninstall a dependency not listed in the Gemfile, for example a dependent codec
+      signal_error(not_installed_message) unless LogStash::PluginManager.installed_plugin?(plugin, gemfile)
+    else
+      # locally installed plugins are not recoginized by ::Gem::Specification
+      # we may ::Bundler.setup to reload but it resets all dependencies so we get error message for future bundler operations
+      # error message: `Bundler::GemNotFound: Could not find rubocop-1.60.2... in locally installed gems`
+      # instead we make sure Gemfile has a definition and ::Gem::Specification recognizes local gem
+      signal_error(not_installed_message) unless !!gemfile.find(plugin)
+
+      local_gem = gemfile.locally_installed_gems.detect { |local_gem| local_gem.name == plugin }
+      signal_error(not_installed_message) unless local_gem
+    end
 
     exit(1) unless ::Bundler::LogstashUninstall.uninstall!(plugin)
     LogStash::Bundler.genericize_platform

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -224,7 +224,7 @@ namespace "artifact" do
   end
 
   desc "Build an RPM of logstash with all dependencies"
-  task "rpm_oss" => ["prepare", "generate_build_metadata"] do
+  task "rpm_oss" => ["prepare-oss", "generate_build_metadata"] do
     #with bundled JDKs
     @bundles_jdk = true
     puts("[artifact:rpm] building rpm OSS package x86_64")
@@ -256,7 +256,7 @@ namespace "artifact" do
   end
 
   desc "Build a DEB of logstash with all dependencies"
-  task "deb_oss" => ["prepare", "generate_build_metadata"] do
+  task "deb_oss" => ["prepare-oss", "generate_build_metadata"] do
     #with bundled JDKs
     @bundles_jdk = true
     puts("[artifact:deb_oss] building deb OSS package x86_64")
@@ -300,7 +300,7 @@ namespace "artifact" do
   end
 
   desc "Build OSS docker image"
-  task "docker_oss" => ["prepare", "generate_build_metadata", "archives_oss"] do
+  task "docker_oss" => ["prepare-oss", "generate_build_metadata", "archives_oss"] do
     puts("[docker_oss] Building OSS docker image")
     build_docker('oss')
   end
@@ -321,7 +321,7 @@ namespace "artifact" do
   end
 
   desc "Generate Dockerfile for oss images"
-  task "dockerfile_oss" => ["prepare", "generate_build_metadata"] do
+  task "dockerfile_oss" => ["prepare-oss", "generate_build_metadata"] do
     puts("[dockerfiles] Building oss Dockerfile")
     build_dockerfile('oss')
   end
@@ -378,6 +378,7 @@ namespace "artifact" do
 
   task "generate_build_metadata" do
     require 'time'
+    require 'tempfile'
 
     return if defined?(BUILD_METADATA_FILE)
     BUILD_METADATA_FILE = Tempfile.new('build.rb')

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -448,7 +448,7 @@ namespace "artifact" do
 
   task "prepare-oss" do
     if ENV['SKIP_PREPARE'] != "1"
-      ["bootstrap", "plugin:install-default-oss", "artifact:clean-bundle-config"].each {|task| Rake::Task[task].invoke }
+      %w[bootstrap plugin:install-default plugin:remove-non-oss-plugins artifact:clean-bundle-config].each {|task| Rake::Task[task].invoke }
     end
   end
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -348,17 +348,19 @@ namespace "artifact" do
   task "build" => [:generate_build_metadata] do
     Rake::Task["artifact:gems"].invoke unless SNAPSHOT_BUILD
     Rake::Task["artifact:deb"].invoke
-    Rake::Task["artifact:deb_oss"].invoke
     Rake::Task["artifact:rpm"].invoke
-    Rake::Task["artifact:rpm_oss"].invoke
     Rake::Task["artifact:archives"].invoke
-    Rake::Task["artifact:archives_oss"].invoke
+
     unless ENV['SKIP_DOCKER'] == "1"
       Rake::Task["artifact:docker"].invoke
-      Rake::Task["artifact:docker_oss"].invoke
       Rake::Task["artifact:docker_ubi8"].invoke
       Rake::Task["artifact:dockerfiles"].invoke
+      Rake::Task["artifact:docker_oss"].invoke
     end
+
+    Rake::Task["artifact:deb_oss"].invoke
+    Rake::Task["artifact:rpm_oss"].invoke
+    Rake::Task["artifact:archives_oss"].invoke
   end
 
   task "build_docker_full" => [:generate_build_metadata] do

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -193,7 +193,7 @@ namespace "artifact" do
   end
 
   desc "Build all (jdk bundled and not) OSS tar.gz and zip of default logstash plugins with all dependencies"
-  task "archives_oss" => ["prepare", "generate_build_metadata"] do
+  task "archives_oss" => ["prepare-oss", "generate_build_metadata"] do
     #with bundled JDKs
     @bundles_jdk = true
     license_details = ['APACHE-LICENSE-2.0', "-oss", oss_exclude_paths]
@@ -443,6 +443,12 @@ namespace "artifact" do
   task "prepare" do
     if ENV['SKIP_PREPARE'] != "1"
       ["bootstrap", "plugin:install-default", "artifact:clean-bundle-config"].each {|task| Rake::Task[task].invoke }
+    end
+  end
+
+  task "prepare-oss" do
+    if ENV['SKIP_PREPARE'] != "1"
+      ["bootstrap", "plugin:install-default-oss", "artifact:clean-bundle-config"].each {|task| Rake::Task[task].invoke }
     end
   end
 

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -53,6 +53,6 @@ module LogStash
     ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
 
     # default plugins will be installed and we exclude only installed plugins from OSS
-    OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS.intersection(self.fetch_plugins_for("oss-excluded"))
+    OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS.intersection(self.fetch_plugins_for("skip-oss"))
   end
 end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -52,7 +52,7 @@ module LogStash
 
     ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
 
-    # default plugins will be installed and we remove only installed plugins.
+    # default plugins will be installed and we exclude only installed plugins from OSS
     OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS.intersection(self.fetch_plugins_for("oss-excluded"))
   end
 end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -53,6 +53,6 @@ module LogStash
     ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
 
     # default plugins will be installed and we exclude only installed plugins from OSS
-    OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS.intersection(self.fetch_plugins_for("skip-oss"))
+    OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS & self.fetch_plugins_for("skip-oss")
   end
 end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -51,5 +51,7 @@ module LogStash
     CORE_SPECS_PLUGINS = self.fetch_plugins_for("core-specs").freeze
 
     ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
+
+    OSS_EXCLUDED_PLUGINS = self.fetch_plugins_for("oss-excluded").freeze
   end
 end

--- a/rakelib/default_plugins.rb
+++ b/rakelib/default_plugins.rb
@@ -52,6 +52,7 @@ module LogStash
 
     ALL_PLUGINS_SKIP_LIST = Regexp.union(self.fetch_plugins_for("skip-list")).freeze
 
-    OSS_EXCLUDED_PLUGINS = self.fetch_plugins_for("oss-excluded").freeze
+    # default plugins will be installed and we remove only installed plugins.
+    OSS_EXCLUDED_PLUGINS = DEFAULT_PLUGINS.intersection(self.fetch_plugins_for("oss-excluded"))
   end
 end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -71,10 +71,9 @@ namespace "plugin" do
 
     LogStash::RakeLib::OSS_EXCLUDED_PLUGINS.each do |plugin|
       remove_plugin(plugin)
-      # gem folder, spec file and cache still stay after removing the plugin
+      # gem folder and spec file still stay after removing the plugin
       FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/gems/#{plugin}*"))
       FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/specifications/#{plugin}*.gemspec"))
-      FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/cache/#{plugin}*"))
     end
     task.reenable # Allow this task to be run again
   end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -71,6 +71,9 @@ namespace "plugin" do
 
     LogStash::RakeLib::OSS_EXCLUDED_PLUGINS.each do |plugin|
       remove_plugin(plugin)
+      # gem folder and spec file still stay after removing the plugin
+      FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/gems/#{plugin}*"))
+      FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/specifications/#{plugin}*.gemspec"))
     end
     task.reenable # Allow this task to be run again
   end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -24,6 +24,13 @@ namespace "plugin" do
     LogStash::PluginManager::Main.run("bin/logstash-plugin", ["install"] + args)
   end
 
+  def remove_plugins(plugins)
+    require_relative "../lib/pluginmanager/main"
+    plugins.each do |plugin|
+      LogStash::PluginManager::Main.run("bin/logstash-plugin", ["remove", plugin])
+    end
+  end
+
   task "install-base" => "bootstrap" do
     puts("[plugin:install-base] Installing base dependencies")
     install_plugins("--development",  "--preserve")
@@ -61,12 +68,9 @@ namespace "plugin" do
     task.reenable # Allow this task to be run again
   end
 
-  task "install-default-oss" => "bootstrap" do
-    puts("[plugin:install-default] Installing default OSS plugins")
-    remove_lockfile # because we want to use the release lockfile
-
-    plugins = LogStash::RakeLib::DEFAULT_PLUGINS - LogStash::RakeLib::OSS_EXCLUDED_PLUGINS
-    install_plugins("--no-verify", "--preserve", *plugins)
+  task "remove-non-oss-plugins" do |task, _|
+    puts("[plugin:remove-non-oss-plugins] Removing non-OSS plugins")
+    remove_plugins(LogStash::RakeLib::OSS_EXCLUDED_PLUGINS)
 
     task.reenable # Allow this task to be run again
   end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -70,7 +70,7 @@ namespace "plugin" do
     puts("[plugin:remove-non-oss-plugins] Removing non-OSS plugins")
 
     LogStash::RakeLib::OSS_EXCLUDED_PLUGINS.each do |plugin|
-      remove_plugin(plugin) if LogStash::RakeLib::DEFAULT_PLUGINS.include?(plugin)
+      remove_plugin(plugin)
     end
     task.reenable # Allow this task to be run again
   end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -24,11 +24,9 @@ namespace "plugin" do
     LogStash::PluginManager::Main.run("bin/logstash-plugin", ["install"] + args)
   end
 
-  def remove_plugins(plugins)
+  def remove_plugin(plugin)
     require_relative "../lib/pluginmanager/main"
-    plugins.each do |plugin|
-      LogStash::PluginManager::Main.run("bin/logstash-plugin", ["remove", plugin])
-    end
+    LogStash::PluginManager::Main.run("bin/logstash-plugin", ["remove", plugin])
   end
 
   task "install-base" => "bootstrap" do
@@ -70,8 +68,10 @@ namespace "plugin" do
 
   task "remove-non-oss-plugins" do |task, _|
     puts("[plugin:remove-non-oss-plugins] Removing non-OSS plugins")
-    remove_plugins(LogStash::RakeLib::OSS_EXCLUDED_PLUGINS)
 
+    LogStash::RakeLib::OSS_EXCLUDED_PLUGINS.each do |plugin|
+      remove_plugin(plugin) if LogStash::RakeLib::DEFAULT_PLUGINS.include?(plugin)
+    end
     task.reenable # Allow this task to be run again
   end
 

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -61,6 +61,16 @@ namespace "plugin" do
     task.reenable # Allow this task to be run again
   end
 
+  task "install-default-oss" => "bootstrap" do
+    puts("[plugin:install-default] Installing default OSS plugins")
+    remove_lockfile # because we want to use the release lockfile
+
+    plugins = LogStash::RakeLib::DEFAULT_PLUGINS - LogStash::RakeLib::OSS_EXCLUDED_PLUGINS
+    install_plugins("--no-verify", "--preserve", *plugins)
+
+    task.reenable # Allow this task to be run again
+  end
+
   task "clean-local-core-gem", [:name, :path] do |task, args|
     name = args[:name]
     path = args[:path]

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -71,9 +71,10 @@ namespace "plugin" do
 
     LogStash::RakeLib::OSS_EXCLUDED_PLUGINS.each do |plugin|
       remove_plugin(plugin)
-      # gem folder and spec file still stay after removing the plugin
+      # gem folder, spec file and cache still stay after removing the plugin
       FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/gems/#{plugin}*"))
       FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/specifications/#{plugin}*.gemspec"))
+      FileUtils.rm_r(Dir.glob("#{LogStash::Environment::BUNDLE_DIR}/**/cache/#{plugin}*"))
     end
     task.reenable # Allow this task to be run again
   end

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -120,7 +120,7 @@
     "skip-list": false
   },
   "logstash-filter-elastic_integration": {
-    "default-plugins": true,
+    "default-plugins": false,
     "skip-list": false,
     "oss-excluded": true
   },

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -120,7 +120,7 @@
     "skip-list": false
   },
   "logstash-filter-elastic_integration": {
-    "default-plugins": false,
+    "default-plugins": true,
     "skip-list": false,
     "skip-oss": true
   },

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -120,7 +120,7 @@
     "skip-list": false
   },
   "logstash-filter-elastic_integration": {
-    "default-plugins": true,
+    "default-plugins": false,
     "skip-list": false,
     "skip-oss": true
   },

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -121,7 +121,8 @@
   },
   "logstash-filter-elastic_integration": {
     "default-plugins": false,
-    "skip-list": false
+    "skip-list": false,
+    "oss-excluded": true
   },
   "logstash-filter-elasticsearch": {
     "default-plugins": true,

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -122,7 +122,7 @@
   "logstash-filter-elastic_integration": {
     "default-plugins": true,
     "skip-list": false,
-    "oss-excluded": true
+    "skip-oss": true
   },
   "logstash-filter-elasticsearch": {
     "default-plugins": true,

--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -120,7 +120,7 @@
     "skip-list": false
   },
   "logstash-filter-elastic_integration": {
-    "default-plugins": false,
+    "default-plugins": true,
     "skip-list": false,
     "oss-excluded": true
   },


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

- Introduces a feature (based on `oss-skip` flag of the plugin metadata) to exclude plugins in OSS distributions
- Sets `elastic_integration` plugin as a default plugin

### History
CI fails were due to https://github.com/elastic/logstash-filter-elastic_integration/pull/114
- We face error if make the plugin as a default now because the `TarWriter` (in `assembleOssTarDistribution` gradle task) complains on the path which cannot be longer than 256. The workaround is to shorten the JAR path in th plugin, the PR: https://github.com/elastic/logstash-filter-elastic_integration/pull/114. We need to merge the PR and release new version of the plugin.


## Why is it important/What is the impact to the user?
Non-user affected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist
Before merging:
- [x] Merge the plugin PR: https://github.com/elastic/logstash-filter-elastic_integration/pull/114
- [x] Run DRA on UI (/pull/15769/merge)
  - [DRA test](https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/467#018d5950-ee9a-4314-827b-17e986b90ac1) 

## How to test this PR locally
- Pull this change and run `rake artifact:archives_oss` (or any of [`rpm_oss`, `deb_oss`. `docker_oss`]) command.
- Commands generate OSS distributions under build. If we unzip and check the dependencies, we don't include `oss-excluded` plugins.

NOTE: currently gradle tasks (`./gradlew clean assembleOssTarDistribution`, `./gradlew clean assembleOssZipDistribution`) to build OSS distros are broken, and the reason looks like [this issue](https://github.com/elastic/logstash/issues/15284)

## Related issues 

## Use cases

## Screenshots

## Logs
