### PR TITLE
[docs] Simplify and improve Logstash monitoring docs.

### DIFF
--- a/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
@@ -14,7 +14,7 @@ You can enroll {agent} in {fleet-guide}/install-fleet-managed-elastic-agent.html
 Complete these steps as you prepare to collect and ship monitoring data for dashboards:
 
 [[disable-default-db]]
-.Disable default collection of {ls} monitoring metrics
+.Enable {ls} monitoring
 [%collapsible]
 ====
 include::monitoring-prereq-disable-default.asciidoc[]

--- a/docs/static/monitoring/monitoring-ea-serverless.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-serverless.asciidoc
@@ -14,7 +14,7 @@ We'll provide steps to help you create one.
 **Prerequisite**
 
 [[disable-default-svrless]]
-.Disable default collection of {ls} monitoring metrics
+.Enable {ls} monitoring
 [%collapsible]
 ====
 include::monitoring-prereq-disable-default.asciidoc[]

--- a/docs/static/monitoring/monitoring-ea.asciidoc
+++ b/docs/static/monitoring/monitoring-ea.asciidoc
@@ -16,7 +16,7 @@ from a central location, or you can run {fleet-guide}/install-standalone-elastic
 Complete these steps as you prepare to collect and ship monitoring data for stack monitoring:
 
 [[disable-default-include-ea]]
-.Disable default collection of {ls} monitoring metrics
+.Enable {ls} monitoring
 [%collapsible]
 ====
 include::monitoring-prereq-disable-default.asciidoc[]

--- a/docs/static/monitoring/monitoring-mb.asciidoc
+++ b/docs/static/monitoring/monitoring-mb.asciidoc
@@ -12,7 +12,7 @@ agent remains active even if the {ls} instance does not.
 
 To collect and ship monitoring data:
 
-. <<disable-default,Disable default collection of monitoring metrics>>
+. <<disable-default,Enable {ls} monitoring>>
 . <<define-cluster__uuid,Specify the target `cluster_uuid` (optional)>>
 . <<configure-metricbeat,Install and configure {metricbeat} to collect monitoring data>>
 
@@ -20,7 +20,7 @@ Want to use {agent} instead? Refer to <<monitoring-with-elastic-agent>>.
 
 [float]
 [[disable-default]]
-==== Disable default collection of {ls} monitoring metrics
+==== Enable {ls} monitoring
 
 --
 The `monitoring` setting is in the {ls} configuration file (logstash.yml), but is
@@ -31,7 +31,7 @@ commented out:
 monitoring.enabled: false
 ----------------------------------
 
-Remove the `#` at the beginning of the line to enable the setting.
+Remove the `#` at the beginning of the line and set it to `true` to enable the setting.
 
 --
 

--- a/docs/static/monitoring/monitoring-prereq-disable-default.asciidoc
+++ b/docs/static/monitoring/monitoring-prereq-disable-default.asciidoc
@@ -1,5 +1,3 @@
-// [[disable-default]]
-// ==== Disable default collection of {ls} monitoring metrics
 
 The `monitoring` setting is in the {ls} configuration file (logstash.yml), but is
 commented out: 
@@ -9,4 +7,4 @@ commented out:
 monitoring.enabled: false
 ----------------------------------
 
-Remove the `#` at the beginning of the line to enable the setting.
+Remove the `#` at the beginning of the line and set it to `true` to enable the setting.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Our [enable Logstash monitoring doc](https://www.elastic.co/guide/en/logstash/current/monitoring-with-metricbeat.html#disable-default) has a discrepancy. It sounds a message that if we remove `#` in front of `monitoring.enabled: false` setting, the monitoring will be enabled.
This PR adds "set it to `true`" followed message so that entire statement will be clearer.
It also suggests to change _false-positive_ title message (Disable default collection of Logstash monitoring metrics) to simply saying _**Enable Logstash monitoring**_, because guide page's goal is to bring customer to collect Logstash monitoring data with Metricbeat.

## Why is it important/What is the impact to the user?
Some users are getting confused with a statement.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- 

## Use cases


## Screenshots


## Logs

