### PR TITLE
Doc Test: Remove extra `+` to force page to rebuild

### DIFF
--- a/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
@@ -108,7 +108,7 @@ include::monitoring-view.asciidoc[]
 === Monitor {ls} logs and metrics
 
 From the list of assets, open the **[Metrics {ls}] {ls} overview** dashboard to view overall performance. Then follow the navigation panel to further drill down into {ls} performance.
-+
+
 [role="screenshot"]
 image::images/integration-dashboard-overview.png[The {ls} Overview dashboard in {kib} with various metrics from your monitored {ls}]
 


### PR DESCRIPTION
The preview for #15981 on the `current` branch doesn't have the problem I'm trying to fix in `main`. The problem still exists in built docs, but not the preview. 

The unnecessary `+` needs to be removed from the source file anyway, so I'm using it as a test so that I can check out the preview. 