### PR TITLE
Create critical_vulnerability_scan.yml

### DIFF
--- a/.github/workflows/critical_vulnerability_scan.yml
+++ b/.github/workflows/critical_vulnerability_scan.yml
@@ -13,12 +13,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: ./gradlew clean assembleTarDistribution
+          ref: ${{ github.head_ref }}
+      - name: build tar distribution
+        run: ./gradlew clean assembleTarDistribution
       - run: mkdir scan
-      - run: cd scan && tar -zxf ../build/logstash-*.tar.gz
-      - name: Scan image
+      - run: tar -zxf ../build/logstash-*.tar.gz
+        working-directory: ./scan
+      - name: scan image
         uses: anchore/scan-action@v3
         with:
-          path: "scan/*"
+          path: "./scan"
           fail-build: true
           severity-cutoff: critical

--- a/.github/workflows/critical_vulnerability_scan.yml
+++ b/.github/workflows/critical_vulnerability_scan.yml
@@ -1,0 +1,24 @@
+name: Scan for vulnerabilities
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  scan_image:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: checkout repo content
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: ./gradlew clean assembleTarDistribution
+      - run: mkdir scan
+      - run: cd scan && tar -zxf ../build/logstash-*.tar.gz
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        with:
+          path: "scan/*"
+          fail-build: true
+          severity-cutoff: critical


### PR DESCRIPTION
This GitHub action will fail a PR if a scanner finds any critical level vulnerability in the dependencies contained in the tar distribution.

To see it in action, check a failed test: https://github.com/jsvd/logstash/actions/runs/8434650833
The PR to fix it: [https://github.com/jsvd/logstash/pull/8](https://github.com/jsvd/logstash/pull/8/files#diff-924a7ad75bf532d9aa5a755b8e2d1bbad67edf9a54bcb3b87a4e2fe1970094edR102)
And the successful check: https://github.com/jsvd/logstash/actions/runs/8434997944/job/23099443708?pr=8