### PR TITLE
introduce go.mod for env2yaml

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -200,16 +200,12 @@ venv: requirements.txt
 	for i in 0 1 2 3 4 5; do sleep "$i"; pip install -r requirements.txt && break; done &&\
 	touch venv
 
-# Make a Golang container that can compile our env2yaml tool.
-golang:
-	docker build -t golang:env2yaml data/golang
-
 # Compile "env2yaml", the helper for configuring logstash.yml via environment
 # variables.
-env2yaml: golang
-	docker run --rm -i \
-	  -v $(PWD)/data/logstash/env2yaml:/usr/local/src/env2yaml:Z \
-	  golang:env2yaml
+env2yaml:
+	docker run --rm \
+	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
+		-w /usr/src/env2yaml golang:1 go build
 
 # Generate the Dockerfiles from Jinja2 templates.
 dockerfile: venv templates/Dockerfile.j2

--- a/docker/data/golang/Dockerfile
+++ b/docker/data/golang/Dockerfile
@@ -1,4 +1,0 @@
-FROM golang:1
-RUN go env -w GO111MODULE=off && (for i in 0 1 2 3 4 5; do sleep "$i"; go get gopkg.in/yaml.v2 && break; done)
-WORKDIR /usr/local/src/env2yaml
-CMD ["go", "build"]

--- a/docker/data/logstash/env2yaml/go.mod
+++ b/docker/data/logstash/env2yaml/go.mod
@@ -1,0 +1,5 @@
+module logstash/env2yaml
+
+go 1.21
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/docker/data/logstash/env2yaml/go.sum
+++ b/docker/data/logstash/env2yaml/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Updated the env2yaml to have a go.mod instead of relying on disabling go modules, otherwise building with golang 1.22 will fail.
This change also directly uses the golang image to build the binary removing the need for an intermediate image.

Tested locally and also with buildkite build docker image:

```
> curl https://artifacts-snapshot.elastic.co/logstash/8.13.0-37a00f62/downloads/logstash/logstash-8.13.0-SNAPSHOT-docker-image-aarch64.tar.gz | docker load

❯ docker run -e PIPELINE_WORKERS -it  docker.elastic.co/logstash/logstash:8.13.0-SNAPSHOT grep build_sha logstash-core/lib/logstash/build.rb
BUILD_INFO = {"build_date"=>"2024-02-08T11:58:19+00:00", "build_sha"=>"7465a35f681caa57b60d49512b0d22111e36bad6", "build_snapshot"=>true}

❯ PIPELINE_WORKERS=2  docker run -e PIPELINE_WORKERS -it  docker.elastic.co/logstash/logstash:8.13.0-SNAPSHOT echo 1
2024/02/08 13:11:43 Setting 'pipeline.workers' from environment.
1
```

fixes https://github.com/elastic/logstash/issues/15920