### PR TITLE
Fix flaky logstash-plugin IT test

### DIFF
--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -29,6 +29,10 @@ def gem_in_lock_file?(pattern, lock_file)
   content.match(pattern)
 end
 
+# Bundler can mess up installation successful output: https://github.com/elastic/logstash/issues/15801
+INSTALL_SUCCESS_RE = /IB?nstall successful/
+INSTALLATION_SUCCESS_RE = /IB?nstallation successful/
+
 describe "CLI > logstash-plugin install" do
   before(:all) do
     @fixture = Fixture.new(__FILE__)
@@ -65,7 +69,7 @@ describe "CLI > logstash-plugin install" do
         it "successfully install the pack" do
           execute = @logstash_plugin.run_raw("#{offline_wrapper_cmd} #{install_command} #{pack}", change_dir)
 
-          expect(execute.stderr_and_stdout).to match(/Install successful/)
+          expect(execute.stderr_and_stdout).to match(INSTALL_SUCCESS_RE)
           expect(execute.exit_code).to eq(0)
 
           installed = @logstash_plugin.list("logstash-output-secret")
@@ -80,7 +84,7 @@ describe "CLI > logstash-plugin install" do
         it "successfully install the pack" do
           execute = @logstash_plugin.run_raw("#{install_command} #{pack}", change_dir)
 
-          expect(execute.stderr_and_stdout).to match(/Install successful/)
+          expect(execute.stderr_and_stdout).to match(INSTALL_SUCCESS_RE)
           expect(execute.exit_code).to eq(0)
 
           installed = @logstash_plugin.list("logstash-output-secret")
@@ -131,7 +135,7 @@ describe "CLI > logstash-plugin install" do
       it "successfully install the plugin" do
         execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}")
 
-        expect(execute.stderr_and_stdout).to match(/Installation successful/)
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
         expect(execute.exit_code).to eq(0)
 
         installed = @logstash_plugin.list(plugin_name)
@@ -141,7 +145,7 @@ describe "CLI > logstash-plugin install" do
       it "successfully installs the plugin with debug enabled" do
         execute = @logstash_plugin.run_raw("#{install_command} #{plugin_name}", true, {"DEBUG" => "1"})
 
-        expect(execute.stderr_and_stdout).to match(/Installation successful/)
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
         expect(execute.exit_code).to eq(0)
 
         installed = @logstash_plugin.list(plugin_name)


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit fixes the flaky IT test:
`install non bundle plugin successfully installs the plugin with debug enabled` by being a bit more lenient with the output which can get garbled by Bundler.

## Why is it important/What is the impact to the user?

Reduces the flakyness described in #15801

## Checklist

~- [ ] My code follows the style guidelines of this project~
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

Reproducing the actual failure (before this PR) is difficult and time consuming.
To test that the PR works as expected, manually, one can run:

```
export JRUBY_OPTS="-J-Xmx1g"
export GRADLE_OPTS="-Xmx2g -Dorg.gradle.jvmargs=-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
export CI=true
# use the seed from one of the failures in the issue
export SPEC_OPTS="--seed 35098 --order rand --format documentation"`
./gradlew clean
./gradlew runIntegrationTests -PrubyIntegrationSpecs="specs/cli/install_spec.rb" --console=plain
```

## Related issues

- Closes #15801
