### PR TITLE
Handle non-unicode payload in Logstash. (#16072)

### DIFF
--- a/logstash-core/lib/logstash/util/unicode_normalizer.rb
+++ b/logstash-core/lib/logstash/util/unicode_normalizer.rb
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module LogStash
+
+  # A class to normalize the invalid unicode data
+  class UnicodeNormalizer
+
+    include LogStash::Util::Loggable
+
+    # Tries to normalize input string to UTF-8 when
+    #   input string encoding is not UTF-8,
+    #   and replaces invalid unicode bytes with replacement characters ('uFFFD')
+    # string_data - The String data to be normalized.
+    # Returns the normalized string data.
+    def self.normalize_string_encoding(string_data)
+      # when given BINARY-flagged string, assume it is UTF-8 so that
+      # subsequent cleanup retains valid UTF-8 sequences
+      source_encoding = string_data.encoding
+      source_encoding = Encoding::UTF_8 if source_encoding == Encoding::BINARY
+      string_data.encode(Encoding::UTF_8, source_encoding, invalid: :replace, undef: :replace).scrub
+    end
+  end
+end

--- a/logstash-core/lib/logstash/util/unicode_trimmer.rb
+++ b/logstash-core/lib/logstash/util/unicode_trimmer.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # encoding: utf-8
 
 module LogStash::Util::UnicodeTrimmer

--- a/versions.yml
+++ b/versions.yml
@@ -24,6 +24,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.18
+jrjackson: 0.4.20
 jackson: 2.15.3
 jackson-databind: 2.15.3


### PR DESCRIPTION
## Cherry picking #16072 to 8.14

Automatic backport didn't work due to conflict (attaching following logs) in `versions.yml` file. Manually cherry picking https://github.com/elastic/logstash/pull/16072
```
INFO: Checkout of 8.14 to backport to...

INFO: Creating backport branch backport_16072_8.14...

INFO: Merge commit detected from PR: 979d30d7016db6f0df8150f794a74d[37](https://github.com/elastic/logstash/actions/runs/9116832148/job/25066303742#step:12:38)85199fb2

INFO: Cherry-picking 979d30d7016db6f0df8150f794a74d3785199fb2

INFO: Looks like you have cherry-pick errors.

INFO: Fix them, then run: 

INFO:     git cherry-pick --continue

INFO:     devtools/backport 8.14 16072 --remote=origin --yes --continue
```


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
