### PR TITLE
Add retries to acceptance/docker steps in BK

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -168,6 +168,7 @@ def acceptance_docker_steps()-> list[typing.Any]:
 set -euo pipefail
 source .buildkite/scripts/common/vm-agent.sh
 ci/docker_acceptance_tests.sh {flavor}"""),
+            "retry": {"automatic": [{"limit": 3}]},
         })
 
     return steps


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Similarly to #15874, this commit adds retries
to another group `acceptance/docker` to reduce
build noise from transient issues.

## Why is it important/What is the impact to the user?

Reduces alert noise for transient failures.

## How to test this PR locally

Test: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/195 (see the entry like https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/195#018d7df9-183c-4231-bcde-79eec2de45a1/101-719)
