### PR TITLE
Backport PR #15900 to 7.17: Fix service startup with acceptance tests #15905

### DIFF
--- a/qa/acceptance/spec/shared_examples/installed.rb
+++ b/qa/acceptance/spec/shared_examples/installed.rb
@@ -24,6 +24,7 @@ RSpec.shared_examples "installable" do |logstash|
   before(:each) do
     logstash.uninstall
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   it "is installed on [#{logstash.human_name}]" do

--- a/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
+++ b/qa/acceptance/spec/shared_examples/installed_with_jdk.rb
@@ -29,6 +29,7 @@ RSpec.shared_examples "installable_with_jdk" do |logstash|
   before(:each) do
     logstash.uninstall
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   after(:each) do

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -135,6 +135,11 @@ module ServiceTester
       client.install(package)
     end
 
+    def write_default_pipeline()
+      # defines a minimal pipeline so that the service is able to start
+      client.write_pipeline("input { heartbeat {} } output { null {} }")
+    end
+
     def uninstall
       client.uninstall(name)
     end

--- a/qa/rspec/commands/base.rb
+++ b/qa/rspec/commands/base.rb
@@ -124,6 +124,10 @@ module ServiceTester
       run_command("curl -fsSL --retry 5 --retry-delay 5 #{from} -o #{to}")
     end
 
+    def write_pipeline(pipeline_string)
+      run_command("bash -c \"echo '#{pipeline_string}' >/etc/logstash/conf.d/pipeline.conf\"")
+    end
+
     def delete_file(path)
       run_command("rm -rf #{path}")
     end


### PR DESCRIPTION
**Backport PR #15900 to 7.17 branch, original message:**

---

## Release notes
[rn:skip]

## What does this PR do?

This commit fixes the startup of the Logstash service during packaging tests by adding a minimal pipeline config.

## Why is it important/What is the impact to the user?

Without it, the service was flapping from start to start and vice versa causing test flakiness.

## How to test this PR locally

Test link: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/199

## Related issues

- Relates https://github.com/elastic/logstash/issues/15784
