### PR TITLE
Fix typo with aarch64 pipeline name to trigger

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -558,7 +558,7 @@ spec:
           cronline: 0 2 * * 1  # every Monday@2AM UTC
           message: Weekly trigger of AARCH64 pipeline per branch
           env:
-            PIPELINES_TO_TRIGGER: 'logstash-linux-jdk-matrix-pipeline'
+            PIPELINES_TO_TRIGGER: 'logstash-aarch64-pipeline'
         Exhaustive Tests:
           branch: main
           cronline: 0 3 * * 1%2  # every other Wednesday@3AM UTC, see https://buildkite.com/docs/pipelines/scheduled-builds#schedule-intervals-crontab-time-syntax


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit fixes a bug instroduced in PR#15850 and uses the correct pipeline name when triggering the aarch64 pipeline on schedule.

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/2852
