### PR TITLE
Doc: Remove include statements for screenshots not rendering properly

### DIFF
--- a/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
@@ -108,7 +108,7 @@ include::monitoring-view.asciidoc[]
 === Monitor {ls} logs and metrics
 
 From the list of assets, open the **[Metrics {ls}] {ls} overview** dashboard to view overall performance. Then follow the navigation panel to further drill down into {ls} performance.
-+
+
 [role="screenshot"]
 image::images/integration-dashboard-overview.png[The {ls} Overview dashboard in {kib} with various metrics from your monitored {ls}]
 

--- a/docs/static/tab-widgets/install-agent.asciidoc
+++ b/docs/static/tab-widgets/install-agent.asciidoc
@@ -19,7 +19,7 @@ data.
 
 // tag::standalone[]
 . When the **Add Agent flyout** appears, navigate to the **Run standalone** tab.
-. Configure the agent. Follow all the instructions in **Install Elastic Agent on your host**.
+. Configure the agent. Follow the instructions in **Install Elastic Agent on your host**.
 . After unpacking the binary, replace the `elastic-agent.yml` file with that supplied in the Add Agent flyout on the "Run standalone" tab, replacing the values of `ES_USERNAME` and `ES_PASSWORD` appropriately.
 . Run `sudo ./elastic-agent install`
 // end::standalone[]

--- a/docs/static/tab-widgets/install-agent.asciidoc
+++ b/docs/static/tab-widgets/install-agent.asciidoc
@@ -1,10 +1,5 @@
 // tag::fleet-managed[]
-. When the **Add Agent flyout** appears, stay on the **Enroll in fleet** tab
-+
---
-[role="screenshot"]
-image::../monitoring/images/integration-agent-add.png[Add agent flyout in {kib}]
---
+. When the **Add Agent flyout** appears, stay on the **Enroll in fleet** tab.
 . Skip the **Select enrollment token** step. The enrollment token you need is
 already selected.
 +
@@ -20,20 +15,11 @@ It takes about a minute for {agent} to enroll in {fleet}, download the
 configuration specified in the policy you just created, and start collecting
 data.
 
---
-[role="screenshot"]
-image::../monitoring/images/integration-agent-confirm.png[Agent confirm data]
---
 // end::fleet-managed[]
 
 // tag::standalone[]
-. When the **Add Agent flyout** appears, navigate to the **Run standalone** tab
-+
---
-[role="screenshot"]
-image::../monitoring/images/integration-agent-add-standalone.png[Add agent flyout in {kib}]
---
-. Configure the agent. Follow all the instructions in **Install Elastic Agent on your host**
+. When the **Add Agent flyout** appears, navigate to the **Run standalone** tab.
+. Configure the agent. Follow all the instructions in **Install Elastic Agent on your host**.
 . After unpacking the binary, replace the `elastic-agent.yml` file with that supplied in the Add Agent flyout on the "Run standalone" tab, replacing the values of `ES_USERNAME` and `ES_PASSWORD` appropriately.
 . Run `sudo ./elastic-agent install`
 // end::standalone[]


### PR DESCRIPTION
Fixes: #15882 

Screenshots are not rendering properly inside widgets. The widgets are documenting guided flows, and the screenshots are not critical for understanding.  Note that I am not deleting the image files. They're still in place for when/if we decide to find a workaround and reimplement them. 

**PREVIEW:** https://logstash_bk_15981.docs-preview.app.elstc.co/guide/en/logstash/master/dashboard-monitoring-with-elastic-agent.html