### PR TITLE
Add retries to PR pipeline steps

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -8,6 +8,9 @@ steps:
       cpu: "4"
       memory: "6Gi"
       ephemeralStorage: "100Gi"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -23,6 +26,9 @@ steps:
       cpu: "4"
       memory: "8Gi"
       ephemeralStorage: "100Gi"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -36,6 +42,9 @@ steps:
       cpu: "8"
       memory: "16Gi"
       ephemeralStorage: "100Gi"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
       if [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
@@ -59,6 +68,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as a non-root user
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -74,6 +86,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as a non-root user
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -89,6 +104,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as non root (logstash) user. UID is hardcoded in image.
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -105,6 +123,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as non root (logstash) user. UID is hardcoded in image.
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -121,6 +142,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as non root (logstash) user. UID is hardcoded in image.
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 
@@ -136,6 +160,9 @@ steps:
       ephemeralStorage: "100Gi"
       # Run as non root (logstash) user. UID is hardcoded in image.
       imageUID: "1002"
+    retry:
+      automatic:
+        - limit: 3
     command: |
       set -euo pipefail
 


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Adds up to 3 retries for all the steps of the PR pipeline.

## Why is it important/What is the impact to the user?

There is occasional flakiness mainly with IT tests requiring us to manually retry such failures when we raise PR (or the first group of the exhaustive suite, which runs the same steps).

## How to test this PR locally

See automated tests triggered by this PR.
