### PR TITLE
Refactored data clumps with the help of LLMs (research project)

### DIFF
--- a/logstash-core/src/main/java/co/elastic/logstash/api/ConfigData.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/ConfigData.java
@@ -1,0 +1,28 @@
+package co.elastic.logstash.api;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class ConfigData<T> {
+
+    public final String name;
+    public final Class<T> type;
+    public final T defaultValue;
+    public final boolean deprecated;
+    public final boolean required;
+    public final Collection<PluginConfigSpec<?>> children;
+
+    public ConfigData(String name, Class<T> type, T defaultValue, boolean deprecated, boolean required) {
+        this(name, type, defaultValue, deprecated, required, Collections.emptyList());
+    }
+
+    public ConfigData(String name, Class<T> type, T defaultValue, boolean deprecated, boolean required, Collection<PluginConfigSpec<?>> children) {
+        this.name = name;
+        this.type = type;
+        this.defaultValue = defaultValue;
+        this.deprecated = deprecated;
+        this.required = required;
+        this.children = children;
+    }
+
+}

--- a/logstash-core/src/main/java/co/elastic/logstash/api/PluginConfigSpec.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/PluginConfigSpec.java
@@ -33,195 +33,149 @@ import java.util.Map;
  */
 public final class PluginConfigSpec<T> {
 
-    private final String name;
-
-    private final Class<T> type;
-
-    private final boolean deprecated;
-
-    private final boolean required;
-
-    private final T defaultValue;
+    private ConfigData<T> configData;
 
     private String rawDefaultValue;
 
-    private final Collection<PluginConfigSpec<?>> children;
 
-    private PluginConfigSpec(final String name, final Class<T> type,
-        final T defaultValue, final boolean deprecated, final boolean required) {
-        this(name, type, defaultValue, deprecated, required, Collections.emptyList());
-    }
-
-    private PluginConfigSpec(final String name, final Class<T> type,
-        final T defaultValue, final boolean deprecated, final boolean required,
-        final Collection<PluginConfigSpec<?>> children) {
-        this.name = name;
-        this.type = type;
-        this.defaultValue = defaultValue;
-        this.deprecated = deprecated;
-        this.required = required;
-        if (!children.isEmpty() && !Map.class.isAssignableFrom(type)) {
-            throw new IllegalArgumentException("Only map type settings can have defined children.");
-        }
-        this.children = children;
+    private PluginConfigSpec(final ConfigData<T> configData) {
+        this.configData = configData;
     }
 
     public static PluginConfigSpec<String> stringSetting(final String name) {
-        return new PluginConfigSpec<>(
-            name, String.class, null, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, String.class, null, false, false));
     }
 
     public static PluginConfigSpec<String> stringSetting(final String name, final String defaultValue) {
-        return new PluginConfigSpec<>(
-                name, String.class, defaultValue, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, String.class, defaultValue, false, false));
     }
 
     public static PluginConfigSpec<String> requiredStringSetting(final String name) {
-        return new PluginConfigSpec<>(name, String.class, null, false, true);
+        return new PluginConfigSpec<>(new ConfigData<>(name, String.class, null, false, true));
     }
 
     public static PluginConfigSpec<String> stringSetting(final String name, final String defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec<>(name, String.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec<>(new ConfigData<>(name, String.class, defaultValue, deprecated, required));
     }
 
     public static PluginConfigSpec<Codec> codecSetting(final String name) {
-        return new PluginConfigSpec<>(
-                name, Codec.class, null, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, Codec.class, null, false, false));
     }
 
     public static PluginConfigSpec<Codec> codecSetting(final String name, final String defaultCodecName) {
-        PluginConfigSpec<Codec> pcs = new PluginConfigSpec<>(
-                name, Codec.class, null, false, false
-        );
+        PluginConfigSpec<Codec> pcs = new PluginConfigSpec<>(new ConfigData<>(name, Codec.class, null, false, false));
         pcs.rawDefaultValue = defaultCodecName;
         return pcs;
     }
 
     public static PluginConfigSpec<Codec> codecSetting(final String name, final Codec defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec<>(name, Codec.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Codec.class, defaultValue, deprecated, required));
     }
 
     public static PluginConfigSpec<URI> uriSetting(final String name) {
-        return new PluginConfigSpec<>(
-                name, URI.class, null, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, URI.class, null, false, false));
     }
 
     public static PluginConfigSpec<URI> uriSetting(final String name, final String defaultUri) {
-        PluginConfigSpec<URI> pcs = new PluginConfigSpec<>(
-                name, URI.class, null, false, false
-        );
+        PluginConfigSpec<URI> pcs = new PluginConfigSpec<>(new ConfigData<>(name, URI.class, null, false, false));
         pcs.rawDefaultValue = defaultUri;
         return pcs;
     }
 
     public static PluginConfigSpec<URI> uriSetting(final String name, final String defaultUri, boolean deprecated, boolean required) {
-        PluginConfigSpec<URI> pcs = new PluginConfigSpec<>(
-                name, URI.class, null, deprecated, required
-        );
+        PluginConfigSpec<URI> pcs = new PluginConfigSpec<>(new ConfigData<>(name, URI.class, null, deprecated, required));
         pcs.rawDefaultValue = defaultUri;
         return pcs;
     }
 
     public static PluginConfigSpec<Long> numSetting(final String name) {
-        return new PluginConfigSpec<>(
-            name, Long.class, null, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, Long.class, null, false, false));
     }
 
     public static PluginConfigSpec<Long> numSetting(final String name, final long defaultValue) {
-        return new PluginConfigSpec<>(
-            name, Long.class, defaultValue, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, Long.class, defaultValue, false, false));
     }
 
     public static PluginConfigSpec<Double> floatSetting(final String name, final double defaultValue) {
-        return new PluginConfigSpec<>(name, Double.class, defaultValue, false, false);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Double.class, defaultValue, false, false));
     }
 
     public static PluginConfigSpec<Double> floatSetting(final String name, final double defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec<>(name, Double.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Double.class, defaultValue, deprecated, required));
     }
 
     public static PluginConfigSpec<Long> numSetting(final String name, final long defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec<>(name, Long.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Long.class, defaultValue, deprecated, required));
     }
 
     public static PluginConfigSpec<Boolean> booleanSetting(final String name) {
-        return new PluginConfigSpec<>(name, Boolean.class, null, false, false);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Boolean.class, null, false, false));
     }
 
     public static PluginConfigSpec<Boolean> booleanSetting(final String name, final boolean defaultValue) {
-        return new PluginConfigSpec<>(name, Boolean.class, defaultValue, false, false);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Boolean.class, defaultValue, false, false));
     }
 
     public static PluginConfigSpec<Boolean> requiredBooleanSetting(final String name) {
-        return new PluginConfigSpec<>(name, Boolean.class, null, false, true);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Boolean.class, null, false, true));
     }
 
     public static PluginConfigSpec<Boolean> booleanSetting(final String name, final boolean defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec<>(name, Boolean.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec<>(new ConfigData<>(name, Boolean.class, defaultValue, deprecated, required));
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<Map<String, Object>> hashSetting(final String name) {
-        return new PluginConfigSpec(name, Map.class, null, false, false);
+        return new PluginConfigSpec(new ConfigData<>(name, Map.class, null, false, false));
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<Map<String, Object>> hashSetting(final String name, Map<String, Object> defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec(name, Map.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec(new ConfigData<>(name, Map.class, defaultValue, deprecated, required));
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<List<Object>> arraySetting(final String name) {
-        return new PluginConfigSpec(name, List.class, null, false, false);
+        return new PluginConfigSpec(new ConfigData<>(name, List.class, null, false, false));
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
     public static PluginConfigSpec<List<Object>> arraySetting(final String name, List<Object> defaultValue, boolean deprecated, boolean required) {
-        return new PluginConfigSpec(name, List.class, defaultValue, deprecated, required);
+        return new PluginConfigSpec(new ConfigData<>(name, List.class, defaultValue, deprecated, required));
     }
 
     public static PluginConfigSpec<Password> passwordSetting(final String name) {
-        return new PluginConfigSpec<>(
-                name, Password.class, null, false, false
-        );
+        return new PluginConfigSpec<>(new ConfigData<>(name, Password.class, null, false, false));
     }
 
     public static PluginConfigSpec<Password> passwordSetting(final String name, final String defaultValue, boolean deprecated, boolean required) {
-        PluginConfigSpec<Password> pcs = new PluginConfigSpec<>(
-                name, Password.class, null, false, false
-        );
+        PluginConfigSpec<Password> pcs = new PluginConfigSpec<>(new ConfigData<>(name, Password.class, null, false, false));
         pcs.rawDefaultValue = defaultValue;
         return pcs;
     }
 
     public Collection<PluginConfigSpec<?>> children() {
-        return children;
+        return configData.children;
     }
 
     public boolean deprecated() {
-        return this.deprecated;
+        return this.configData.deprecated;
     }
 
     public boolean required() {
-        return this.required;
+        return this.configData.required;
     }
 
     public T defaultValue() {
-        return this.defaultValue;
+        return this.configData.defaultValue;
     }
 
     public String name() {
-        return name;
+        return configData.name;
     }
 
     public Class<T> type() {
-        return type;
+        return configData.type;
     }
 
     public String getRawDefaultValue() {

--- a/logstash-core/src/test/java/org/logstash/plugins/ConfigurationImplTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/ConfigurationImplTest.java
@@ -52,9 +52,9 @@ public class ConfigurationImplTest {
     public void testConfiguration() {
         Configuration config = getTestConfiguration();
 
-        PluginConfigSpec<String> stringConfig = PluginConfigSpec.stringSetting(stringKey, "", false, false);
-        PluginConfigSpec<Long> numberConfig = PluginConfigSpec.numSetting(numberKey, 0L, false, false);
-        PluginConfigSpec<Boolean> booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, false, false, false);
+        PluginConfigSpec<String> stringConfig = PluginConfigSpec.stringSetting(stringKey, "");
+        PluginConfigSpec<Long> numberConfig = PluginConfigSpec.numSetting(numberKey, 0L);
+        PluginConfigSpec<Boolean> booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, false);
 
         Assert.assertEquals(stringValue, config.get(stringConfig));
         Assert.assertEquals(longValue, (long) config.get(numberConfig));
@@ -69,9 +69,9 @@ public class ConfigurationImplTest {
         long defaultLongValue = 43L;
         boolean defaultBooleanValue = false;
 
-        PluginConfigSpec<String> stringConfig = PluginConfigSpec.stringSetting(stringKey, defaultStringValue, false, false);
-        PluginConfigSpec<Long> numberConfig = PluginConfigSpec.numSetting(numberKey, defaultLongValue, false, false);
-        PluginConfigSpec<Boolean> booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, defaultBooleanValue, false, false);
+        PluginConfigSpec<String> stringConfig = PluginConfigSpec.stringSetting(stringKey, defaultStringValue);
+        PluginConfigSpec<Long> numberConfig = PluginConfigSpec.numSetting(numberKey, defaultLongValue);
+        PluginConfigSpec<Boolean> booleanConfig = PluginConfigSpec.booleanSetting(booleanKey, defaultBooleanValue);
 
         Assert.assertEquals(defaultStringValue, unsetConfig.get(stringConfig));
         Assert.assertEquals(defaultLongValue, (long) unsetConfig.get(numberConfig));
@@ -87,9 +87,9 @@ public class ConfigurationImplTest {
     public void testBrokenConfig() {
         Configuration config = getTestConfiguration();
 
-        PluginConfigSpec<Long> brokenLongConfig = PluginConfigSpec.numSetting(stringKey, 0L, false, false);
-        PluginConfigSpec<Boolean> brokenBooleanConfig = PluginConfigSpec.booleanSetting(numberKey, false, false, false);
-        PluginConfigSpec<String> brokenStringConfig = PluginConfigSpec.stringSetting(booleanKey, "", false, false);
+        PluginConfigSpec<Long> brokenLongConfig = PluginConfigSpec.numSetting(stringKey, 0L);
+        PluginConfigSpec<Boolean> brokenBooleanConfig = PluginConfigSpec.booleanSetting(numberKey, false);
+        PluginConfigSpec<String> brokenStringConfig = PluginConfigSpec.stringSetting(booleanKey, "");
 
         try {
             Long l = config.get(brokenLongConfig);


### PR DESCRIPTION

## What does this PR do?

Hello maintainers,

I am conducting a master thesis project focused on enhancing code quality through automated refactoring of data clumps, assisted by Large Language Models (LLMs).


<details>
  <summary>Data clump definition</summary>
  
A data clump exists if
1. two methods (in the same or in different classes) have at least 3 common parameters and one of those methods does not override the other,  or 
2. At least three fields in a class are common with the parameters of a method (in the same or in a different class), or
3. Two different classes have at least three common fields
  
See also the following UML diagram as an example
![Example data clump](https://raw.githubusercontent.com/compf/data_clump_eval_assets/main/data_clump_explained.svg)
</details>


I believe these refactoring can contribute to the project by reducing complexity and enhancing readability of your source code.

Pursuant to the EU AI Act, I fully disclose the use of LLMs in generating these refactorings, emphasizing that all changes have undergone human review for quality assurance. 


Even if you decide not to integrate my changes to your codebase (which is perfectly fine), I ask you to fill out a feedback survey, which will be scientifically evaluated to determine the acceptance of AI-supported refactorings. You can find the feedback survey under https://campus.lamapoll.de/Data-clump-refactoring/en


Thank you for considering my contribution. I look forward to your feedback. If you have any other questions or comments, feel free to write a comment, or email me under tschoemaker@uni-osnabrueck.de .


Best regards,
Timo Schoemaker
Department of Computer Science
University of Osnabrück



-->

## Checklist


- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~


