### PR TITLE
Set Netty's maxOrder options to previous default

### DIFF
--- a/tools/jvm-options-parser/build.gradle
+++ b/tools/jvm-options-parser/build.gradle
@@ -31,11 +31,11 @@ buildscript {
   }
 }
 
-project.sourceCompatibility = JavaVersion.VERSION_1_8
-project.targetCompatibility = JavaVersion.VERSION_1_8
+project.sourceCompatibility = JavaVersion.VERSION_11
+project.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-  testImplementation "junit:junit:4.12"
+  testImplementation "junit:junit:4.13.1"
 }
 
 javadoc {

--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -180,7 +181,26 @@ public class JvmOptionsParser {
         // Set mandatory JVM options
         jvmOptionsContent.addAll(getMandatoryJvmOptions(javaMajorVersion));
 
-        System.out.println(String.join(" ", jvmOptionsContent));
+        final Set<String> jvmFinalOptions = nettyMaxOrderDefaultTo11(jvmOptionsContent);
+
+        System.out.println(String.join(" ", jvmFinalOptions));
+    }
+
+    /**
+     * Inplace method that verifies if Netty's maxOrder option is already set, else configure it to have
+     * the default value of 11.
+     *
+     * @param options the collection of options to examine.
+     * @return the collection of input option eventually with Netty maxOrder added.
+     * */
+    private Set<String> nettyMaxOrderDefaultTo11(Set<String> options) {
+        boolean maxOrderAlreadyContained = options.stream().anyMatch(s -> s.startsWith("-Dio.netty.allocator.maxOrder"));
+        if (maxOrderAlreadyContained) {
+            return options;
+        }
+        final Set<String> acc = new HashSet<>(options);
+        acc.add("-Dio.netty.allocator.maxOrder=11");
+        return acc;
     }
 
     /**


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Updates Netty's configuration of maxOrder to a previously proven value, if not already customised by the user.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Adds a step to the JvmOption parsing tool, which is used to compose the JVM options string to pass down to Logstash at startup.
The added step rework the parsed options to set  the allocator max order `-Dio.netty.allocator.maxOrder=11` so that the maximum pooled buffer is up to 16MB and not 4MB. 
This option is added iff it's not yet specified by the user

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
It brings back the performance of Netty based plugins to the same as of Logstash previous of `8.7.0`, which introduced an update of Netty library.
With messages bigger then 2Kb each it triggered a problem of using unpooled buffers, which kills performance. With this change it moved back to 8Kb.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

The test splits in 2, verify that the line `-Dio.netty.allocator.maxOrder=11` is added when the flag is not in `config/jvm.options` and verify that if the flag is already present it's not overwritten.
Run Logstash with
```sh
bin/logstash -e "input {stdin {}} output {stdout{}}"
```
- first test: run Logstash and verify that the log that prints all the flag contains the redefinition of maxOrder
```
[INFO ][logstash.runner          ][main] JVM bootstrap flags: [-Xms4g,...-Dio.netty.allocator.maxOrder=11...
```
-second test: edit `config/jvm.options` and add a custom `io.netty.allocator.maxOrder`, start Logstash and verify logs contains the definition was added.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15765 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
