### PR TITLE
Scheduled runs of exhaustive and aarch64 pipelines

### DIFF
--- a/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
+++ b/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
@@ -13,6 +13,8 @@ set -eo pipefail
 # *******************************************************
 
 ACTIVE_BRANCHES_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/branches.json"
+EXCLUDE_BRANCHES_ARRAY=()
+BRANCHES=()
 
 function install_yq() {
 if ! [[ -x $(which yq) && $(yq --version) == *mikefarah* ]]; then
@@ -26,6 +28,28 @@ function parse_pipelines() {
   IFS="," read -ra PIPELINES <<< "$PIPELINES_TO_TRIGGER"
 }
 
+# converts the (optional) $EXCLUDE_BRANCHES env var, containing a comma separated branches string, to $EXCLUDE_BRANCHES_ARRAY
+function exclude_branches_to_array() {
+  if [[ ! -z "$EXCLUDE_BRANCHES" ]]; then
+    IFS="," read -ra EXCLUDE_BRANCHES_ARRAY <<< "$EXCLUDE_BRANCHES"
+  fi
+}
+
+function check_if_branch_in_exclude_array() {
+  local branch=$1
+  local _excl_br
+  local ret_val="false"
+
+  for _excl_br in "${EXCLUDE_BRANCHES_ARRAY[@]}"; do
+    if [[ "$branch" == "$_excl_br" ]]; then
+      ret_val="true"
+      break
+    fi
+  done
+
+  echo $ret_val
+}
+
 if [[ -z $PIPELINES_TO_TRIGGER ]]; then
     echo "^^^ +++"
     echo "Required environment variable [PIPELINES_TO_TRIGGER] is missing."
@@ -34,23 +58,37 @@ if [[ -z $PIPELINES_TO_TRIGGER ]]; then
 fi
 
 parse_pipelines
+exclude_branches_to_array
 
 set -u
 set +e
-BRANCHES=$(curl --retry-all-errors --retry 5 --retry-delay 5 -fsSL $ACTIVE_BRANCHES_URL | jq -r '.branches[].branch')
+# pull releaseable branches from $ACTIVE_BRANCHES_URL
+readarray -t ELIGIBLE_BRANCHES < <(curl --retry-all-errors --retry 5 --retry-delay 5 -fsSL $ACTIVE_BRANCHES_URL | jq -r '.branches[].branch')
 if [[ $? -ne 0 ]]; then
   echo "There was an error downloading or parsing the json output from [$ACTIVE_BRANCHES_URL]. Exiting."
   exit 1
 fi
-
 set -e
+
+if [[ ${#EXCLUDE_BRANCHES_ARRAY[@]} -eq 0 ]]; then
+  # no branch exclusions
+  BRANCHES=("${ELIGIBLE_BRANCHES[@]}")
+else
+  # exclude any branches passed via optional $EXCLUDE_BRANCHES
+  for _branch in "${ELIGIBLE_BRANCHES[@]}"; do
+    res=$(check_if_branch_in_exclude_array $_branch)
+    if [[ "$res" == "false" ]]; then
+      BRANCHES+=("$_branch")
+    fi
+  done
+fi
 
 install_yq
 
 echo 'steps:' >pipeline_steps.yaml
 
 for PIPELINE in "${PIPELINES[@]}"; do
-  for BRANCH in $BRANCHES; do
+  for BRANCH in "${BRANCHES[@]}"; do
       cat >>pipeline_steps.yaml <<EOF
   - trigger: $PIPELINE
     label: ":testexecute: Triggering ${PIPELINE} / ${BRANCH}"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -545,6 +545,19 @@ spec:
           message: Weekly trigger of JDK matrix pipelines per branch
           env:
             PIPELINES_TO_TRIGGER: 'logstash-linux-jdk-matrix-pipeline,logstash-windows-jdk-matrix-pipeline'
+        AARCH64 Tests:
+          branch: main
+          cronline: 0 2 * * 1  # every Monday@2AM UTC
+          message: Weekly trigger of AARCH64 pipeline per branch
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-linux-jdk-matrix-pipeline'
+        Exhaustive Tests:
+          branch: main
+          cronline: 0 3 * * 1%2  # every other Wednesday@3AM UTC, see https://buildkite.com/docs/pipelines/scheduled-builds#schedule-intervals-crontab-time-syntax
+          message: Biweekly trigger of Exhaustive pipeline for non-main branches
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-exhaustive-tests-pipeline'
+            EXCLUDE_BRANCHES: 'main'
       skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds a schedule to run non-main branches of the exhaustive pipeline (biweekly, every other Wednesday @2AM UTC)
and all branches of the aarch64 (weekly, every Monday@2AM UTC).

## Why is it important/What is the impact to the user?

As described in https://github.com/elastic/ingest-dev/issues/2852:

- exhaustive is currently triggered with push events, and for branches with low traffic e.g. `7.17` we also want to get coverage on a regular basis to have a regular baseline and catch potential external issues (unpinned gem updates, packaging/os issues etc.)
- `aarch64` is currently manually triggered, and we'd like coverage on all branches for similar reasons.

## How to test this PR locally

The main thing to test is the enhancement of the shell script to exclude branches:

### Use all release branches (as of now)
```
$ PIPELINES_TO_TRIGGER="logstash-exhaustive-tests-pipeline" .buildkite/scripts/common/trigger-pipeline-generate-steps.sh 
--- Printing generated steps
steps:
  - trigger: logstash-exhaustive-tests-pipeline
    label: ":testexecute: Triggering logstash-exhaustive-tests-pipeline / main"
    build:
      branch: "main"
      message: ":testexecute: Scheduled build for main"
  - trigger: logstash-exhaustive-tests-pipeline
    label: ":testexecute: Triggering logstash-exhaustive-tests-pipeline / 8.12"
    build:
      branch: "8.12"
      message: ":testexecute: Scheduled build for 8.12"
  - trigger: logstash-exhaustive-tests-pipeline
    label: ":testexecute: Triggering logstash-exhaustive-tests-pipeline / 7.17"
    build:
      branch: "7.17"
      message: ":testexecute: Scheduled build for 7.17"
```

### Exclude `main` branch

```
$ EXCLUDE_BRANCHES="main" PIPELINES_TO_TRIGGER="logstash-exhaustive-tests-pipeline" .buildkite/scripts/common/trigger-pipeline-generate-steps.sh 
--- Printing generated steps
steps:
  - trigger: logstash-exhaustive-tests-pipeline
    label: ":testexecute: Triggering logstash-exhaustive-tests-pipeline / 8.12"
    build:
      branch: "8.12"
      message: ":testexecute: Scheduled build for 8.12"
  - trigger: logstash-exhaustive-tests-pipeline
    label: ":testexecute: Triggering logstash-exhaustive-tests-pipeline / 7.17"
    build:
      branch: "7.17"
      message: ":testexecute: Scheduled build for 7.17"
```

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/2852
