### PR TITLE
Handle non-unicode payload in Logstash.

### DIFF
--- a/logstash-core/lib/logstash/json.rb
+++ b/logstash-core/lib/logstash/json.rb
@@ -56,7 +56,8 @@ module LogStash
         data.map { |item| normalize_encoding(item) }
       when Hash
         # origin key might change when normalizing, so requires transformation
-        data.transform_keys { |key| normalize_encoding(key) }
+        modifiable_hash = data.to_hash # if coming from jruby objects such as UnmodifiableMap
+        modifiable_hash.transform_keys { |key| normalize_encoding(key) }
             .transform_values { |value| normalize_encoding(value) }
       else
         data # use as it is

--- a/logstash-core/lib/logstash/json.rb
+++ b/logstash-core/lib/logstash/json.rb
@@ -36,7 +36,40 @@ module LogStash
       # test for enumerable here to work around an omission in JrJackson::Json.dump to
       # also look for Java::JavaUtil::ArrayList, see TODO submit issue
       # o.is_a?(Enumerable) ? JrJackson::Raw.generate(o) : JrJackson::Json.dump(o)
-      JrJackson::Base.generate(o, options)
+      if o.class == String # TODO: test only, make it happen for all data structures
+        duplicated_input_string = o.dup
+        if duplicated_input_string.encoding != Encoding::UTF_8
+          encoding_converter = Encoding::Converter.new(duplicated_input_string.encoding, Encoding::UTF_8)
+          conversion_error = false
+          begin
+            utf_encoded_string = encoding_converter.convert(duplicated_input_string).freeze
+          rescue Encoding::UndefinedConversionError => e
+            # trace logging
+            puts "Could not convert, #{e.inspect}"
+            conversion_error = true
+          ensure
+            # we don't catch the error raised by `JrJackson::Base.generate`
+            # and we let normalize and replace invalid unicode bytes before `JrJackson::Base.generate`
+            return JrJackson::Base.generate(utf_encoded_string, options) unless conversion_error
+          end
+        end
+
+        begin
+          # non expensive `force_encoding` operation which changes the encoding metadata, otherwise unicode normalization rejects
+          duplicated_input_string = duplicated_input_string.force_encoding(Encoding::UTF_8)
+          # force UTF-8 encoding might also have invalid bytes, we try to normalize first
+          # use replacement char with `scrub` if invalid bytes found
+          duplicated_input_string.unicode_normalize # maybe use :nfkc?
+        rescue ArgumentError => e
+          # trace log
+          puts "Could not normalize to unicode, #{e.inspect}"
+          puts "Replacing invalid non-utf bytes with replacement char."
+          duplicated_input_string.scrub!
+        end
+        JrJackson::Base.generate(duplicated_input_string, options)
+      else
+        JrJackson::Base.generate(o, options)
+      end
     rescue => e
       raise LogStash::Json::GeneratorError.new(e.message)
     end

--- a/logstash-core/lib/logstash/json.rb
+++ b/logstash-core/lib/logstash/json.rb
@@ -33,7 +33,7 @@ module LogStash
     end
 
     def jruby_dump(o, options = {})
-      encoding_normalized_data = normalize_encoding(o.dup)&.freeze
+      encoding_normalized_data = normalize_encoding(o.dup).freeze
 
       # TODO [guyboertje] remove these comments in 5.0
       # test for enumerable here to work around an omission in JrJackson::Json.dump to
@@ -56,8 +56,8 @@ module LogStash
         data.map { |item| normalize_encoding(item) }
       when Hash
         # origin key might change when normalizing, so requires transformation
-        modifiable_hash = data.to_hash # if coming from jruby objects such as UnmodifiableMap
-        modifiable_hash.transform_keys { |key| normalize_encoding(key) }
+        data.to_hash # if coming from jruby objects such as UnmodifiableMap
+            .transform_keys { |key| normalize_encoding(key) }
             .transform_values { |value| normalize_encoding(value) }
       else
         data # use as it is

