### PR TITLE
feat(syntax): allow comments in hashes and before EOF

### DIFF
--- a/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
+++ b/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
@@ -80,7 +80,91 @@ module LogStashCompilerLSCLGrammar
     r0
   end
 
+  module NewlineOrEoi0
+  end
+
+  def _nt_newline_or_eoi
+    start_index = index
+    if node_cache[:newline_or_eoi].has_key?(index)
+      cached = node_cache[:newline_or_eoi][index]
+      if cached
+        node_cache[:newline_or_eoi][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+        @index = cached.interval.end
+      end
+      return cached
+    end
+
+    i0 = index
+    i1, s1 = index, []
+    if (match_len = has_terminal?("\r", false, index))
+      r3 = true
+      @index += match_len
+    else
+      terminal_parse_failure('"\\r"')
+      r3 = nil
+    end
+    if r3
+      r2 = r3
+    else
+      r2 = instantiate_node(SyntaxNode,input, index...index)
+    end
+    s1 << r2
+    if r2
+      if (match_len = has_terminal?("\n", false, index))
+        r4 = true
+        @index += match_len
+      else
+        terminal_parse_failure('"\\n"')
+        r4 = nil
+      end
+      s1 << r4
+    end
+    if s1.last
+      r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
+      r1.extend(NewlineOrEoi0)
+    else
+      @index = i1
+      r1 = nil
+    end
+    if r1
+      r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
+      r0 = r1
+    else
+      i5 = index
+      if index < input_length
+        r6 = true
+        @index += 1
+      else
+        terminal_parse_failure("any character")
+        r6 = nil
+      end
+      if r6
+        @index = i5
+        r5 = nil
+        terminal_parse_failure("any character", true)
+      else
+        @terminal_failures.pop
+        @index = i5
+        r5 = instantiate_node(SyntaxNode,input, index...index)
+      end
+      if r5
+        r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
+        r0 = r5
+      else
+        @index = i0
+        r0 = nil
+      end
+    end
+
+    node_cache[:newline_or_eoi][start_index] = r0
+
+    r0
+  end
+
   module Comment0
+    def newline_or_eoi
+      elements[3]
+    end
   end
 
   def _nt_comment
@@ -132,29 +216,8 @@ module LogStashCompilerLSCLGrammar
           r5 = instantiate_node(SyntaxNode,input, i5...index, s5)
           s1 << r5
           if r5
-            if (match_len = has_terminal?("\r", false, index))
-              r8 = true
-              @index += match_len
-            else
-              terminal_parse_failure('"\\r"')
-              r8 = nil
-            end
-            if r8
-              r7 = r8
-            else
-              r7 = instantiate_node(SyntaxNode,input, index...index)
-            end
+            r7 = _nt_newline_or_eoi
             s1 << r7
-            if r7
-              if (match_len = has_terminal?("\n", false, index))
-                r9 = true
-                @index += match_len
-              else
-                terminal_parse_failure('"\\n"')
-                r9 = nil
-              end
-              s1 << r9
-            end
           end
         end
       end
@@ -1674,7 +1737,7 @@ module LogStashCompilerLSCLGrammar
   end
 
   module Hashentries0
-    def whitespace
+    def cs
       elements[0]
     end
 
@@ -1708,7 +1771,7 @@ module LogStashCompilerLSCLGrammar
       s2, i2 = [], index
       loop do
         i3, s3 = index, []
-        r4 = _nt_whitespace
+        r4 = _nt_cs
         s3 << r4
         if r4
           r5 = _nt_hashentry

--- a/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.treetop
+++ b/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.treetop
@@ -6,8 +6,13 @@ grammar LogStashCompilerLSCLGrammar
     (cs plugin_section)* cs <LogStash::Compiler::LSCL::AST::Config>
   end
 
+  rule newline_or_eoi
+    # `!.` is a negative lookahead for 'anything', i.e. it matches at the end of input.
+    ("\r"? "\n") / !.
+  end
+
   rule comment
-    (whitespace? "#" [^\r\n]* "\r"? "\n")+ <LogStash::Compiler::LSCL::AST::Comment>
+    (whitespace? "#" [^\r\n]* newline_or_eoi)+ <LogStash::Compiler::LSCL::AST::Comment>
   end
 
   rule cs
@@ -114,7 +119,7 @@ grammar LogStashCompilerLSCLGrammar
   end
 
   rule hashentries
-    hashentry (whitespace hashentry)*
+    hashentry (cs hashentry)*
     <LogStash::Compiler::LSCL::AST::HashEntries>
   end
 

--- a/logstash-core/lib/logstash/config/grammar.rb
+++ b/logstash-core/lib/logstash/config/grammar.rb
@@ -104,7 +104,91 @@ module LogStashConfig
     r0
   end
 
+  module NewlineOrEoi0
+  end
+
+  def _nt_newline_or_eoi
+    start_index = index
+    if node_cache[:newline_or_eoi].has_key?(index)
+      cached = node_cache[:newline_or_eoi][index]
+      if cached
+        node_cache[:newline_or_eoi][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+        @index = cached.interval.end
+      end
+      return cached
+    end
+
+    i0 = index
+    i1, s1 = index, []
+    if (match_len = has_terminal?("\r", false, index))
+      r3 = true
+      @index += match_len
+    else
+      terminal_parse_failure('"\\r"')
+      r3 = nil
+    end
+    if r3
+      r2 = r3
+    else
+      r2 = instantiate_node(SyntaxNode,input, index...index)
+    end
+    s1 << r2
+    if r2
+      if (match_len = has_terminal?("\n", false, index))
+        r4 = true
+        @index += match_len
+      else
+        terminal_parse_failure('"\\n"')
+        r4 = nil
+      end
+      s1 << r4
+    end
+    if s1.last
+      r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
+      r1.extend(NewlineOrEoi0)
+    else
+      @index = i1
+      r1 = nil
+    end
+    if r1
+      r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
+      r0 = r1
+    else
+      i5 = index
+      if index < input_length
+        r6 = true
+        @index += 1
+      else
+        terminal_parse_failure("any character")
+        r6 = nil
+      end
+      if r6
+        @index = i5
+        r5 = nil
+        terminal_parse_failure("any character", true)
+      else
+        @terminal_failures.pop
+        @index = i5
+        r5 = instantiate_node(SyntaxNode,input, index...index)
+      end
+      if r5
+        r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
+        r0 = r5
+      else
+        @index = i0
+        r0 = nil
+      end
+    end
+
+    node_cache[:newline_or_eoi][start_index] = r0
+
+    r0
+  end
+
   module Comment0
+    def newline_or_eoi
+      elements[3]
+    end
   end
 
   def _nt_comment
@@ -156,29 +240,8 @@ module LogStashConfig
           r5 = instantiate_node(SyntaxNode,input, i5...index, s5)
           s1 << r5
           if r5
-            if (match_len = has_terminal?("\r", false, index))
-              r8 = true
-              @index += match_len
-            else
-              terminal_parse_failure('"\\r"')
-              r8 = nil
-            end
-            if r8
-              r7 = r8
-            else
-              r7 = instantiate_node(SyntaxNode,input, index...index)
-            end
+            r7 = _nt_newline_or_eoi
             s1 << r7
-            if r7
-              if (match_len = has_terminal?("\n", false, index))
-                r9 = true
-                @index += match_len
-              else
-                terminal_parse_failure('"\\n"')
-                r9 = nil
-              end
-              s1 << r9
-            end
           end
         end
       end
@@ -1698,7 +1761,7 @@ module LogStashConfig
   end
 
   module Hashentries0
-    def whitespace
+    def cs
       elements[0]
     end
 
@@ -1732,7 +1795,7 @@ module LogStashConfig
       s2, i2 = [], index
       loop do
         i3, s3 = index, []
-        r4 = _nt_whitespace
+        r4 = _nt_cs
         s3 << r4
         if r4
           r5 = _nt_hashentry

--- a/logstash-core/lib/logstash/config/grammar.treetop
+++ b/logstash-core/lib/logstash/config/grammar.treetop
@@ -6,8 +6,13 @@ grammar LogStashConfig
     cs plugin_section cs (cs plugin_section)* cs <LogStash::Config::AST::Config>
   end
 
+  rule newline_or_eoi
+    # `!.` is a negative lookahead for 'anything', i.e. it matches at the end of input.
+    ("\r"? "\n") / !.
+  end
+
   rule comment
-    (whitespace? "#" [^\r\n]* "\r"? "\n")+ <LogStash::Config::AST::Comment>
+    (whitespace? "#" [^\r\n]* newline_or_eoi)+ <LogStash::Config::AST::Comment>
   end
 
   rule cs
@@ -114,7 +119,7 @@ grammar LogStashConfig
   end
 
   rule hashentries
-    hashentry (whitespace hashentry)*
+    hashentry (cs hashentry)*
     <LogStash::Config::AST::HashEntries>
   end
 

--- a/logstash-core/spec/logstash/config/config_ast_spec.rb
+++ b/logstash-core/spec/logstash/config/config_ast_spec.rb
@@ -211,6 +211,51 @@ describe LogStashConfigParser do
         end
       end
     end
+
+    context "commentary in odd places" do
+      let(:config) { %q(
+        # early
+        input # bla
+        { # bla
+          plugin # bla
+          # bla
+          { # bla
+            # bla
+            arg  # bla
+            => # bla
+            bareword # bla
+            # bla
+            hasharg => {
+              #preentry
+              "firstkey" => "firstvalue"
+              # bla
+              "middle" # bla
+              # bla
+              => # bla
+              # bla
+              "midvalue"  # bla
+              # bla
+              "lastkey" => "lastvalue"
+              # bla
+            }
+          } # bla
+        # bla
+        } # bla
+        # comment ending in EOF:
+      ).strip }
+      subject { LogStashConfigParser.new }
+      def line_to_source(*args); end
+      def plugin(*args); end
+      it "hasn't got a trailing newline in the test config" do
+        # just to be clear that the last comment is supposed to end with EOF not \n
+        expect(config).not_to(end_with "\n")
+      end
+      it "should permit the comments" do
+        result = subject.parse(config)
+        expect(result).not_to(be_nil)
+        expect { eval(result.compile) }.not_to(raise_error)
+      end
+    end
   end
 
   context "when using two plugin sections of the same type" do


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Fixed the syntax rules to allow comments between hash entries and immediately before the end of a file. Comments in these places would previously give syntax errors.

## What does this PR do?

In the grammer definitions for hashes, `whitespace` was replaced with `cs` to allow either whitespace _or_ comments. 
Additionally, the grammar definition for comments was previously required to end with a newline, now it can end with a newline _or_ EOF, using the "not anything" treetop rule `!.`.

## Why is it important/What is the impact to the user?

Users get surprised when they find out that comments are not allowed in hashes or at the end of a file.
This is allowed in practically all other languages, including ruby.
This PR thus aligns Logstash syntax with user expectations.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
    - AFAICT, no automated check for this? I believe it follows the guide though.
- [x] I have commented my code, particularly in hard-to-understand areas
    - I only added syntax, generated code (treetop), and test code. Aside from the generated code, changes are trivial.
- [x] I have made corresponding changes to the documentation
    - No docs changes should be needed.
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
    - Should also not be needed.
- [x] I have added tests that prove my fix is effective or that my feature works
    - Yes though!

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To run the test that I added, execute `SPEC_OPTS="-fd -P logstash-core/spec/logstash/config/config_ast_spec.rb" ./gradlew :logstash-core:rubyTests --tests org.logstash.RSpecTests` (this command is copied from `README.md` but with the path changed).

Alternatively, create a hash in a logstash configuration manually with at least two entries, and put a comment between them. It will work on the patched logstash, and give a syntax error on the unpatched logstash.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #15651 
- Closes #15561 

## Use cases

For example,

```
filter {
  mutate {
    add_field => {
      "field1" => "value1"
      # You can now put a comment between hash entries, like here
      "field2" => "value"
    }
  }
}
# You can now also put a comment before an EOF (i.e. no trailing newline)
```

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
