### PR TITLE
Save  name came through ENV vars to let Logstash decide using value from either keystore or ENV.

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -21,18 +21,116 @@ import (
 	"log"
 	"os"
 	"strings"
+	"fmt"
 )
 
-// If the given string can be parsed as YAML, then do so and return the
-// resulting entity. Otherwise, return the string unmodified.
-func FromYamlIfPossible(str string) interface{} {
-	var entity interface{}
-	err := yaml.Unmarshal([]byte(str), &entity)
-	if err == nil {
-		return entity
-	} else {
-		return str
-	}
+var validSettings = [...]string{
+	"api.enabled",
+	"api.http.host",
+	"api.http.port",
+	"api.environment",
+	"node.name",
+	"path.data",
+	"pipeline.id",
+	"pipeline.workers",
+	"pipeline.output.workers",
+	"pipeline.batch.size",
+	"pipeline.batch.delay",
+	"pipeline.unsafe_shutdown",
+	"pipeline.ecs_compatibility",
+	"pipeline.ordered",
+	"pipeline.plugin_classloaders",
+	"pipeline.separate_logs",
+	"path.config",
+	"config.string",
+	"config.test_and_exit",
+	"config.reload.automatic",
+	"config.reload.interval",
+	"config.debug",
+	"config.support_escapes",
+	"config.field_reference.escape_style",
+	"event_api.tags.illegal",
+	"queue.type",
+	"path.queue",
+	"queue.page_capacity",
+	"queue.max_events",
+	"queue.max_bytes",
+	"queue.checkpoint.acks",
+	"queue.checkpoint.writes",
+	"queue.checkpoint.interval",
+	"queue.drain",
+	"dead_letter_queue.enable",
+	"dead_letter_queue.max_bytes",
+	"dead_letter_queue.flush_interval",
+	"dead_letter_queue.storage_policy",
+	"dead_letter_queue.retain.age",
+	"path.dead_letter_queue",
+	"http.enabled",     // DEPRECATED: prefer `api.enabled`
+	"http.environment", // DEPRECATED: prefer `api.environment`
+	"http.host",        // DEPRECATED: prefer `api.http.host`
+	"http.port",        // DEPRECATED: prefer `api.http.port`
+	"log.level",
+	"log.format",
+	"modules",
+	"metric.collect",
+	"path.logs",
+	"path.plugins",
+	"api.auth.type",
+	"api.auth.basic.username",
+	"api.auth.basic.password",
+	"api.auth.basic.password_policy.mode",
+	"api.auth.basic.password_policy.length.minimum",
+	"api.auth.basic.password_policy.include.upper",
+	"api.auth.basic.password_policy.include.lower",
+	"api.auth.basic.password_policy.include.digit",
+	"api.auth.basic.password_policy.include.symbol",
+	"allow_superuser",
+	"monitoring.cluster_uuid",
+	"xpack.monitoring.enabled",
+	"xpack.monitoring.collection.interval",
+	"xpack.monitoring.elasticsearch.hosts",
+	"xpack.monitoring.elasticsearch.username",
+	"xpack.monitoring.elasticsearch.password",
+	"xpack.monitoring.elasticsearch.proxy",
+	"xpack.monitoring.elasticsearch.api_key",
+	"xpack.monitoring.elasticsearch.cloud_auth",
+	"xpack.monitoring.elasticsearch.cloud_id",
+	"xpack.monitoring.elasticsearch.sniffing",
+	"xpack.monitoring.elasticsearch.ssl.certificate_authority",
+	"xpack.monitoring.elasticsearch.ssl.ca_trusted_fingerprint",
+	"xpack.monitoring.elasticsearch.ssl.verification_mode",
+	"xpack.monitoring.elasticsearch.ssl.truststore.path",
+	"xpack.monitoring.elasticsearch.ssl.truststore.password",
+	"xpack.monitoring.elasticsearch.ssl.keystore.path",
+	"xpack.monitoring.elasticsearch.ssl.keystore.password",
+	"xpack.monitoring.elasticsearch.ssl.certificate",
+	"xpack.monitoring.elasticsearch.ssl.key",
+	"xpack.monitoring.elasticsearch.ssl.cipher_suites",
+	"xpack.management.enabled",
+	"xpack.management.logstash.poll_interval",
+	"xpack.management.pipeline.id",
+	"xpack.management.elasticsearch.hosts",
+	"xpack.management.elasticsearch.username",
+	"xpack.management.elasticsearch.password",
+	"xpack.management.elasticsearch.proxy",
+	"xpack.management.elasticsearch.api_key",
+	"xpack.management.elasticsearch.cloud_auth",
+	"xpack.management.elasticsearch.cloud_id",
+	"xpack.management.elasticsearch.sniffing",
+	"xpack.management.elasticsearch.ssl.certificate_authority",
+	"xpack.management.elasticsearch.ssl.ca_trusted_fingerprint",
+	"xpack.management.elasticsearch.ssl.verification_mode",
+	"xpack.management.elasticsearch.ssl.truststore.path",
+	"xpack.management.elasticsearch.ssl.truststore.password",
+	"xpack.management.elasticsearch.ssl.keystore.path",
+	"xpack.management.elasticsearch.ssl.keystore.password",
+	"xpack.management.elasticsearch.ssl.certificate",
+	"xpack.management.elasticsearch.ssl.key",
+	"xpack.management.elasticsearch.ssl.cipher_suites",
+	"xpack.geoip.download.endpoint",
+	"xpack.geoip.downloader.enabled",
+	"cloud.id",
+	"cloud.auth",
 }
 
 // Given a setting name, return a downcased version with delimiters removed.
@@ -46,118 +144,9 @@ func squashSetting(setting string) string {
 // Given a setting name like "pipeline.workers" or "PIPELINE_UNSAFE_SHUTDOWN",
 // return the canonical setting name. eg. 'pipeline.unsafe_shutdown'
 func normalizeSetting(setting string) (string, error) {
-	valid_settings := []string{
-		"api.enabled",
-		"api.http.host",
-		"api.http.port",
-		"api.environment",
-		"node.name",
-		"path.data",
-		"pipeline.id",
-		"pipeline.workers",
-		"pipeline.output.workers",
-		"pipeline.batch.size",
-		"pipeline.batch.delay",
-		"pipeline.unsafe_shutdown",
-		"pipeline.ecs_compatibility",
-		"pipeline.ordered",
-		"pipeline.plugin_classloaders",
-		"pipeline.separate_logs",
-		"path.config",
-		"config.string",
-		"config.test_and_exit",
-		"config.reload.automatic",
-		"config.reload.interval",
-		"config.debug",
-		"config.support_escapes",
-		"config.field_reference.escape_style",
-		"event_api.tags.illegal",
-		"queue.type",
-		"path.queue",
-		"queue.page_capacity",
-		"queue.max_events",
-		"queue.max_bytes",
-		"queue.checkpoint.acks",
-		"queue.checkpoint.writes",
-		"queue.checkpoint.interval",
-		"queue.drain",
-		"dead_letter_queue.enable",
-		"dead_letter_queue.max_bytes",
-		"dead_letter_queue.flush_interval",
-		"dead_letter_queue.storage_policy",
-		"dead_letter_queue.retain.age",
-		"path.dead_letter_queue",
-		"http.enabled",     // DEPRECATED: prefer `api.enabled`
-		"http.environment", // DEPRECATED: prefer `api.environment`
-		"http.host",        // DEPRECATED: prefer `api.http.host`
-		"http.port",        // DEPRECATED: prefer `api.http.port`
-		"log.level",
-		"log.format",
-		"modules",
-		"metric.collect",
-		"path.logs",
-		"path.plugins",
-		"api.auth.type",
-		"api.auth.basic.username",
-		"api.auth.basic.password",
-		"api.auth.basic.password_policy.mode",
-		"api.auth.basic.password_policy.length.minimum",
-		"api.auth.basic.password_policy.include.upper",
-		"api.auth.basic.password_policy.include.lower",
-		"api.auth.basic.password_policy.include.digit",
-		"api.auth.basic.password_policy.include.symbol",
-		"allow_superuser",
-		"monitoring.cluster_uuid",
-		"xpack.monitoring.enabled",
-		"xpack.monitoring.collection.interval",
-		"xpack.monitoring.elasticsearch.hosts",
-		"xpack.monitoring.elasticsearch.username",
-		"xpack.monitoring.elasticsearch.password",
-		"xpack.monitoring.elasticsearch.proxy",
-		"xpack.monitoring.elasticsearch.api_key",
-		"xpack.monitoring.elasticsearch.cloud_auth",
-		"xpack.monitoring.elasticsearch.cloud_id",
-		"xpack.monitoring.elasticsearch.sniffing",
-		"xpack.monitoring.elasticsearch.ssl.certificate_authority",
-		"xpack.monitoring.elasticsearch.ssl.ca_trusted_fingerprint",
-		"xpack.monitoring.elasticsearch.ssl.verification_mode",
-		"xpack.monitoring.elasticsearch.ssl.truststore.path",
-		"xpack.monitoring.elasticsearch.ssl.truststore.password",
-		"xpack.monitoring.elasticsearch.ssl.keystore.path",
-		"xpack.monitoring.elasticsearch.ssl.keystore.password",
-		"xpack.monitoring.elasticsearch.ssl.certificate",
-		"xpack.monitoring.elasticsearch.ssl.key",
-		"xpack.monitoring.elasticsearch.ssl.cipher_suites",
-		"xpack.management.enabled",
-		"xpack.management.logstash.poll_interval",
-		"xpack.management.pipeline.id",
-		"xpack.management.elasticsearch.hosts",
-		"xpack.management.elasticsearch.username",
-		"xpack.management.elasticsearch.password",
-		"xpack.management.elasticsearch.proxy",
-		"xpack.management.elasticsearch.api_key",
-		"xpack.management.elasticsearch.cloud_auth",
-		"xpack.management.elasticsearch.cloud_id",
-		"xpack.management.elasticsearch.sniffing",
-		"xpack.management.elasticsearch.ssl.certificate_authority",
-		"xpack.management.elasticsearch.ssl.ca_trusted_fingerprint",
-		"xpack.management.elasticsearch.ssl.verification_mode",
-		"xpack.management.elasticsearch.ssl.truststore.path",
-		"xpack.management.elasticsearch.ssl.truststore.password",
-		"xpack.management.elasticsearch.ssl.keystore.path",
-		"xpack.management.elasticsearch.ssl.keystore.password",
-		"xpack.management.elasticsearch.ssl.certificate",
-		"xpack.management.elasticsearch.ssl.key",
-		"xpack.management.elasticsearch.ssl.cipher_suites",
-		"xpack.geoip.download.endpoint",
-		"xpack.geoip.downloader.enabled",
-		"cloud.id",
-		"cloud.auth",
-	}
-
-	for _, valid_setting := range valid_settings {
-		if squashSetting(setting) == squashSetting(valid_setting) {
-			return valid_setting, nil
+	for _, validSetting := range validSettings {
+		if squashSetting(setting) == squashSetting(validSetting) {
+			return validSetting, nil
 		}
 	}
 	return "", errors.New("Invalid setting: " + setting)
@@ -186,12 +175,12 @@ func main() {
 	for _, line := range os.Environ() {
 		kv := strings.SplitN(line, "=", 2)
 		key := kv[0]
-		value := kv[1]
 		setting, err := normalizeSetting(key)
 		if err == nil {
 			foundNewSettings = true
 			log.Printf("Setting '%s' from environment.", setting)
-			settings[setting] = FromYamlIfPossible(value)
+			// we need to keep ${KEY} in the logstash.yml to let Logstash decide using ${KEY}'s value from either keystore or environment
+			settings[setting] = fmt.Sprintf("${%s}", key)
 		}
 	}
 

--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 )
 
-var validSettings = [...]string{
+var validSettings = []string{
 	"api.enabled",
 	"api.http.host",
 	"api.http.port",


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?
This PR fixes the historical bug: when running Logstash in a docker container with ENV variables, `env2yaml` tool saves ENV `${KEY}=${VALUE}` by resolving its _actual value_. This will be an issue when keystore has a same ${KEY} where the expected behavior is to be keystore precedence.

## Why is it important/What is the impact to the user?
If users are using same ${KEY} in both keystore and docker ENV, they may see the behavior where keystore  ${KEY}=VALUE will be used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally
- pull this PR
- run `rake artifact:docker` -> creates an docker image (see the logs below)
- run the container with `docker run --rm --name={preferredName} -e API_ENABLED=false -e  {dockerImageHashBuiltByRake}`
- add `API_ENABLED` same key to the keystore with value of `true`, `bin/logstash-keystore add API_ENABLED`
- rerun the docker container
- check the Logstash logs that API server will be executed because Logstash uses keystore `API_ENABLED=true`
- got to container and check the `config/logstash.yml` file. Before the fix, `logstash.yml` would contain `api.enabled: false` lines. After the fix it is, `api.enabled: ${API_ENABLED}` 


## Related issues

- Closes #15766

## Use cases


## Screenshots


## Logs

```
Using system java: /usr/bin/java
....
[docker] Building docker image
../vendor/jruby/bin/jruby -S erb -T "-" created_date="2024-03-25T12:32:27-07:00" elastic_version="8.14.0-SNAPSHOT" arch="arm64" version_tag="8.14.0-SNAPSHOT" image_flavor="oss" local_artifacts="true" templates/Dockerfile.erb > "/Users/mashhur/Dev/elastic/logstash/build/Dockerfile-oss" ;   ../vendor/jruby/bin/jruby -S erb -T "-" created_date="2024-03-25T12:32:27-07:00" elastic_version="8.14.0-SNAPSHOT" arch="arm64" version_tag="8.14.0-SNAPSHOT" image_flavor="full" local_artifacts="true" templates/Dockerfile.erb > "/Users/mashhur/Dev/elastic/logstash/build/Dockerfile-full" ;   ../vendor/jruby/bin/jruby -S erb -T "-" created_date="2024-03-25T12:32:27-07:00" elastic_version="8.14.0-SNAPSHOT" arch="arm64" version_tag="8.14.0-SNAPSHOT" image_flavor="ubi8" local_artifacts="true" templates/Dockerfile.erb > "/Users/mashhur/Dev/elastic/logstash/build/Dockerfile-ubi8" ; 
docker run --rm \
	  -v "/Users/mashhur/Dev/elastic/logstash/docker/data/logstash/env2yaml:/usr/src/env2yaml" \
		-e GOARCH=arm64 -e GOOS=linux \
		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-arm64
Unable to find image 'golang:1' locally
1: Pulling from library/golang
...
Digest: sha256:0b55ab82ac2a54a6f8f85ec8b943b9e470c39e32c109b766bbc1b801f3fa8d3b
Status: Downloaded newer image for golang:1
go: downloading gopkg.in/yaml.v2 v2.4.0
docker run --rm \
	  -v "/Users/mashhur/Dev/elastic/logstash/docker/data/logstash/env2yaml:/usr/src/env2yaml" \
		-e GOARCH=amd64 -e GOOS=linux \
		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-amd64
go: downloading gopkg.in/yaml.v2 v2.4.0
docker run --rm -d --name=logstash-docker-artifact-server \
	           -p 8000:8000 --expose=8000 -v /Users/mashhur/Dev/elastic/logstash/build:/mnt \
	           python:3 bash -c 'cd /mnt && python3 -m http.server'
Unable to find image 'python:3' locally
3: Pulling from library/python
...
Digest: sha256:336461f63f4eb1100e178d5acbfea3d1a5b2a53dea88aa0f9b8482d4d02e981c
Status: Downloaded newer image for python:3
c0788dc1c4055d4822d64dfb189f8a82c5d81aefed259b9ddc4013e94195d183
timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
docker build --network=host -t docker.elastic.co/logstash/logstash-full:8.14.0-SNAPSHOT -f /Users/mashhur/Dev/elastic/logstash/build/Dockerfile-full data/logstash || \
	  (docker kill logstash-docker-artifact-server; false); \
	docker tag docker.elastic.co/logstash/logstash-full:8.14.0-SNAPSHOT docker.elastic.co/logstash/logstash:8.14.0-SNAPSHOT;
[+] Building 2.5s (19/19) FINISHED                                                                                                                                                       
 => [internal] load build definition from Dockerfile-full                                                                                                                           0.1s
 => => transferring dockerfile: 3.26kB                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                   0.1s
 => => transferring context: 2B                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                     1.8s
 => [ 1/14] FROM docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d                                                             0.0s
 => [internal] load build context                                                                                                                                                   0.0s
 => => transferring context: 3.16MB                                                                                                                                                 0.0s
 => CACHED [ 2/14] RUN for iter in {1..10}; do export DEBIAN_FRONTEND=noninteractive && apt-get update -y && apt-get upgrade -y && apt-get install -y procps findutils tar gzip &&  0.0s
 => CACHED [ 3/14] RUN groupadd --gid 1000 logstash &&     adduser --uid 1000 --gid 1000     --home /usr/share/logstash --no-create-home     logstash                               0.0s
 => CACHED [ 4/14] RUN  curl -Lo - http://localhost:8000/logstash-8.14.0-SNAPSHOT-linux-$(arch).tar.gz |     tar zxf - -C /usr/share &&     mv /usr/share/logstash-8.14.0-SNAPSHOT  0.0s
...
 => [14/14] RUN chmod 0755 /usr/local/bin/docker-entrypoint                                                                                                                         0.1s
 => exporting to image                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                             0.0s
 => => writing image sha256:e89b6d0d04e262f5fa3b51378ca23982756a6b585af411b917dfd2010122806a                                                                                        0.0s
 => => naming to docker.elastic.co/logstash/logstash-full:8.14.0-SNAPSHOT                                                                                                           0.0s
docker kill logstash-docker-artifact-server
logstash-docker-artifact-server
```