### PR TITLE
Fix packaging service check failures

### DIFF
--- a/qa/rspec/commands/system_helpers.rb
+++ b/qa/rspec/commands/system_helpers.rb
@@ -26,7 +26,7 @@ module ServiceTester
       stdout.force_encoding(Encoding::UTF_8)
       (
         stdout.match(/Active: active \(running\)/) &&
-        stdout.match(/^\s*(└─|`-)\d*\s.*#{jdk_path}/) &&
+        stdout.match(/^\s*(└─|`-)\d*\s.*#{jdk_path}.*org\.logstash\.Logstash/) &&
         stdout.match(/#{package}.service - #{package}/)
       )
     end


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit tightens the checks for the status
output of the Logstash OS service to specifically
scan for `org.logstash.Logstash` rather than
only the jdk path.

The reason is that the startup script first runs
an options parser, and then the logstash process
itself, both referencing the JDK path.

## Why is it important/What is the impact to the user?

Currently packaging tests can be flaky (esp. on RPM distros) which we circumvent with Buildkite native retries (which doesn't always help).

## How to test this PR locally

BK link to exhaustive job: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/245

I also ran it in several iterations of loops like below on a rhel-8 VM and didn't get any failure, whereas I'd always get a failure without the PR:

```
for i in {1..30}; do echo ">>> Iteration $i"; bundle exec rspec acceptance/spec -e 'behaves like installable_with_jdk is running on'; if [[ $? -ne 0 ]]; then echo ">>>>> Failed, exiting"; break; fi; done
```

## Related issues

Closes https://github.com/elastic/ingest-dev/issues/2950
