### PR TITLE
Bump ES output to include unicode-vs-compression fix

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -592,7 +592,7 @@ GEM
     logstash-output-csv (3.0.10)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-output-file
-    logstash-output-elasticsearch (11.4.1-java)
+    logstash-output-elasticsearch (11.4.2-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-deprecation_logger_support (~> 1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.0)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Updates the Elasticsearch output to include a fix for situations where events containing non-unicode strings could be serialized incorrectly when sending to Elasticsearch with http compression enabled

## What does this PR do?

Updates ES output to consume https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1171

## Why is it important/What is the impact to the user?

When compression is enabled and events contain non-unicode characters, without this fix invalid payloads could be sent to Elasticsearch resulting in indexing rejections.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Relates: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1171

## Use cases

 - ES Output with http compression enabled
