### PR TITLE
Add incomplete integration plugins to metadata.json as skip

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -441,6 +441,14 @@
     "default-plugins": true,
     "skip-list": false
   },
+  "logstash-integration-internal": {
+    "default-plugins": false,
+    "skip-list": true
+  },
+  "logstash-integration-zeromq": {
+    "default-plugins": false,
+    "skip-list": true
+  },
   "logstash-input-cloudwatch": {
     "default-plugins": false,
     "skip-list": true


### PR DESCRIPTION
#### Release notes
[rn:skip] to leave this PR out of release notes 

#### Step 1: Move integration plugins 
This PR moves `logstash-integration-internal` and `logstash-integration-zeromq` plugins to [plugins-metadata.json](https://github.com/elastic/logstash/blob/main/rakelib/plugins-metadata.json ) and configure them as `default-plugins: false` and `"skip-list": true` to set us up to make the next set of changes to docs tooling. 

#### Next steps
- ToDo:  Change docs tooling to remove skip logic for integration plugins. 

Related: https://github.com/elastic/docs-tools/issues/106

