### PR TITLE
[health] bootstrap HealthObserver from agent to API

### DIFF
--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -40,6 +40,8 @@ class LogStash::Agent
   attr_reader :metric, :name, :settings, :dispatcher, :ephemeral_id, :pipeline_bus
   attr_accessor :logger
 
+  attr_reader :health_observer
+
   # initialize method for LogStash::Agent
   # @param params [Hash] potential parameters are:
   #   :name [String] - identifier for the agent
@@ -50,6 +52,9 @@ class LogStash::Agent
     @settings = settings
     @auto_reload = setting("config.reload.automatic")
     @ephemeral_id = SecureRandom.uuid
+
+    java_import("org.logstash.health.HealthObserver")
+    @health_observer = HealthObserver.new
 
     # Mutex to synchronize in the exclusive method
     # Initial usage for the Ruby pipeline initialization which is not thread safe

--- a/logstash-core/lib/logstash/api/commands/default_metadata.rb
+++ b/logstash-core/lib/logstash/api/commands/default_metadata.rb
@@ -28,7 +28,7 @@ module LogStash
              :id => service.agent.id,
              :name => service.agent.name,
              :ephemeral_id => service.agent.ephemeral_id,
-             :status => "green",  # This is hard-coded to mirror x-pack behavior
+             :status => service.agent.health_observer.status,
              :snapshot => ::BUILD_INFO["build_snapshot"],
              :pipeline => {
                :workers => LogStash::SETTINGS.get("pipeline.workers"),

--- a/logstash-core/spec/logstash/webserver_spec.rb
+++ b/logstash-core/spec/logstash/webserver_spec.rb
@@ -55,7 +55,13 @@ describe LogStash::WebServer do
   end
 
   let(:logger) { LogStash::Logging::Logger.new("testing") }
-  let(:agent) { OpenStruct.new({:webserver => webserver_block, :http_address => "127.0.0.1", :id => "myid", :name => "myname"}) }
+  let(:agent) { OpenStruct.new({
+                                 webserver:       webserver_block,
+                                 http_address:    "127.0.0.1",
+                                 id:              "myid",
+                                 name:            "myname",
+                                 health_observer: org.logstash.health.HealthObserver.new,
+                               }) }
   let(:webserver_block) { OpenStruct.new({}) }
 
   subject(:webserver) { LogStash::WebServer.new(logger, agent, webserver_options) }

--- a/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
+++ b/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.logstash.health;
 
 import com.google.common.collect.Iterables;

--- a/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
+++ b/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
@@ -1,0 +1,21 @@
+package org.logstash.health;
+
+import com.google.common.collect.Iterables;
+
+import java.util.EnumSet;
+
+public class HealthObserver {
+    public final Status getStatus() {
+        // INTERNAL-ONLY Proof-of-concept to show flow-through to API results
+        switch (System.getProperty("logstash.apiStatus", "green")) {
+            case "green":  return Status.GREEN;
+            case "yellow": return Status.YELLOW;
+            case "red":    return Status.RED;
+            case "random":
+                final EnumSet<Status> statuses = EnumSet.allOf(Status.class);
+                return Iterables.get(statuses, new java.util.Random().nextInt(statuses.size()));
+            default:
+                return Status.UNKNOWN;
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/health/Status.java
+++ b/logstash-core/src/main/java/org/logstash/health/Status.java
@@ -1,0 +1,32 @@
+package org.logstash.health;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Status {
+    UNKNOWN,
+    GREEN,
+    YELLOW,
+    RED,
+    ;
+
+    private final String externalValue = name().toLowerCase();
+
+    @JsonValue
+    public String externalValue() {
+        return externalValue;
+    }
+
+    /**
+     * Combine this status with another status.
+     * This method is commutative.
+     * @param status the other status
+     * @return the more-degraded of the two statuses.
+     */
+    public Status reduce(Status status) {
+        if (compareTo(status) >= 0) {
+            return this;
+        } else {
+            return status;
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/health/Status.java
+++ b/logstash-core/src/main/java/org/logstash/health/Status.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.logstash.health;
 
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/logstash-core/src/test/java/org/logstash/health/StatusTest.java
+++ b/logstash-core/src/test/java/org/logstash/health/StatusTest.java
@@ -1,0 +1,106 @@
+package org.logstash.health;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Collections2.orderedPermutations;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.health.Status.*;
+
+@RunWith(Enclosed.class)
+public class StatusTest {
+
+    public static class Tests {
+        @Test
+        public void testReduceUnknown() {
+            assertThat(UNKNOWN.reduce(UNKNOWN), is(UNKNOWN));
+            assertThat(UNKNOWN.reduce(GREEN), is(GREEN));
+            assertThat(UNKNOWN.reduce(YELLOW), is(YELLOW));
+            assertThat(UNKNOWN.reduce(RED), is(RED));
+        }
+
+        @Test
+        public void testReduceGreen() {
+            assertThat(GREEN.reduce(UNKNOWN), is(GREEN));
+            assertThat(GREEN.reduce(GREEN), is(GREEN));
+            assertThat(GREEN.reduce(YELLOW), is(YELLOW));
+            assertThat(GREEN.reduce(RED), is(RED));
+        }
+
+        @Test
+        public void testReduceYellow() {
+            assertThat(YELLOW.reduce(UNKNOWN), is(YELLOW));
+            assertThat(YELLOW.reduce(GREEN), is(YELLOW));
+            assertThat(YELLOW.reduce(YELLOW), is(YELLOW));
+            assertThat(YELLOW.reduce(RED), is(RED));
+        }
+
+        @Test
+        public void testReduceRed() {
+            assertThat(RED.reduce(UNKNOWN), is(RED));
+            assertThat(RED.reduce(GREEN), is(RED));
+            assertThat(RED.reduce(YELLOW), is(RED));
+            assertThat(RED.reduce(RED), is(RED));
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class JacksonSerialization {
+        @Parameters(name = "{0}")
+        public static Iterable<?> data() {
+            return EnumSet.allOf(Status.class);
+        }
+
+        @Parameter
+        public Status status;
+
+        private final ObjectMapper mapper = new ObjectMapper();
+
+        @Test
+        public void testSerialization() throws Exception {
+            assertThat(mapper.writeValueAsString(status), is(equalTo('"' + status.name().toLowerCase() + '"')));
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ReduceCommutativeSpecification {
+        @Parameters(name = "{0}<=>{1}")
+        public static Collection<Object[]> data() {
+            return getCombinations(EnumSet.allOf(Status.class), 2);
+        }
+
+        @Parameter(0)
+        public Status statusA;
+        @Parameter(1)
+        public Status statusB;
+
+        @Test
+        public void testReduceCommutative() {
+            assertThat(statusA.reduce(statusB), is(statusB.reduce(statusA)));
+        }
+
+        private static <T extends Comparable<T>> List<Object[]> getCombinations(Collection<T> source, int count) {
+            return orderedPermutations(source).stream()
+                    .map((l) -> l.subList(0, count))
+                    .map(ArrayList::new).peek(Collections::sort)
+                    .collect(Collectors.toSet())
+                    .stream()
+                    .map(List::toArray)
+                    .collect(Collectors.toList());
+        }
+    }
+}


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

 - Introduces `org.logstash.health.HealthObserver` that is accessible via `Agent#health_observer`
 - Introduces `org.logstash.health.Status` with facilities for combining statuses
 - Populates API-common top-level `status` with `HealthObserver#status`. In bootstrap form, the value is controlled by system property `logstash.apiStatus`, but will be derived from indicators once they are added in a subsequent PR.

## Why is it important/What is the impact to the user?

These are steps toward delivering the health report API as RFC'd in #16056

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

To prove that the value of API response's `status` is no longer hard-coded to green, 
this bootstrap contains a hidden feature flag java property `logstash.apiStatus` which can be any of `unknown`, `green`, `yellow`, `red`, or `random` (it defaults to `green`).

Start Logstash running a long-lived pipeline:

~~~
LS_JAVA_OPTS="-Dlogstash.apiStatus=random" bin/logstash -e 'input { heartbeat {} }'
~~~

Get the API response for `GET /_node` and/or `GET /_node_stats` and observe that the status is no longer hard-coded to `green`:
~~~
╭─{ rye@perhaps:~/src/elastic/logstash@main (health-api-bootstrap ✔) }
╰─● curl --silent -XGET http://localhost:9600/_node | jq .status
"yellow"
[success]                                                                                                                                                                                                                                                                                                                                                                                                                        

╭─{ rye@perhaps:~/src/elastic/logstash@main (health-api-bootstrap ✔) }
╰─● curl --silent -XGET http://localhost:9600/_node | jq .status
"yellow"
[success]                                                                                                                                                                                                                                                                                                                                                                                                                        

╭─{ rye@perhaps:~/src/elastic/logstash@main (health-api-bootstrap ✔) }
╰─● curl --silent -XGET http://localhost:9600/_node | jq .status
"red"
[success]                                                                                                                                                                                                                                                                                                                                                                                                                        

╭─{ rye@perhaps:~/src/elastic/logstash@main (health-api-bootstrap ✔) }
╰─● curl --silent -XGET http://localhost:9600/_node | jq .status
"green"
[success]                                                                                                                                                                                                                                                                                                                                                                                                                        

╭─{ rye@perhaps:~/src/elastic/logstash@main (health-api-bootstrap ✔) }
╰─● curl --silent -XGET http://localhost:9600/_node | jq .status
"unknown"
[success] 
~~~

## Related issues

- Closes elastic/ingest-dev#3241
- Closes elastic/ingest-dev#3242
