### PR TITLE
Move Docker build context artifacts to architecture specific locations

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -57,7 +57,7 @@ build-from-local-ubi8-artifacts: dockerfile env2yaml
 COPY_FILES := $(ARTIFACTS_DIR)/docker/arm64/config/pipelines.yml $(ARTIFACTS_DIR)/docker/arm64/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/arm64/config/logstash-full.yml
 COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/config/log4j2.file.properties $(ARTIFACTS_DIR)/docker/arm64/config/log4j2.properties
 COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/pipeline/default.conf $(ARTIFACTS_DIR)/docker/arm64/bin/docker-entrypoint
-COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/env2yaml
+COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/env2yaml/env2yaml
 COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/config/pipelines.yml $(ARTIFACTS_DIR)/docker/amd64/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/amd64/config/logstash-full.yml
 COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/config/log4j2.file.properties $(ARTIFACTS_DIR)/docker/amd64/config/log4j2.properties
 COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/pipeline/default.conf $(ARTIFACTS_DIR)/docker/amd64/bin/docker-entrypoint
@@ -141,7 +141,7 @@ public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-full" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-full Dockerfile && \
-	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
+	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -155,7 +155,7 @@ public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-oss" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
-	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
+	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
 
 public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -169,7 +169,7 @@ public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-ubi8" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 Dockerfile && \
-	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
+	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
 
 public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Dockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -140,8 +140,9 @@ public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		local_artifacts="false" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-full" && \
 	cd $(ARTIFACTS_DIR)/docker && \
-	cp $(ARTIFACTS_DIR)/Dockerfile-full Dockerfile && \
-	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
+	cp $(ARTIFACTS_DIR)/Dockerfile-full arm64/Dockerfile && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-full amd64/Dockerfile && \
+	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz arm64 amd64
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -154,8 +155,9 @@ public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		local_artifacts="false" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-oss" && \
 	cd $(ARTIFACTS_DIR)/docker && \
-	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
-	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
+	cp $(ARTIFACTS_DIR)/Dockerfile-oss arm64/Dockerfile && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-oss amd64/Dockerfile && \
+	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz arm64 amd64
 
 public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -168,8 +170,9 @@ public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		local_artifacts="false" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-ubi8" && \
 	cd $(ARTIFACTS_DIR)/docker && \
-	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 Dockerfile && \
-	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile arm64 amd64
+	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 arm64/Dockerfile && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 amd64/Dockerfile && \
+	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz arm64 amd64
 
 public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Dockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -54,31 +54,49 @@ build-from-local-ubi8-artifacts: dockerfile env2yaml
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
-COPY_FILES := $(ARTIFACTS_DIR)/docker/config/pipelines.yml $(ARTIFACTS_DIR)/docker/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/config/logstash-full.yml
-COPY_FILES += $(ARTIFACTS_DIR)/docker/config/log4j2.file.properties $(ARTIFACTS_DIR)/docker/config/log4j2.properties
-COPY_FILES += $(ARTIFACTS_DIR)/docker/pipeline/default.conf $(ARTIFACTS_DIR)/docker/bin/docker-entrypoint
-COPY_FILES += $(ARTIFACTS_DIR)/docker/env2yaml/env2yaml-arm64 
-COPY_FILES += $(ARTIFACTS_DIR)/docker/env2yaml/env2yaml-amd64
+COPY_FILES := $(ARTIFACTS_DIR)/docker/arm64/config/pipelines.yml $(ARTIFACTS_DIR)/docker/arm64/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/arm64/config/logstash-full.yml
+COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/config/log4j2.file.properties $(ARTIFACTS_DIR)/docker/arm64/config/log4j2.properties
+COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/pipeline/default.conf $(ARTIFACTS_DIR)/docker/arm64/bin/docker-entrypoint
+COPY_FILES += $(ARTIFACTS_DIR)/docker/arm64/env2yaml
+COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/config/pipelines.yml $(ARTIFACTS_DIR)/docker/amd64/config/logstash-oss.yml $(ARTIFACTS_DIR)/docker/amd64/config/logstash-full.yml
+COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/config/log4j2.file.properties $(ARTIFACTS_DIR)/docker/amd64/config/log4j2.properties
+COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/pipeline/default.conf $(ARTIFACTS_DIR)/docker/amd64/bin/docker-entrypoint
+COPY_FILES += $(ARTIFACTS_DIR)/docker/amd64/env2yaml/env2yaml
 
