### PR TITLE
Test base images without Python

### DIFF
--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -19,7 +19,7 @@ def package_x86_step(branch, workflow_type):
   key: "logstash_build_packages_dra"
   agents:
     provider: gcp
-    imageProject: elastic-images-prod
+    imageProject: elastic-images-qa
     image: family/platform-ingest-logstash-ubuntu-2204
     machineType: "n2-standard-16"
     diskSizeGb: 200
@@ -38,7 +38,7 @@ def package_x86_docker_step(branch, workflow_type):
   key: "logstash_build_x86_64_docker_dra"
   agents:
     provider: gcp
-    imageProject: elastic-images-prod
+    imageProject: elastic-images-qa
     image: family/platform-ingest-logstash-ubuntu-2204
     machineType: "n2-standard-16"
     diskSizeGb: 200
@@ -78,7 +78,7 @@ def publish_dra_step(branch, workflow_type, depends_on):
   depends_on: "{depends_on}"
   agents:
     provider: gcp
-    imageProject: elastic-images-prod
+    imageProject: elastic-images-qa
     image: family/platform-ingest-logstash-ubuntu-2204
     machineType: "n2-standard-16"
     diskSizeGb: 200

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -61,7 +61,7 @@ def compat_step(imagesuffix: str, command: LiteralScalarString) -> dict[str, typ
     else:
        step["agents"] = {
             "provider": "gcp",
-            "imageProject": "elastic-images-prod",
+            "imageProject": "elastic-images-qa",
             "image": f"family/{VM_IMAGE_PREFIX}{imagesuffix}",
             "machineType": "n2-standard-4",
             "diskSizeGb": 200,
@@ -93,10 +93,10 @@ def aws_agent(vm_name: str, instance_type: str, image_prefix: str = "platform-in
         "diskSizeGb": disk_size_gb,
     }
 
-def gcp_agent(vm_name: str, instance_type: str = "n2-standard-4", image_prefix: str = "family/platform-ingest-logstash-multi-jdk", disk_size_gb: int = 200) -> dict[str, typing.Any]:
+def gcp_agent(vm_name: str, instance_type: str = "n2-standard-4", image_prefix: str = "family/platform-ingest-logstash-multi-jdk", image_project="elastic-images-qa", disk_size_gb: int = 200) -> dict[str, typing.Any]:
     return {
         "provider": "gcp",
-        "imageProject": "elastic-images-prod",
+        "imageProject": image_project,
         "image": f"{image_prefix}-{vm_name}",
         "machineType": instance_type,
         "diskSizeGb": disk_size_gb,


### PR DESCRIPTION
PR to test https://github.com/elastic/ci-agent-images/pull/575

Test DRA #main snapshot: https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/674
Test exhaustive #main job:  https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/324

However, the above images won't work with `8.12`/`7.17` because the removal of the Python dependency hasn't been backported back enough, see https://github.com/elastic/logstash/pull/15142#issuecomment-2012392485

**DO NOT MERGE**