### PR TITLE
Fix service startup with acceptance tests

### DIFF
--- a/qa/acceptance/spec/shared_examples/installed.rb
+++ b/qa/acceptance/spec/shared_examples/installed.rb
@@ -23,6 +23,7 @@ RSpec.shared_examples "installable" do |logstash|
   before(:each) do
     logstash.uninstall
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.configure
   end
 
   it "is installed on [#{logstash.human_name}]" do

--- a/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
+++ b/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
@@ -28,6 +28,7 @@ RSpec.shared_examples "installable_with_jdk" do |logstash|
   before(:each) do
     logstash.uninstall
     logstash.install({:bundled_jdk => true, :version => LOGSTASH_VERSION})
+    logstash.configure
   end
 
   after(:each) do

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -135,6 +135,10 @@ module ServiceTester
       client.install(package)
     end
 
+    def configure()
+      client.configure()
+    end
+
     def uninstall
       client.uninstall(name)
     end

--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -123,6 +123,11 @@ module ServiceTester
       run_command("curl -fsSL --retry 5 --retry-delay 5 #{from} -o #{to}")
     end
 
+    def configure()
+      # defines a minimal pipeline so that the service is able to start
+      run_command('bash -c "echo \"input { heartbeat {} } output { null {} }\" >/etc/logstash/conf.d/pipeline.conf"')
+    end
+
     def delete_file(path)
       run_command("rm -rf #{path}")
     end


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit fixes the startup of the Logstash service during packaging tests by adding a minimal pipeline config.

## Why is it important/What is the impact to the user?

Without it, the service was flapping from start to start and vice versa causing test flakiness.

## How to test this PR locally

Test link:

## Related issues

- Relates https://github.com/elastic/logstash/issues/15784
