### PR TITLE
Fix acceptance/packaging upgrade test near a release

### DIFF
--- a/qa/acceptance/helpers.rb
+++ b/qa/acceptance/helpers.rb
@@ -16,9 +16,8 @@
 # under the License.
 
 require 'net/http'
-require 'json'
 
-ARTIFACTS_API = "https://artifacts-api.elastic.co/v1/versions"
+ARTIFACT_VERSIONS_API = "https://storage.googleapis.com/artifacts-api/releases.properties"
 
 def logstash_download_metadata(version, arch, artifact_type)
   filename = "logstash-#{version}-#{arch}.#{artifact_type}"
@@ -26,14 +25,12 @@ def logstash_download_metadata(version, arch, artifact_type)
 end
 
 def fetch_latest_logstash_release_version(branch)
-  uri = URI(ARTIFACTS_API)
+  uri = URI(ARTIFACT_VERSIONS_API)
+  major = branch.split('.').first
 
   response = retryable_http_get(uri)
-  versions_data = JSON.parse(response)
 
-  filtered_versions = versions_data["versions"].select { |v| v.start_with?(branch) && !v.include?('SNAPSHOT') }
-
-  return filtered_versions.max_by { |v| Gem::Version.new(v) }
+  response.match(/current_#{major}=(\S+)/)&.captures&.first
 end
 
 def retryable_http_get(uri, max_retries=5, retry_wait=10)


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

The current mechanism of discovering the latest released version per branch (via ARTIFACTS_API) isn't foolproof near the time of a new release, as it may be pick a version that hasn't been released yet. This leads to failures of the packaging upgrade tests, as we attempt to download a package file that doesn't exist yet.

This commit switches to an API that that is more up to date regarding the release version truth.

Note that branch `7.17` isn't affected by this issue as we are attempting an upgrade from the previous minor (which is guaranteed to be released): https://github.com/elastic/logstash/blob/c0f13dfe3f8738b0c64c23c9b8ca722d56fa92bc/qa/acceptance/spec/shared_examples/updated.rb#L36

[^1]: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/125#018d319b-9a33-4306-b7f2-5b41937a8881/1033-1125

## Why is it important/What is the impact to the user?

Fixes exhaustive suite failures on main.

## How to test this PR locally

See this build: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/128#018d31fe-0eff-4a57-af0a-f1e2ffb9729e
(versus the failing one in https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/125#018d319b-9a33-4306-b7f2-5b41937a8881/1033-1125)

## Logs

Buildkite failure before this PR: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/125#018d319b-9a33-4306-b7f2-5b41937a8881/1033-1125
