### PR TITLE
Follow up to #15900 -- fix remaining acceptance tests

### DIFF
--- a/qa/acceptance/spec/lib/artifact_composition_spec.rb
+++ b/qa/acceptance/spec/lib/artifact_composition_spec.rb
@@ -22,6 +22,7 @@ describe "artifacts composition" do
 
   before(:each) do
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   after(:each) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
@@ -22,6 +22,7 @@ require "fileutils"
 shared_examples "logstash generate" do |logstash|
   before(:each) do
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   after(:each) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -22,6 +22,7 @@ require "fileutils"
 shared_examples "logstash install" do |logstash|
   before(:each) do
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   after(:each) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
@@ -24,6 +24,7 @@ shared_examples "integration plugins compatible" do |logstash|
     let(:plugin) { "logstash-integration-rabbitmq" }
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do
@@ -60,6 +61,7 @@ shared_examples "integration plugins compatible" do |logstash|
     let(:plugin) { "logstash-integration-rabbitmq" }
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do
@@ -83,6 +85,7 @@ shared_examples "integration plugins compatible" do |logstash|
     let(:plugin) { "logstash-integration-rabbitmq" }
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -23,6 +23,7 @@ shared_examples "logstash list" do |logstash|
   describe "logstash-plugin list on [#{logstash.human_name}]" do
     before(:all) do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after(:all) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
@@ -23,6 +23,7 @@ shared_examples "logstash remove" do |logstash|
   describe "logstash-plugin remove on [#{logstash.human_name}]" do
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
@@ -23,6 +23,7 @@ shared_examples "logstash uninstall" do |logstash|
   describe "logstash-plugin uninstall on [#{logstash.human_name}]" do
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
@@ -22,6 +22,7 @@ shared_examples "logstash update" do |logstash|
   describe "logstash-plugin update on [#{logstash.human_name}]" do
     before :each do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :each do

--- a/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash/version.rb
@@ -22,6 +22,7 @@ shared_examples "logstash version" do |logstash|
   describe "logstash --version" do
     before :all do
       logstash.install({:version => LOGSTASH_VERSION})
+      logstash.write_default_pipeline
     end
 
     after :all do

--- a/qa/acceptance/spec/shared_examples/running.rb
+++ b/qa/acceptance/spec/shared_examples/running.rb
@@ -22,6 +22,7 @@ require          'logstash/version'
 RSpec.shared_examples "runnable" do |logstash|
   before(:each) do
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
   end
 
   it "is running on [#{logstash.human_name}]" do

--- a/qa/acceptance/spec/shared_examples/updated.rb
+++ b/qa/acceptance/spec/shared_examples/updated.rb
@@ -37,12 +37,14 @@ RSpec.shared_examples "updated" do |logstash, from_release_branch|
     logstash.download(url, dest)
     options = {:version => latest_logstash_release_version, :snapshot => false, :base => "./", :skip_jdk_infix => false }
     logstash.install(options)
+    logstash.write_default_pipeline
   end
 
   it "can be updated and run on [#{logstash.human_name}]" do
     expect(logstash).to be_installed
     # Performing the update
     logstash.install({:version => LOGSTASH_VERSION})
+    logstash.write_default_pipeline
     expect(logstash).to be_installed
     # starts the service to be sure it runs after the upgrade
     with_running_logstash_service(logstash) do


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

PR #15900 missed a few more places where Logstash is installed but a working minimal pipeline config is added.
This commit adds the missing config in all remaining places.

## Why is it important/What is the impact to the user?

It reduces the time spent for [with_running_logstash_service](https://github.com/elastic/logstash/blob/3c9db658bc7c64eb0da2ed40936382535a84ff21/qa/acceptance/spec/spec_helper.rb#L23-L33) -- for example [here](https://github.com/elastic/logstash/pull/15907/files#diff-8e95d7180ce6b86912a0dc5f958958c60bc6e5831ab8b55fd123720b081c9644L48) -- to succeed (or maybe even fail, after 40 retries).

## How to test this PR locally

Example run:

## Related issues

- Relates https://github.com/elastic/logstash/issues/15784