--- a/logstash-core/lib/logstash/util/unicode_normalizer.rb
+++ b/logstash-core/lib/logstash/util/unicode_normalizer.rb
@@ -34,17 +34,12 @@ module LogStash
 
       if input_string.encoding != Encoding::UTF_8
         encoding_converter = Encoding::Converter.new(input_string.encoding, Encoding::UTF_8)
-        conversion_error, utf8_string = false, nil
         begin
-          utf8_string = encoding_converter.convert(input_string).freeze
+          # if we can successfully convert, then our work is done.
+          return encoding_converter.convert(input_string).freeze
         rescue => e
           # we mostly get Encoding::UndefinedConversionError but let's do not expect surprise crashes
           logger.trace? && logger.trace("Could not convert, #{e.inspect}")
-          conversion_error = true
-        ensure
-          # if we cannot convert with a standard way
-          # we let normalize and replace invalid unicode bytes
-          return utf8_string unless conversion_error
         end
       end
 

--- a/logstash-core/lib/logstash/util/unicode_normalizer.rb
+++ b/logstash-core/lib/logstash/util/unicode_normalizer.rb
@@ -1,0 +1,66 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module LogStash
+
+  # A class to normalize the invalid unicode data
+  class UnicodeNormalizer
+
+    include LogStash::Util::Loggable
+
+    # Tries to convert input string to UTF-8 with a standard way
+    # If input string is the force encoded invalid unicode:
+    #   applies unicode normalization
+    #   replaces invalid unicode bytes with replacement characters
+    # string_data - The String data to be normalized.
+    # Returns the normalized string data.
+    def self.normalize_string_encoding(string_data)
+      input_string = string_data.dup if string_data.frozen?
+      input_string = string_data unless string_data.frozen?
+
+      if input_string.encoding != Encoding::UTF_8
+        encoding_converter = Encoding::Converter.new(input_string.encoding, Encoding::UTF_8)
+        conversion_error, utf8_string = false, nil
+        begin
+          utf8_string = encoding_converter.convert(input_string).freeze
+        rescue => e
+          # we mostly get Encoding::UndefinedConversionError but let's do not expect surprise crashes
+          logger.trace? && logger.trace("Could not convert, #{e.inspect}")
+          conversion_error = true
+        ensure
+          # if we cannot convert with a standard way
+          # we let normalize and replace invalid unicode bytes
+          return utf8_string unless conversion_error
+        end
+      end
+
+      begin
+        # non expensive `force_encoding` operation which changes the encoding metadata
+        # otherwise unicode normalization rejects
+        input_string = input_string.force_encoding(Encoding::UTF_8)
+        # force UTF-8 encoding as data might also have invalid bytes
+        # we try to normalize first, use replacement char with `scrub` if invalid bytes found
+        input_string.unicode_normalize! # use default :NFC normalization since decompositions may result multiple characters
+      rescue => e
+        logger.trace? && logger.trace("Could not normalize to unicode, #{e.inspect}")
+        logger.trace? && logger.trace("Replacing invalid non-utf bytes with replacement char.")
+        input_string.scrub!
+      end
+      input_string
+    end
+  end
+end

--- a/logstash-core/lib/logstash/util/unicode_trimmer.rb
+++ b/logstash-core/lib/logstash/util/unicode_trimmer.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # encoding: utf-8
 
 module LogStash::Util::UnicodeTrimmer

--- a/logstash-core/spec/logstash/json_spec.rb
+++ b/logstash-core/spec/logstash/json_spec.rb
@@ -174,5 +174,22 @@ describe "LogStash::Json" do
       end
 
     end
