### PR TITLE
Update plugins-metadata.json with integration-snmp: set skiplist to false

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -433,6 +433,10 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-integration-snmp": {
+    "default-plugins": false,
+    "skip-list": false
+  },
   "logstash-integration-aws": {
     "default-plugins": true,
     "skip-list": false


### PR DESCRIPTION
Adding `integration-snmp` to plugins-metadata.json so that it will be picked up for the Logstash Reference plugin docgen

### Why?
After the VPR job ran and picked up `integration-snmp`, I kicked off a docgen for Logstash Reference on `main`.  It didn't pick anything up, and I believe that's because we need this piece added to plugins-metadata.json. 

### Aligning Logstash Reference (LSR) docgen settings
@jsvd, what changes should I make to `input-snmp` and `input-snmp-trap` settings in [https://github.com/elastic/logstash/blame/main/rakelib/plugins-metadata.json](https://github.com/elastic/logstash/blame/main/rakelib/plugins-metadata.json)? 
<img width="741" alt="Screen Shot 2024-05-03 at 11 12 35 AM" src="https://github.com/elastic/logstash/assets/35154725/fef0134b-1fc6-4244-8116-76e924575aaf"> 

At 8.15 I believe that we'll want to set the individual plugins to `"skip-list": true`. Is the current config acceptable in the interim? 
