### PR TITLE
Split LS_JAVA_OPTS content when contains multiple options

### DIFF
--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -176,13 +176,9 @@ public class JvmOptionsParser {
             if (isDebugEnabled()) {
                 System.err.println("Appending jvm options from environment LS_JAVA_OPTS");
             }
-            if (lsJavaOpts.contains(" ")) {
-                Arrays.stream(lsJavaOpts.split(" "))
-                        .filter(s -> !s.isBlank())
-                        .forEach(jvmOptionsContent::add);
-            } else {
-              jvmOptionsContent.add(lsJavaOpts);
-            }
+            Arrays.stream(lsJavaOpts.split(" "))
+                    .filter(s -> !s.isBlank())
+                    .forEach(jvmOptionsContent::add);
         }
         // Set mandatory JVM options
         jvmOptionsContent.addAll(getMandatoryJvmOptions(javaMajorVersion));

--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -176,7 +176,13 @@ public class JvmOptionsParser {
             if (isDebugEnabled()) {
                 System.err.println("Appending jvm options from environment LS_JAVA_OPTS");
             }
-            jvmOptionsContent.add(lsJavaOpts);
+            if (lsJavaOpts.contains(" ")) {
+                Arrays.stream(lsJavaOpts.split(" "))
+                        .filter(s -> !s.isBlank())
+                        .forEach(jvmOptionsContent::add);
+            } else {
+              jvmOptionsContent.add(lsJavaOpts);
+            }
         }
         // Set mandatory JVM options
         jvmOptionsContent.addAll(getMandatoryJvmOptions(javaMajorVersion));

--- a/tools/jvm-options-parser/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
+++ b/tools/jvm-options-parser/src/test/java/org/logstash/launchers/JvmOptionsParserTest.java
@@ -39,12 +39,23 @@ public class JvmOptionsParserTest {
     }
 
     @Test
-    public void test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable() throws IOException, InterruptedException, ReflectiveOperationException {
+    public void test_LS_JAVA_OPTS_isUsedWhenNoJvmOptionsIsAvailable() {
         JvmOptionsParser.handleJvmOptions(new String[] {temp.toString()}, "-Xblabla");
 
         // Verify
         final String output = outputStreamCaptor.toString();
         assertTrue("Output MUST contains the options present in LS_JAVA_OPTS", output.contains("-Xblabla"));
+    }
+
+    @Test
+    public void givenLS_JAVA_OPTS_containingMultipleDefinitionsWithAlsoMaxOrderThenNoDuplicationOfMaxOrderOptionShouldHappen() throws IOException {
+        JvmOptionsParser.handleJvmOptions(new String[] {temp.toString()}, "-Xblabla -Dio.netty.allocator.maxOrder=13");
+
+        // Verify
+        final String output = outputStreamCaptor.toString();
+        int firstMatch = output.indexOf("-Dio.netty.allocator.maxOrder");
+        int lastMatch = output.lastIndexOf("-Dio.netty.allocator.maxOrder");
+        assertEquals("No duplication of options (io.netty.allocator.maxOrder) are admitted \n raw data[" + output + "]", firstMatch, lastMatch);
     }
 
     @SuppressWarnings({ "unchecked" })


### PR DESCRIPTION
## Release notes
Bugfix to parse correctly Java options when the environment variable LS_JAVA_OPTS contains multiple definitions separated by space character.

## What does this PR do?
Adapt the parsing of `LS_JAVA_OPTS` environment variable to split by space various definitions it can contains.

## Why is it important/What is the impact to the user?

Permit the user insert multiple space separated options in `LS_JAVA_OPTS`, fixing a bug that created duplicated maxOrder option when used by Docker.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```sh
export LS_JAVA_OPTS=" -Xmx4g -Dio.netty.allocator.maxOrder=6" && bin/Logstash -e "input{stdin{}} output{stdout{codec => rubydebug}}"
```

In Logstash's logs shouldn't appear both `-Dio.netty.allocator.maxOrder=6` and the default setting `-Dio.netty.allocator.maxOrder=11`, because the maxOrder is added only if it wasn't specified before.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #16078 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