+
+    context 'with hash data structure' do
+      let(:input) {{"Th\xEFs key and".b.force_encoding(Encoding::WINDOWS_1252).freeze =>
+                      {"Thïs key also".b.force_encoding(Encoding::UTF_8).freeze => "not-quite-v\xCEalid uni\xF0\x9D\x84code string 💖ok".b.force_encoding(Encoding::UTF_8).freeze}}}
+      it 'normalizes and replaces each invalid key-value with the xFFFD replacement character' do
+        expect(result).to be_utf8.with_bytes("{\"Th\u{EF}s key and\":{\"Thïs key also\":\"not-quite-v\u{FFFD}alid uni\u{FFFD}code string 💖ok\"}}".bytes)
+      end
+    end
+
+    context 'with array data structure' do
+      let(:input) {["Th\xEFs entry and".b.force_encoding(Encoding::WINDOWS_1252).freeze,
+                    "Thïs entry also".b.force_encoding(Encoding::UTF_8).freeze,
+                    "not-quite-v\xCEalid uni\xF0\x9D\x84code strings 💖ok".b.force_encoding(Encoding::UTF_8).freeze]}
+      it 'normalizes and replaces each invalid array values with the xFFFD replacement character' do
+        expect(result).to be_utf8.with_bytes("[\"Th\u{EF}s entry and\",\"Thïs entry also\",\"not-quite-v\u{FFFD}alid uni\u{FFFD}code strings 💖ok\"]".bytes)
+      end
+    end
   end
 end

--- a/logstash-core/spec/logstash/json_spec.rb
+++ b/logstash-core/spec/logstash/json_spec.rb
@@ -118,4 +118,61 @@ describe "LogStash::Json" do
     o = LogStash::Json.load("  ")
     expect(o).to be_nil
   end
+
+  context "Unicode edge-cases" do
+    matcher :be_utf8 do
+      match(:notify_expectation_failures => true) do |actual|
+        aggregate_failures do
+          expect(actual).to have_attributes(:encoding => Encoding::UTF_8, :valid_encoding? => true)
+          expect(actual.bytes).to eq(@expected_bytes) unless @expected_bytes.nil?
+        end
+      end
+      chain :with_bytes do |expected_bytes|
+        @expected_bytes = expected_bytes
+      end
+    end
+
+    let(:result) { LogStash::Json::dump(input) }
+
+    context "with valid non-unicode encoding" do
+      let(:input) { "Th\xEFs \xCCs W\xCFnd\xD8w\x8A".b.force_encoding(Encoding::WINDOWS_1252).freeze }
+      it 'transcodes to equivalent UTF-8 code-points' do
+        aggregate_failures do
+          expect(result).to be_utf8.with_bytes("\u{22}Th\u{EF}s \u{CC}s W\u{CF}nd\u{D8}w\u{160}\u{22}".bytes)
+        end
+      end
+    end
+
+    context "with unicode that has invalid sequences" do
+      let(:input) { "Thïs is a not-quite-v\xCEalid uni\xF0\x9D\x84code string 💖ok".b.force_encoding(Encoding::UTF_8).freeze }
+      it 'replaces each invalid sequence with the xFFFD replacement character' do
+        expect(result).to be_utf8.with_bytes("\x22Thïs is a not-quite-v\u{FFFD}alid uni\u{FFFD}code string 💖ok\x22".bytes)
+      end
+    end
+
+    context 'with valid unicode' do
+      let(:input) { "valid \u{A7}\u{a9c5}\u{18a5}\u{1f984} unicode".encode('UTF-8').freeze }
+      it 'keeps the unicode in-tact' do
+        expect(result).to be_utf8.with_bytes(('"' + input + '"').bytes)
+      end
+    end
+
+    context 'with binary-flagged input' do
+
+      context 'that contains only lower-ascii' do
+        let(:input) { "hello, world. This is a test including newline(\x0A) literal-backslash(\x5C) double-quote(\x22)".b.force_encoding(Encoding::BINARY).freeze}
+        it 'does not munge the bytes' do
+          expect(result).to be_utf8.with_bytes("\x22hello, world. This is a test including newline(\x5Cn) literal-backslash(\x5C\x5C) double-quote(\x5C\x22)\x22".bytes)
+        end
+      end
+
+      context 'that contains bytes outside lower-ascii' do
+        let(:input) { "Thïs is a not-quite-v\xCEalid uni\xF0\x9D\x84code string 💖ok".b.force_encoding(Encoding::BINARY).freeze }
+        it 'replaces each invalid sequence with the xFFFD replacement character' do
+          expect(result).to be_utf8.with_bytes("\x22Thïs is a not-quite-v\u{FFFD}alid uni\u{FFFD}code string 💖ok\x22".bytes)
+        end
+      end
+
+    end
+  end
 end

