### PR TITLE
Mute DLQ test on Windows

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.FULL_SEGMENT_FILE_SIZE;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.GB;
 import static org.logstash.common.io.DeadLetterQueueTestUtils.MB;
@@ -334,8 +335,15 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         }
     }
 
+    private static boolean isWindows() {
+        return System.getProperty("os.name").startsWith("Windows");
+    }
+
     @Test
     public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException {
+        // https://github.com/elastic/logstash/issues/15768
+        assumeThat(isWindows(), is(not(true)));
+
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
                 Collections.singletonMap("message", "Not so important content"));
 


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit mutes the DLQ test:
`testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty` when running on Windows.

## How to test this PR locally

Using this PR:

Example windows build: https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/82#_
Example Linux build: https://buildkite.com/elastic/logstash-pull-request-pipeline/builds/754#018d376b-b614-4fa2-9a63-d8433bcc1207

## Related issues

- Closes https://github.com/elastic/logstash/issues/15768
