### PR TITLE
flow_metrics: pull `worker_utilization` up to pipeline-level

### DIFF
--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -499,6 +499,10 @@ Example response:
     "worker_concurrency" : {
       "current": 1.973,
       "lifetime": 1.721
+    },
+    "worker_utilization" : {
+      "current": 49.32,
+      "lifetime": 43.02
     }
   }
 }
@@ -535,6 +539,19 @@ A _pipeline_ is considered "saturated" when its `worker_concurrency` flow metric
 Tuning a saturated pipeline to have more workers can often work to increase that pipeline's throughput and decrease back-pressure to its queue, unless the pipeline is experiencing back-pressure from its outputs.
 
 A _process_ is also considered "saturated" when its top-level `worker_concurrency` flow metric approaches the _cumulative_ `pipeline.workers` across _all_ pipelines, and similarly can be addressed by tuning the <<pipeline-stats,individual pipelines>> that are saturated.
+
+| worker_utilization |
+
+This is a unitless metric that indicates the percentage of available worker time being used by all plugins in a given pipeline (`duration` / (`uptime` * `pipeline.workers`).
+It is useful for determining whether the pipeline has consistently-idle resources or is under resource contention.
+
+A _pipeline_ is considered "saturated" when its `worker_utilization` flow metric approaches 100, because it indicates that all of its workers are being kept busy.
+This is typically an indication of either downstream back-pressure or insufficient resources allocated to the pipeline.
+Tuning a saturated pipeline to have more workers can often work to increase that pipeline's throughput and decrease back-pressure to its queue, unless the pipeline is experiencing back-pressure from its outputs.
+
+A _pipeline_ is considered "starved" when its `worker_utilization` flow metric approaches 0, because it indicates that none of its workers are being kept busy.
+This is typically an indication that the inputs are not receiving or retrieving enough volume to keep the pipeline workers busy.
+Tuning a starved pipeline to have fewer workers can help it to consume less memory and CPU, freeing up resources for other pipelines.
 
 | queue_backpressure |
 This is a unitless metric representing the cumulative time spent by all inputs blocked pushing events into their pipeline's queue, relative to wall-clock time (`queue_push_duration_in_millis` / millisecond).
@@ -623,6 +640,10 @@ Example response:
         "worker_concurrency" : {
           "current" : 0.941,
           "lifetime" : 0.9709
+        },
+        "worker_utilization" : {
+          "current" : 93.092,
+          "lifetime" : 92.187
         }
       },
       "plugins" : {
@@ -740,6 +761,10 @@ Example response:
         "worker_concurrency" : {
           "current" : 8.0,
           "lifetime" : 5.903
+        },
+        "worker_utilization" : {
+          "current" : 100,
+          "lifetime" : 75.8
         }
       },
       "plugins" : {
@@ -835,6 +860,10 @@ Example response:
         "worker_concurrency" : {
           "current" : 1.471,
           "lifetime" : 0.9709
+        },
+        "worker_utilization" : {
+          "current" : 74.54,
+          "lifetime" : 46.10
         },
         "queue_persisted_growth_bytes" : {
           "current" : 8731,

--- a/logstash-core/spec/logstash/api/commands/stats_spec.rb
+++ b/logstash-core/spec/logstash/api/commands/stats_spec.rb
@@ -179,6 +179,7 @@ describe LogStash::Api::Commands::Stats do
                                                  :filter_throughput,
                                                  :queue_backpressure,
                                                  :worker_concurrency,
+                                                 :worker_utilization,
                                                  :input_throughput,
                                                  :queue_persisted_growth_bytes,
                                                  :queue_persisted_growth_events

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -117,6 +117,7 @@ describe LogStash::Api::Modules::NodeStats do
          "filter_throughput" => Hash,
          "queue_backpressure" => Hash,
          "worker_concurrency" => Hash,
+         "worker_utilization" => Hash,
          "input_throughput" => Hash,
          "queue_persisted_growth_bytes" => Hash,
          "queue_persisted_growth_events" => Hash

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -536,6 +536,13 @@ public class AbstractPipelineExt extends RubyBasicObject {
         this.flowMetrics.add(concurrencyFlow);
         storeMetric(context, flowNamespace, concurrencyFlow);
 
+        final int workerCount = getSetting(context, SettingKeyDefinitions.PIPELINE_WORKERS).convertToInteger().getIntValue();
+        final UpScaledMetric percentScaledDurationInMillis = new UpScaledMetric(durationInMillis, 100);
+        final UpScaledMetric availableWorkerTimeInMillis = new UpScaledMetric(uptimeInPreciseMillis, workerCount);
+        final FlowMetric utilizationFlow = createFlowMetric(WORKER_UTILIZATION_KEY, percentScaledDurationInMillis, availableWorkerTimeInMillis);
+        this.flowMetrics.add(utilizationFlow);
+        storeMetric(context, flowNamespace, utilizationFlow);
+
         initializePqFlowMetrics(context, flowNamespace, uptimeMetric);
         initializePluginFlowMetrics(context, uptimeMetric);
         return context.nil;

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -268,6 +268,7 @@ describe "Test Monitoring API" do
         # due to three-decimal-place rounding, it is easy for our worker_concurrency and queue_backpressure
         # to be zero, so we are just looking for these to be _populated_
         'worker_concurrency' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
         'queue_backpressure' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
         # depending on flow capture interval, our current rate can easily be zero, but our lifetime rates
         # should be non-zero so long as pipeline uptime is less than ~10 minutes.

--- a/qa/integration/specs/reload_config_spec.rb
+++ b/qa/integration/specs/reload_config_spec.rb
@@ -116,6 +116,7 @@ describe "Test Logstash service when config reload is enabled" do
         # due to three-decimal-place rounding, it is easy for our worker_concurrency and queue_backpressure
         # to be zero, so we are just looking for these to be _populated_
         'worker_concurrency' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
+        'worker_utilization' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
         'queue_backpressure' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
         # depending on flow capture interval, our current rate can easily be zero, but our lifetime rates
         # should be non-zero so long as pipeline uptime is less than ~10 minutes.


### PR DESCRIPTION


## Release notes

Adds a pipeline-level `worker_utilization` flow-metric, providing visibility of how a pipeline is utilizing its allocated workers on a scale from 0-100.

## What does this PR do?

Pulls up the existing per-plugin `worker_utilization` metric to the pipeline level, so that we can tell at-a-glance what percentage of the pipeline's allocated workers are being utilized.

## Why is it important/What is the impact to the user?

Provides a simpler and more immediately-usable metric than the `worker_concurrency` flow metric, which requires that the user have side-channel information about how many workers are allocated to the pipeline in order to have actionable insight about whether the available resources are being utilized.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Use a "bursty" pipeline, which generates a lot of events and processes them either quickly or slowly depending on the current timestamp:

> ~~~
> input {
>   java_generator {
>     eps => 1000
>     threads => 10
>   }
> }
> 
> filter {
>   ruby {
>     code => "
>       Time.now.then {|t| [t.min+(t.sec/30), t.hour+(t.sec/3), t.sec] }.each do |q|
>         sleep((2.0 ** Random.rand) - 0.99) if (q % 5).zero?
>       end
>     "
>   }
> }
> 
> output {
>   sink { }
> }
> ~~~
> -- `bursty.pipeline`

~~~ sh
bin/logstash -f bursty.pipeline -w 32
~~~

Then, run a `watch` command to observe the API result changing over time:

~~~
watch --color "curl -XGET 'localhost:9600/_node/stats' | jq -C .pipelines.main.flow"
~~~

Observe that `worker_utilization` is at 99.8%, which is easier to interpret as fully-saturated than the `worker_concurrency` metric's value of 31.94 (which is 99.8% of the pipeline's 32 workers):

![Screenshot 2024-02-06 at 10 40 32 AM](https://github.com/elastic/logstash/assets/210924/769805f5-0bba-4a41-9628-05b471073832)


## Related issues

Relates:
 - Flow Metrics Meta [#14539](https://github.com/elastic/logstash/issues/14463)
 - Per-Plugin Flow Metrics (introduced `worker_utilization`) [#14601](https://github.com/elastic/logstash/issues/14601)
