### PR TITLE
PQ: avoid blocking writer when precisely full

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -61,7 +61,7 @@ The total of `queue.max_bytes` for _all_ queues should be
 lower than the capacity of your disk.
 +
 TIP: If you are using persistent queues to protect against data loss, but don't
-require much buffering, you can set `queue.max_bytes` to a smaller value.
+require much buffering, you can set `queue.max_bytes` to a smaller value as long as it is not less than the value of `queue.page_capacity`.
 A smaller value produces smaller queues and improves queue performance. 
 
 `queue.checkpoint.acks`:: Sets the number of acked events before forcing a checkpoint. 

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Queue.java
@@ -506,18 +506,13 @@ public final class Queue implements Closeable {
     }
 
     /**
-     * <p>Checks if the Queue is full, with "full" defined as either of:</p>
-     * <p>Assuming a maximum size of the queue larger than 0 is defined:</p>
+     * <p>Checks if the Queue is full, with "full" defined as either of:
      * <ul>
-     *     <li>The sum of the size of all allocated pages is more than the allowed maximum Queue
-     *     size</li>
-     *     <li>The sum of the size of all allocated pages equal to the allowed maximum Queue size
-     *     and the current head page has no remaining capacity.</li>
-     * </ul>
-     * <p>or assuming a max unread count larger than 0, is defined "full" is also defined as:</p>
-     * <ul>
-     *     <li>The current number of unread events exceeds or is equal to the configured maximum
-     *     number of allowed unread events.</li>
+     *     <li>{@code maxUnread} is non-zero and is met or exceeded by the total
+     *         number of unread events on all pages ({@code unreadCount})</li>
+     *     <li>{@code maxBytes} is non-zero and is exceeded by the sum of the sizes
+     *         of all allocated tail pages plus the portion of the current head page
+     *         containing events</li>
      * </ul>
      * @return True iff the queue is full
      */
@@ -535,8 +530,7 @@ public final class Queue implements Closeable {
             return false;
         }
 
-        final long persistedByteSize = getPersistedByteSize();
-        return ((persistedByteSize > this.maxBytes) || (persistedByteSize == this.maxBytes && !this.headPage.hasSpace(1)));
+        return getPersistedByteSize() > this.maxBytes;
     }
 
     private boolean isMaxUnreadReached() {


### PR DESCRIPTION
## Release notes

Fixes an issue in which an input writing to a PQ could become blocked indefinitely after writing an event that _precisely_ fit the remaining capacity of a PQ configured to handle a single PQ-page of events.

## What does this PR do?

A PQ is considered full (and therefore needs to block before releasing the
writer) when its persisted size on disk _exceeds_ its `queue.max_bytes`
capacity.
    
This removes an edge-case preemptive block when the persisted size after
writing an event _meets_ its `queue.max_bytes` precisely AND its current
head page has insufficient room to also accept a hypothetical future event.

A block formed in this way would only be broken the next time a tail page
is fully-acked, which cannot occur when the `queue.max_bytes` is configured
to match `queue.page_capacity`.

## Why is it important/What is the impact to the user?

Users who configure their `queue.max_bytes` to match `queue.page_capacity` do so to eliminate buffering, and this fix eliminates an edge-case that could cause their PQ to block indefinitely.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

See: https://github.com/elastic/logstash/issues/16172

## Related issues

Fixes: https://github.com/elastic/logstash/issues/16172