--- a/versions.yml
+++ b/versions.yml
@@ -24,6 +24,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.18
+jrjackson: 0.4.20
 jackson: 2.16.2
 jackson-databind: 2.16.2


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Logstash's source pieces/tools to handle when invalid unicode payload passess (through `LogStash::Json.dump(invalid_unicode_payload)`), doesn't deal with input encoding or normalize the unicode bytestream if force encoded (metadata vs actual bytes may mismatch in ruby String).
This PR tries to properly 
- treat input payload encoding and use ruby `Encoding::Converter` to make a correct representation
- if encoding converters, do not understand, Logstash tries to keep the same bytestream as received and treats it as unicode (`force_encoding(Encoding::UTF_8)`) 
- validates the unicode _claimed_ payload with ruby's unicode normalization (`unicode_normalize`) to make sure 
- replaces the invalid unicode bytes with the replacement char (`\uFFFD`)

## Why is it important/What is the impact to the user?
Users who are ingesting data as a non-unicode stream, they may see the strange encoding behavior or if they are using `elasticsearch-output` <=11.22.2 versions, ES rejects the events.

## Checklist

- [x] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Currently, for testing purpose only considered _String_, need to handle also any other data structures like hash, etc..
- [x] Pseudo source applied for now. Separate the logic into two: conversion + normalization, think about how to _brightly_ place the `scrub` (applying replacement char)
- [x] Tests with Hash & Array data structure use-cases

## How to test this PR locally
See the unit tests or pull this change and treat any invalid/valid unicode payloads (for now only _String_s please)
- The easy way is to emit invalid unicode events with ruby filter, example by using following config
```
input { generator { count => 1 } }
filter { ruby { code => 'str = "\xAC"; event.set("message", str)' } }
output {
  elasticsearch {
    cloud_id => "your_cloud_id"
    cloud_auth => "elastic:PWD"
  }
  stdout { }
}
```
- Run Logstash with trace mode: `bin/logstash -f your-config.conf --log.level=trace` to see the pipeline unicode handling outputs

## Related issues

- Closes #15833

## Use cases


## Screenshots


## Logs

```
[2024-04-10T13:16:15,103][TRACE][logstash.unicodenormalizer][main][999000c22ac1744372923039d3bee405a92df01b3dafcd64f0830a24ad60acc6] Could not normalize to unicode, #<ArgumentError: invalid byte sequence in UTF-8>
[2024-04-10T13:16:15,103][TRACE][logstash.unicodenormalizer][main][999000c22ac1744372923039d3bee405a92df01b3dafcd64f0830a24ad60acc6] Replacing invalid non-utf bytes with replacement char.
[2024-04-10T13:16:15,106][DEBUG][logstash.outputs.elasticsearch][main][999000c22ac1744372923039d3bee405a92df01b3dafcd64f0830a24ad60acc6] Sending final bulk request for batch. {:action_count=>1, :payload_size=>313, :content_length=>253, :batch_offset=>0}
{
      "@version" => "1",
          "host" => {
        "name" => "Mashhurs.local.host"
    },
    "@timestamp" => 2024-04-10T20:16:14.946669Z,
       "message" => "�",
         "event" => {
        "original" => "Hello world!",
        "sequence" => 0
    }
}

```