### PR TITLE
Fix github checkout for critical_vulnerability_scan action

### DIFF
--- a/.github/workflows/critical_vulnerability_scan.yml
+++ b/.github/workflows/critical_vulnerability_scan.yml
@@ -1,7 +1,7 @@
 name: Scan for vulnerabilities
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
 
@@ -10,10 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: checkout repo content
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
+        uses: actions/checkout@v4
       - name: build tar distribution
         run: ./gradlew clean assembleTarDistribution
       - run: mkdir scan


### PR DESCRIPTION
Change trigger from pull_request_target to pull_request, as the former uses the base branch instead of the PR source code. This allows simplification of the checkout action (also took the opportunity to bump from v2 to v4).