-$(ARTIFACTS_DIR)/docker/config/pipelines.yml: data/logstash/config/pipelines.yml
-$(ARTIFACTS_DIR)/docker/config/logstash-oss.yml: data/logstash/config/logstash-oss.yml
-$(ARTIFACTS_DIR)/docker/config/logstash-full.yml: data/logstash/config/logstash-full.yml
-$(ARTIFACTS_DIR)/docker/config/log4j2.file.properties: data/logstash/config/log4j2.file.properties
-$(ARTIFACTS_DIR)/docker/config/log4j2.properties: data/logstash/config/log4j2.properties
-$(ARTIFACTS_DIR)/docker/pipeline/default.conf: data/logstash/pipeline/default.conf
-$(ARTIFACTS_DIR)/docker/bin/docker-entrypoint: data/logstash/bin/docker-entrypoint
-$(ARTIFACTS_DIR)/docker/env2yaml/env2yaml-arm64: data/logstash/env2yaml/env2yaml-arm64
-$(ARTIFACTS_DIR)/docker/env2yaml/env2yaml-amd64: data/logstash/env2yaml/env2yaml-amd64
+$(ARTIFACTS_DIR)/docker/arm64/config/pipelines.yml: data/logstash/config/pipelines.yml
+$(ARTIFACTS_DIR)/docker/arm64/config/logstash-oss.yml: data/logstash/config/logstash-oss.yml
+$(ARTIFACTS_DIR)/docker/arm64/config/logstash-full.yml: data/logstash/config/logstash-full.yml
+$(ARTIFACTS_DIR)/docker/arm64/config/log4j2.file.properties: data/logstash/config/log4j2.file.properties
+$(ARTIFACTS_DIR)/docker/arm64/config/log4j2.properties: data/logstash/config/log4j2.properties
+$(ARTIFACTS_DIR)/docker/arm64/pipeline/default.conf: data/logstash/pipeline/default.conf
+$(ARTIFACTS_DIR)/docker/arm64/bin/docker-entrypoint: data/logstash/bin/docker-entrypoint
+$(ARTIFACTS_DIR)/docker/arm64/env2yaml/env2yaml: data/logstash/env2yaml/env2yaml-arm64
+
+$(ARTIFACTS_DIR)/docker/amd64/config/pipelines.yml: data/logstash/config/pipelines.yml
+$(ARTIFACTS_DIR)/docker/amd64/config/logstash-oss.yml: data/logstash/config/logstash-oss.yml
+$(ARTIFACTS_DIR)/docker/amd64/config/logstash-full.yml: data/logstash/config/logstash-full.yml
+$(ARTIFACTS_DIR)/docker/amd64/config/log4j2.file.properties: data/logstash/config/log4j2.file.properties
+$(ARTIFACTS_DIR)/docker/amd64/config/log4j2.properties: data/logstash/config/log4j2.properties
+$(ARTIFACTS_DIR)/docker/amd64/pipeline/default.conf: data/logstash/pipeline/default.conf
+$(ARTIFACTS_DIR)/docker/amd64/bin/docker-entrypoint: data/logstash/bin/docker-entrypoint
+$(ARTIFACTS_DIR)/docker/amd64/env2yaml/env2yaml: data/logstash/env2yaml/env2yaml-amd64
+
 
 $(ARTIFACTS_DIR)/docker/%:
 	cp -f $< $@
 
 docker_paths:
 	mkdir -p $(ARTIFACTS_DIR)/docker/
-	mkdir -p $(ARTIFACTS_DIR)/docker/bin
-	mkdir -p $(ARTIFACTS_DIR)/docker/config
-	mkdir -p $(ARTIFACTS_DIR)/docker/env2yaml
-	mkdir -p $(ARTIFACTS_DIR)/docker/pipeline
+	mkdir -p $(ARTIFACTS_DIR)/docker/amd64
+	mkdir -p $(ARTIFACTS_DIR)/docker/arm64
+	mkdir -p $(ARTIFACTS_DIR)/docker/amd64/bin
+	mkdir -p $(ARTIFACTS_DIR)/docker/amd64/config
+	mkdir -p $(ARTIFACTS_DIR)/docker/amd64/env2yaml
+	mkdir -p $(ARTIFACTS_DIR)/docker/amd64/pipeline
+	mkdir -p $(ARTIFACTS_DIR)/docker/arm64/bin
+	mkdir -p $(ARTIFACTS_DIR)/docker/arm64/config
+	mkdir -p $(ARTIFACTS_DIR)/docker/arm64/env2yaml
+	mkdir -p $(ARTIFACTS_DIR)/docker/arm64/pipeline
 
 COPY_IRONBANK_FILES := $(ARTIFACTS_DIR)/ironbank/scripts/config/pipelines.yml $(ARTIFACTS_DIR)/ironbank/scripts/config/logstash.yml
 COPY_IRONBANK_FILES += $(ARTIFACTS_DIR)/ironbank/scripts/config/log4j2.file.properties $(ARTIFACTS_DIR)/ironbank/scripts/config/log4j2.properties

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -151,9 +151,8 @@ COPY pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Ensure Logstash gets the correct locale by default.
 ENV LANG=<%= locale %> LC_ALL=<%= locale %>
-# Copy over the appropriate env2yaml artifact
-ARG TARGETARCH
-COPY env2yaml/env2yaml-${TARGETARCH} /usr/local/bin/env2yaml
+
+COPY env2yaml/env2yaml /usr/local/bin/env2yaml
 # Place the startup wrapper script.
 COPY bin/docker-entrypoint /usr/local/bin/
 


### PR DESCRIPTION
This commit moves the Docker build context artifacts under architecture specific folders, and removes the `TARGETARCH` specifier introduced in #15980 

This follows the guidelines for multi-architecture public Dockerfiles in https://github.com/docker-library/official-images?tab=readme-ov-file#multiple-architectures.