### PR TITLE
add openssl to ubi image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -186,7 +186,7 @@ env2yaml:
 	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
 		-w /usr/src/env2yaml golang:1 go build
 
-# Generate the Dockerfiles from Jinja2 templates.
+# Generate the Dockerfiles from ERB templates.
 dockerfile: templates/Dockerfile.erb
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
 		../vendor/jruby/bin/jruby -S erb -T "-"\

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -75,6 +75,9 @@ export DEBIAN_FRONTEND=noninteractive && \
 <%= package_manager %> upgrade -y && \
 <% end -%>
 <%= package_manager %> install -y procps findutils tar gzip curl && \
+<% if image_flavor == 'ubi8' -%>
+<%= package_manager %> install -y openssl && \
+<% end -%>
 <% if image_flavor == 'ubi8' || image_flavor == 'ironbank' -%>
 <%= package_manager %> install -y which shadow-utils && \
 <% else -%>

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -332,7 +332,7 @@ namespace "artifact" do
     build_dockerfile('full')
   end
 
-  desc "Generate Dockerfile for full images"
+  desc "Generate Dockerfile for UBI8 images"
   task "dockerfile_ubi8" => ["prepare", "generate_build_metadata"] do
     puts("[dockerfiles] Building ubi8 Dockerfiles")
     build_dockerfile('ubi8')


### PR DESCRIPTION
Logstash on ECK requires `openssl` command to  build TLS keystore. logstash-ubi:8.12.0 has openssl command, but 8.12.1 and 8.12.2 don't.
This commit adds `microdnf install -y openssl` to ensure the command exists in ubi image

relates: https://github.com/elastic/cloud-on-k8s/issues/7544