### PR TITLE
Annotate successful DRA builds with summary URL

### DIFF
--- a/.buildkite/scripts/dra/publish.sh
+++ b/.buildkite/scripts/dra/publish.sh
@@ -90,7 +90,16 @@ docker run --rm \
       --workflow "${WORKFLOW_TYPE}" \
       --version "${PLAIN_STACK_VERSION}" \
       --artifact-set main \
-      ${DRA_DRY_RUN}
+      ${DRA_DRY_RUN} | tee rm-output.txt
+
+# extract the summary URL from a release manager output line like:
+# Report summary-8.22.0.html can be found at https://artifacts-staging.elastic.co/logstash/8.22.0-ABCDEFGH/summary-8.22.0.html
+
+SUMMARY_URL=$(grep -E '^Report summary-.* can be found at ' rm-output.txt | grep -oP 'https://\S+' | awk '{print $1}')
+rm rm-output.txt
+
+# and make it easily clickable as a Builkite annotation
+printf "**Summary link:** [${SUMMARY_URL}](${SUMMARY_URL})\n" | buildkite-agent annotate --style=success 
 
 info "Teardown logins"
 $(dirname "$0")/docker-env-teardown.sh


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit makes the generated DRA URL easily accessible via a Buildkite annotation.

## Why is it important/What is the impact to the user?

As explained in the [linked issue](https://github.com/elastic/ingest-dev/issues/2608), currently the link is buried under a lot of release manager generated output and can be difficult to spot.
This commit improves accessibility and readability.

## How to test this PR locally

Example DRA build triggered from this PR: https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/425

resulting in a clickable link (screenshot):

![image](https://github.com/elastic/logstash/assets/1754575/f18e388a-4d3c-4c40-af7c-886cd9efbb0e)

## Related issues

- Relates/Closes https://github.com/elastic/ingest-dev/issues/2608
