### PR TITLE
geoip: avoid crash cleaning non-existing managed dbs

### DIFF
--- a/x-pack/lib/geoip_database_management/manager.rb
+++ b/x-pack/lib/geoip_database_management/manager.rb
@@ -59,9 +59,13 @@ module LogStash module GeoipDatabaseManagement class Manager
     @metadata = Metadata.new(data_path)
 
     unless enabled?
-      logger.info("database manager is disabled; removing managed databases from disk``")
-      metadata.delete
-      clean_up_database
+      if @metadata.exist?
+        logger.info("database manager is disabled; removing managed databases from disk``")
+        metadata.delete
+        clean_up_database
+      else
+        logger.info("database manager is disabled.")
+      end
     end
   end
 
@@ -142,6 +146,8 @@ module LogStash module GeoipDatabaseManagement class Manager
   end
 
   def clean_up_database(excluded_dirnames = [])
+    return unless ::Dir.exist?(data_path.root)
+
     protected_dirnames = excluded_dirnames.uniq
     existing_dirnames = ::Dir.children(data_path.root)
                              .select { |f| ::File.directory? ::File.join(data_path.root, f) }

--- a/x-pack/spec/geoip_database_management/manager_spec.rb
+++ b/x-pack/spec/geoip_database_management/manager_spec.rb
@@ -116,8 +116,6 @@ describe LogStash::GeoipDatabaseManagement::Manager, aggregate_failures: true, v
         let(:existing_asn_db_path) { nil }
 
         it 'logs info about database manager being disabled' do
-          ::Dir.glob("#{settings_path_data}/**/*").each {|f| puts "  EXISTS(#{f})"}
-
           manager_instance # instantiate
 
           expect(mock_logger).to have_received(:info).with(a_string_including "database manager is disabled")

--- a/x-pack/spec/geoip_database_management/manager_spec.rb
+++ b/x-pack/spec/geoip_database_management/manager_spec.rb
@@ -37,10 +37,13 @@ describe LogStash::GeoipDatabaseManagement::Manager, aggregate_failures: true, v
   let(:geoip_data_path) { ::File.expand_path("geoip_database_management", settings_path_data)}
   let(:geoip_metadata_path) { ::File.expand_path("metadata.csv", geoip_data_path) }
 
+  let(:populate_geoip_data_path) { true }
   let(:metadata_contents) { nil }
   before(:each) do
-    ::FileUtils.mkdir_p(::File.dirname(geoip_metadata_path))
-    ::File.write(geoip_metadata_path, metadata_contents) unless metadata_contents.nil?
+    if populate_geoip_data_path
+      ::FileUtils.mkdir_p(::File.dirname(geoip_metadata_path))
+      ::File.write(geoip_metadata_path, metadata_contents) unless metadata_contents.nil?
+    end
   end
 
   after(:each) do
@@ -105,6 +108,20 @@ describe LogStash::GeoipDatabaseManagement::Manager, aggregate_failures: true, v
 
         expect(Pathname(existing_city_db_path)).to_not be_file
         expect(Pathname(existing_asn_db_path)).to_not be_file
+      end
+
+      context "and data directory does not exist" do
+        let(:populate_geoip_data_path) { false }
+        let(:existing_city_db_path) { nil }
+        let(:existing_asn_db_path) { nil }
+
+        it 'logs info about database manager being disabled' do
+          ::Dir.glob("#{settings_path_data}/**/*").each {|f| puts "  EXISTS(#{f})"}
+
+          manager_instance # instantiate
+
+          expect(mock_logger).to have_received(:info).with(a_string_including "database manager is disabled")
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fixes an issue in which the GeoIP filter could fail to start when the GeoIP Database Manager was disabled and had never been configured.

## What does this PR do?

Resolves: logstash-plugins/logstash-filter-geoip#222

## Why is it important/What is the impact to the user?

When a user does not have GeoIP Database Management enabled, they are unlikely to have a managed directory so we should not crash trying to clean up something that doesn't exist.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->

 - Resolves: logstash-plugins/logstash-filter-geoip#222
