### PR TITLE
force ruby-maven-libs constraint to >= 3.9.6.1

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -9,7 +9,7 @@ gem "paquet", "~> 0.2"
 gem "pleaserun", "~>0.0.28", require: false
 gem "rake", "~> 13", require: false
 gem "ruby-progressbar", "~> 1", require: false
-gem "ruby-maven-libs", "~> 3", ">= 3.8.9"
+gem "ruby-maven-libs", "~> 3", ">= 3.9.6.1"
 gem "logstash-output-elasticsearch", ">= 11.14.0"
 gem "polyglot", require: false
 gem "treetop", require: false


### PR DESCRIPTION
follow up to https://github.com/jruby/ruby-maven-libs/pull/5