### PR TITLE
Version bump 7.17.19

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.17.18)
+      logstash-core (= 7.17.19)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.17.18-java)
+    logstash-core (7.17.19-java)
       chronic_duration (~> 0.10)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.17.18
-logstash-core: 7.17.18
+logstash: 7.17.19
+logstash-core: 7.17.19
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Bumps version of 7.17 branch to 7.17.19.

## Why is it important/What is the impact to the user?
Non user facing change.

