### PR TITLE
Fix docker build issues

### DIFF
--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1
+FROM golang:1.21
 RUN go env -w GO111MODULE=off && (for i in 0 1 2 3 4 5; do sleep "$i"; go get gopkg.in/yaml.v2 && break; done)
 WORKDIR /usr/local/src/env2yaml
 CMD ["go", "build"]


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

We don't pin the minor version of the go docker
image and the recent update to 1.22 resulted in
the following error:

```
go env -w GO111MODULE=off && go get gopkg.in/yaml.v2
go: modules disabled by GO111MODULE=off; see 'go help modules'
```

This commit pins the Go docker image to 1.21
until we resolve the issue in a more proper manner (using go modules) in a follow up PR.



## Why is it important/What is the impact to the user?

Unblocks DRA and CI.

## How to test this PR locally

DRA snapshot build link (main): https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/495

## Related issues

https://github.com/elastic/logstash/issues/15920

