### PR TITLE
Fix failing DLQ test due to time scheduling

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -134,8 +134,6 @@ public final class DeadLetterQueueWriter implements Closeable {
          * Register the callback action to invoke on every clock tick.
          * */
         void repeatedAction(Runnable action);
-
-        void shutdown();
     }
 
     private static class FixedRateScheduler implements SchedulerService {
@@ -157,22 +155,11 @@ public final class DeadLetterQueueWriter implements Closeable {
         public void repeatedAction(Runnable action) {
             scheduledExecutor.scheduleAtFixedRate(action, 1L, 1L, TimeUnit.SECONDS);
         }
-
-        @Override
-        public void shutdown() {
-            scheduledExecutor.shutdown();
-        }
-
     }
 
     private static class NoopScheduler implements SchedulerService {
         @Override
         public void repeatedAction(Runnable action) {
-            // Noop
-        }
-
-        @Override
-        public void shutdown() {
             // Noop
         }
     }
@@ -323,8 +310,6 @@ public final class DeadLetterQueueWriter implements Closeable {
             } catch (Exception e) {
                 logger.warn("Unable to release fileLock, ignoring", e);
             }
-
-            flusherService.shutdown();
 
             try {
                 // flushScheduler is null only if it's not explicitly started, which happens only in tests.

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -134,6 +134,8 @@ public final class DeadLetterQueueWriter implements Closeable {
          * Register the callback action to invoke on every clock tick.
          * */
         void repeatedAction(Runnable action);
+
+        void shutdown();
     }
 
     private static class FixedRateScheduler implements SchedulerService {
@@ -155,11 +157,22 @@ public final class DeadLetterQueueWriter implements Closeable {
         public void repeatedAction(Runnable action) {
             scheduledExecutor.scheduleAtFixedRate(action, 1L, 1L, TimeUnit.SECONDS);
         }
+
+        @Override
+        public void shutdown() {
+            scheduledExecutor.shutdown();
+        }
+
     }
 
     private static class NoopScheduler implements SchedulerService {
         @Override
         public void repeatedAction(Runnable action) {
+            // Noop
+        }
+
+        @Override
+        public void shutdown() {
             // Noop
         }
     }
@@ -310,6 +323,8 @@ public final class DeadLetterQueueWriter implements Closeable {
             } catch (Exception e) {
                 logger.warn("Unable to release fileLock, ignoring", e);
             }
+
+            flusherService.shutdown();
 
             try {
                 // flushScheduler is null only if it's not explicitly started, which happens only in tests.

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -77,11 +77,6 @@ public class DeadLetterQueueWriterAgeRetentionTest {
             this.action = action;
         }
 
-        @Override
-        public void shutdown() {
-            // Noop
-        }
-
         void executeAction() {
             action.run();
         }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -345,7 +345,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     }
 
     @Test
-    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException {
+    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException, InterruptedException {
         // https://github.com/elastic/logstash/issues/15768
 //        assumeThat(isWindows(), is(not(true)));
 
@@ -366,6 +366,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
             DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
             writeManager.writeEntry(entry);
+
+            // WARN: writeEntry set the lastWrite instant which is later checked by isStale in RecordIOWriter
+            // against now - flush period. Given that flush period is 0, it could be that now is the same
+            // instant as lastWrite, while should be greater than, so put an artificial small delay
+            Thread.sleep(10);
 
             triggerExecutionOfFlush();
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -77,6 +77,11 @@ public class DeadLetterQueueWriterAgeRetentionTest {
             this.action = action;
         }
 
+        @Override
+        public void shutdown() {
+            // Noop
+        }
+
         void executeAction() {
             action.run();
         }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -347,7 +347,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     @Test
     public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException {
         // https://github.com/elastic/logstash/issues/15768
-        assumeThat(isWindows(), is(not(true)));
+//        assumeThat(isWindows(), is(not(true)));
 
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
                 Collections.singletonMap("message", "Not so important content"));

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -335,15 +335,8 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         }
     }
 
-    private static boolean isWindows() {
-        return System.getProperty("os.name").startsWith("Windows");
-    }
-
     @Test
-    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException, InterruptedException {
-        // https://github.com/elastic/logstash/issues/15768
-//        assumeThat(isWindows(), is(not(true)));
-
+    public void testDLQWriterFlusherRemovesExpiredSegmentWhenCurrentHeadSegmentIsEmpty() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(
                 Collections.singletonMap("message", "Not so important content"));
 
@@ -360,12 +353,15 @@ public class DeadLetterQueueWriterAgeRetentionTest {
                 .build()) {
 
             DLQEntry entry = new DLQEntry(event, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(fakeClock));
+            Instant beforeWriteEntry = Instant.now();
             writeManager.writeEntry(entry);
 
             // WARN: writeEntry set the lastWrite instant which is later checked by isStale in RecordIOWriter
             // against now - flush period. Given that flush period is 0, it could be that now is the same
             // instant as lastWrite, while should be greater than, so put an artificial small delay
-            Thread.sleep(10);
+            Awaitility.await("Let the time flow a little so that last write is recognized to be in the past")
+                      .atMost(Duration.ofSeconds(1))
+                      .until(() -> Instant.now().isAfter(beforeWriteEntry));
 
             triggerExecutionOfFlush();
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

Adds a burning of time condition to avoid a collision of time which, under certain circumstances, would fail the test.
The sealing of a segment happens if the segment is considered as `stale`, which requires 2 conditions:
- the segment must have received a write
- the time of the last write must exceed the flush interval.

In this failing test, the flush interval is set to `ZERO` because of the synchronicity of the test, to avoid time dependency. However, with coarse grain timer resolution, could happen that the last write coincide with the time of the stale check, so fail the seal condition.

## Why is it important/What is the impact to the user?

As a developer the test should work the same way on multiple OSes, independently of time schedules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] Verify on Windows OS. https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/113

## How to test this PR locally

Run the test on a Windows OS:
```
.\gradlew clean :logstash-core:javaTests --tests org.logstash.common.io.DeadLetterQueueWriterAgeRetentionTest
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #15767 

