### PR TITLE
Doc: Update plugin headers to deeplink into support matrix

### DIFF
--- a/docs/include/plugin_header-integration.asciidoc
+++ b/docs/include/plugin_header-integration.asciidoc
@@ -15,5 +15,5 @@ For other versions, see the
 
 For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. 
 For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-integration-{integration}[Github].
-For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#logstash_plugins[Elastic Support Matrix].
 

--- a/docs/include/plugin_header.asciidoc
+++ b/docs/include/plugin_header.asciidoc
@@ -21,5 +21,5 @@ endif::[]
 ==== Getting Help
 
 For questions about the plugin, open a topic in the http://discuss.elastic.co[Discuss] forums. For bugs or feature requests, open an issue in https://github.com/logstash-plugins/logstash-{type}-{plugin}[Github].
-For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#matrix_logstash_plugins[Elastic Support Matrix].
+For the list of Elastic supported plugins, please consult the https://www.elastic.co/support/matrix#logstash_plugins[Elastic Support Matrix].
 


### PR DESCRIPTION
Co-authored by: Alessandro Stoltenberg <alessandro.stoltenberg@elastic.co>

Related: #15823 
New commit and PR--with github attribution--because of docs-ci problems on original PR. 

This PR also makes the corresponding change to the integrations plugin header. 

Thanks, @alstolten!