### PR TITLE
Version bump to 8.12.2

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.12.1)
+      logstash-core (= 8.12.2)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.12.1-java)
+    logstash-core (8.12.2-java)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.12.1
-logstash-core: 8.12.1
+logstash: 8.12.2
+logstash-core: 8.12.2
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Bumps the version of 8.12 branch to 8.12.2

## Why is it important/What is the impact to the user?
Non user facing change.
