### PR TITLE
Backport PR #15738 to 7.17: Run BK exhaustive pipeline when code is pushed

### DIFF
--- a/.buildkite/exhaustive_tests_pipeline.yml
+++ b/.buildkite/exhaustive_tests_pipeline.yml
@@ -2,9 +2,19 @@ steps:
   - label: "Exhaustive tests pipeline"
     command: |
       #!/usr/bin/env bash
+      echo "--- Check for docs changes"
+      set +e
+      .buildkite/scripts/common/check-files-changed.sh '^docs/.*'
+      if [[ $$? -eq 0 ]]; then
+        echo "^^^ +++"
+        echo "Skipping running pipeline as all changes are related to docs."
+        exit 0
+      else
+        echo "Changes are not exclusively related to docs, continuing."
+      fi
+
       set -eo pipefail
 
-      source .buildkite/scripts/common/container-agent.sh
       echo "--- Downloading prerequisites"
       python3 -m pip install ruamel.yaml
       curl -fsSL --retry-max-time 60 --retry 3 --retry-delay 5 -o /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/.buildkite/scripts/common/check-files-changed.sh
+++ b/.buildkite/scripts/common/check-files-changed.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# **********************************************************
+# Returns true if current checkout compared to parent commit
+# has changes ONLY matching the argument regexp
+#
+# Used primarily to skip running the exhaustive pipeline
+# when only docs changes have happened.
+# ********************************************************
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 <regexp>"
+  exit 1
+fi
+
+previous_commit=$(git rev-parse HEAD^)
+changed_files=$(git diff --name-only $previous_commit)
+
+if [[ -n "$changed_files" ]] && [[ -z "$(echo "$changed_files" | grep -vE "$1")" ]]; then
+    echo "All files compared to the previous commit [$previous_commit] match the specified regex: [$1]"
+    echo "Files changed:"
+    git diff --name-only HEAD^
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
**Backport PR #15738 to 7.17 branch, original message:**

---

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip]

## What does this PR do?

As we are close to sunsetting Jenkins by completing the exhaustive tests Buildkite pipeline, it makes sense to start already running the existing phases (testing and compatibility).

This commit defines the trigger to be code events, i.e. direct pushes and merge commits, similar to what we currently have in Jenkins.

## Why is it important/What is the impact to the user?

It allows us to gradually remove the corresponding phases from Jenkins to reduce CI duplication.
This will be especially useful when merging https://github.com/elastic/logstash/pull/15696 as the change is incompatible with Jenkins.

## How to test this PR locally

An example build triggered manually can be found in https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/49#_
Unfortunately Windows tests will fail due to https://github.com/elastic/logstash/issues/15562

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/1722
