### PR TITLE
Bump 7.17.18

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.17.17)
+      logstash-core (= 7.17.18)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.17.17-java)
+    logstash-core (7.17.18-java)
       chronic_duration (~> 0.10)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.17.17
-logstash-core: 7.17.17
+logstash: 7.17.18
+logstash-core: 7.17.18
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Bumps version on 7.17 branch after 7.17.17 release so that upcoming snapshots builds will be tagged 7.17.18
