### PR TITLE
Don't trigger exhaustive tests with backports

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -441,6 +441,8 @@ spec:
         build_pull_requests: false
         build_tags: false
         trigger_mode: code
+        filter_condition: 'build.branch !~ /^backport.*$/'
+        filter_enabled: true
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       env:


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Having enabled branch pushes as triggers for the exhaustive test pipeline, we have an unwanted sideeffect, that when using PR automation (@logstashmachine) to create backports, the temporary branches also triggered exhaustive tests.

This commit skips triggering this pipeline when upstream branches starting with `backport` get pushed.

## Testing

I've tested this by manually editing the pipeline (via the UI):

![image](https://github.com/elastic/logstash/assets/1754575/c22ec0d5-ee60-4d6b-89dc-13e544e99c9e)

and then triggering a [backport PR](https://github.com/elastic/logstash/pull/15792); notice that the exhaustive pipeline got skipped without issues:

![image](https://github.com/elastic/logstash/assets/1754575/a431a204-e833-461a-98ac-fb1aed501923)

Also tested that this filter (applied with the above UI modification in place) doesn't block jobs that should run, by triggering the exhaustive suite via this PR, which started as expected: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/83

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/1722

## Screenshots

This commit will avoid triggering the pipeline marked with the red arrow below, when using logstashmachine to create backports (which pushes branches starting with `backport` to upstream)

![image](https://github.com/elastic/logstash/assets/1754575/9cee075d-af60-4808-b2c4-2b6613aa0f4d)

