### PR TITLE
Add BK retries to exhaustive/compat steps

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -48,6 +48,7 @@ def compat_step(imagesuffix: str, command: LiteralScalarString) -> dict[str, typ
         "key": slugify_bk_key(f"compat-linux-{imagesuffix}"),
         "command": command,
         "agents": {},
+        "retry": {"automatic": [{"limit": 3}]},
     }
 
     if "amazon" in imagesuffix.lower():


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

As a follow up to #15787 we also add Buildkite retries for the exhaustive pipeline / compatibility group steps to prevent failures due to flakiness.

## Why is it important/What is the impact to the user?

Reduce build noise/improve OKRs esp. since most of the errors, e.g. https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/166#018d596b-b946-4971-b522-e00e2ddbe1ff/48-55
are due to transient network related timeouts while gradle downloads from remote repositories/artifactories.
