### PR TITLE
[CI] [Sonar] Explicitly specified test sources for sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=elastic_logstash_AYm_nEbQaV3I-igkX1q9
 sonar.host.url=https://sonar.elastic.dev
 
-sonar.exclusions=vendor/**, gradle/**, rakelib/**, logstash-core-plugin-api/**, licenses/**, qa/**, spec/**
+sonar.exclusions=vendor/**, gradle/**, rakelib/**, logstash-core-plugin-api/**, licenses/**, qa/**
 
 # Ruby
 sonar.ruby.coverage.reportPaths=coverage/coverage.json
@@ -9,3 +9,4 @@ sonar.ruby.coverage.reportPaths=coverage/coverage.json
 # Java
 sonar.coverage.jacoco.xmlReportPaths=**/jacocoTestReport.xml
 sonar.java.binaries=**/build/classes
+sonar.tests=**/src/test/**, **/spec/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,8 @@
 sonar.projectKey=elastic_logstash_AYm_nEbQaV3I-igkX1q9
 sonar.host.url=https://sonar.elastic.dev
 
-sonar.exclusions=vendor/**, gradle/**, rakelib/**, logstash-core-plugin-api/**, licenses/**, qa/**
+sonar.exclusions=vendor/**, gradle/**, rakelib/**, logstash-core-plugin-api/**, licenses/**, qa/**, **/spec/**
+sonar.tests=logstash-core/src/test, x-pack/src/test, buildSrc/src/test 
 
 # Ruby
 sonar.ruby.coverage.reportPaths=coverage/coverage.json
@@ -9,4 +10,3 @@ sonar.ruby.coverage.reportPaths=coverage/coverage.json
 # Java
 sonar.coverage.jacoco.xmlReportPaths=**/jacocoTestReport.xml
 sonar.java.binaries=**/build/classes
-sonar.tests=**/src/test/**, **/spec/**


### PR DESCRIPTION

## What does this PR do?
Explicitly specifies test sources for sonar

## Why is it important/What is the impact on the user?
We can't use `sonar-grade-plugin` due to multilanguage support.  Hence we need to narrow the coverage scope and explicitly specify the test sources using a glob pattersn
