### PR TITLE
Remove Ubuntu 18.04 from CI jobs

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -19,8 +19,6 @@ steps:
             value: "ubuntu-2204"
           - label: "Ubuntu 20.04"
             value: "ubuntu-2004"
-          - label: "Ubuntu 18.04"
-            value: "ubuntu-1804"
           - label: "Debian 11"
             value: "debian-11"
           - label: "Debian 10"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -1,7 +1,7 @@
 {
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
-        "ubuntu": ["ubuntu-2204", "ubuntu-2004", "ubuntu-1804"],
+        "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
         "debian": ["debian-11", "debian-10"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Remove Ubuntu 18.04 from CI jobs.

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/2849
