### PR TITLE
Add Debian 12 to CI

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -19,6 +19,8 @@ steps:
             value: "ubuntu-2204"
           - label: "Ubuntu 20.04"
             value: "ubuntu-2004"
+          - label: "Debian 12"
+            value: "debian-12"
           - label: "Debian 11"
             value: "debian-11"
           - label: "Debian 10"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -2,7 +2,7 @@
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
         "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
-        "debian": ["debian-11", "debian-10"],
+        "debian": ["debian-12", "debian-11", "debian-10"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],
         "rocky": ["rocky-linux-8"],


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds Debian 12 (Bookworm) to the
Linux JDK matrix pipeline and Compat Phase of the
exhaustive pipeline respectively.

## Why is it important/What is the impact to the user?

This is important to ensure we have coverage for Debian 12.

## How to test this PR locally

Link:

- JDK matrix: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/123

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/2871

