### PR TITLE
Update log4j rollover to configure time retention

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -1,4 +1,4 @@
-status = error
+status = trace
 name = LogstashPropertiesConfig
 
 appender.console.type = Console
@@ -26,6 +26,12 @@ appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size = 100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 30
+appender.rolling.strategy.action.type = Delete
+appender.rolling.strategy.action.basepath = ${sys:ls.logs}
+appender.rolling.strategy.action.condition.type = IfFileName
+appender.rolling.strategy.action.condition.glob = logstash-plain-*
+appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
+appender.rolling.strategy.action.condition.nested_condition.age = 7D
 appender.rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
 
 appender.json_rolling.type = RollingFile
@@ -43,6 +49,12 @@ appender.json_rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.json_rolling.policies.size.size = 100MB
 appender.json_rolling.strategy.type = DefaultRolloverStrategy
 appender.json_rolling.strategy.max = 30
+appender.json_rolling.strategy.action.type = Delete
+appender.json_rolling.strategy.action.basepath = ${sys:ls.logs}
+appender.json_rolling.strategy.action.condition.type = IfFileName
+appender.json_rolling.strategy.action.condition.glob = logstash-json-*
+appender.json_rolling.strategy.action.condition.nested_condition.type = IfLastModified
+appender.json_rolling.strategy.action.condition.nested_condition.age = 7D
 appender.json_rolling.avoid_pipelined_filter.type = PipelineRoutingFilter
 
 appender.routing.type = PipelineRouting
@@ -57,6 +69,12 @@ appender.routing.pipeline.policy.type = SizeBasedTriggeringPolicy
 appender.routing.pipeline.policy.size = 100MB
 appender.routing.pipeline.strategy.type = DefaultRolloverStrategy
 appender.routing.pipeline.strategy.max = 30
+appender.routing.pipeline.strategy.action.type = Delete
+appender.routing.pipeline.strategy.action.basepath = ${sys:ls.logs}
+appender.routing.pipeline.strategy.action.condition.type = IfFileName
+appender.routing.pipeline.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}*.log.gz
+appender.routing.pipeline.strategy.action.condition.nested_condition.type = IfLastModified
+appender.routing.pipeline.strategy.action.condition.nested_condition.age = 7D
 
 rootLogger.level = ${sys:ls.log.level}
 rootLogger.appenderRef.console.ref = ${sys:ls.log.format}_console

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -1,4 +1,4 @@
-status = trace
+status = error
 name = LogstashPropertiesConfig
 
 appender.console.type = Console

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -48,6 +48,68 @@ The logger is usually identified by a Java class name, such as
 path as in `org.logstash.dissect`.  For Ruby classes, like `LogStash::Outputs::Elasticsearch`,
 the logger name is obtained by lowercasing the full class name and replacing double colons with a single dot.
 
+It's strongly recommended to use the default log4j configuration that's shipped with {ls}, however the
+following section describe in detail how the rolling strategy works, so you have more control on these settings.
+
+In `log4j2.properties` file are defined three appenders to write on log files: one for plain text, one with json format,
+and another to split log lines on per pipeline basis when using the `pipeline.separate_logs` setting.
+These appenders define triggering policies and rollover strategy. The triggering policy determines if a rollover
+should be performed, while the strategy defines how the rollover should be done.
+In default definition are used two triggering policies: time and size. The time policy defines to create one file per day
+while the size policy force to create a new file every time the size surpasses a limit (100 MB by default).
+
+The default strategy defines to roll logs up to a maximum number of 30 files and also specify to execute the delete action on
+files older than seven days.
+This means that for each day, a maximum of 30 files is created. When the 31-st has to be created a rollover happen, the first
+is removed, all the other are renamed, so that 2nd becomes 1st, and 30th becomes 29th, so creating the space for the new file.
+Each file has a date and if the files are older than seven days they are removed on the rollover execution.
+
+[source,text]
+----------------------------------
+appender.rolling.type = RollingFile <1>
+appender.rolling.name = plain_rolling
+appender.rolling.fileName = ${sys:ls.logs}/logstash-plain.log <2>
+appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}-%i.log.gz <3>
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy <4>
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy <5>
+appender.rolling.policies.size.size = 100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 30 <6>
+appender.rolling.strategy.action.type = Delete <7>
+appender.rolling.strategy.action.basepath = ${sys:ls.logs}
+appender.rolling.strategy.action.condition.type = IfFileName
+appender.rolling.strategy.action.condition.glob = logstash-plain-* <8>
+appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
+appender.rolling.strategy.action.condition.nested_condition.age = 7D <9>
+----------------------------------
+<1> The appender type, which rolls older log files.
+<2> Name of the current log file.
+<3> Name's format definition of the rolled files, in this case a date followed by an incremental number (up to 30, in this case).
+<4> Time policy to trigger a rollover at the end of the day.
+<5> Size policy to trigger a rollover once the plain text file reaches the dimension of 100 MB.
+<6> Rollover strategy defines a maximum of 30 files.
+<7> Action to execute during the rollover.
+<8> The file set to consider by the action.
+<9> Condition to execute the rollover action, so older than 7 days.
+
+The conditions matched by the rollover action can also enforce a space limitation, in such case deletes older files to match
+the requested condition, as an example:
+
+[source,text]
+----------------------------------
+appender.rolling.type = RollingFile
+...
+appender.rolling.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}.*.log.gz
+appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
+appender.rolling.strategy.action.condition.nested_condition.exceeds = 5MB <1>
+----------------------------------
+<1> Only delete if we have accumulated too many compressed logs.
+
 ==== Logging APIs
 
 For temporary logging changes, modifying the `log4j2.properties` file and restarting Logstash leads to unnecessary

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -64,7 +64,38 @@ This means that for each day, a maximum of 30 files is created. When the 31-st h
 is removed, all the other are renamed, so that 2nd becomes 1st, and 30th becomes 29th, so creating the space for the new file.
 Each file has a date and if the files are older than seven days they are removed on the rollover execution.
 
-
+[source,text]
+----------------------------------
+appender.rolling.type = RollingFile <1>
+appender.rolling.name = plain_rolling
+appender.rolling.fileName = ${sys:ls.logs}/logstash-plain.log <2>
+appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}-%i.log.gz <3>
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy <4>
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy <5>
+appender.rolling.policies.size.size = 100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 30 <6>
+appender.rolling.strategy.action.type = Delete <7>
+appender.rolling.strategy.action.basepath = ${sys:ls.logs}
+appender.rolling.strategy.action.condition.type = IfFileName
+appender.rolling.strategy.action.condition.glob = logstash-plain-* <8>
+appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
+appender.rolling.strategy.action.condition.nested_condition.age = 7D <9>
+----------------------------------
+<1> The appender type, which rolls older log files.
+<2> Name of the current log file.
+<3> Name's format definition of the rolled files, in this case a date followed by an incremental number (up to 30, in this case).
+<4> Time policy to trigger a rollover at the end of the day.
+<5> Size policy to trigger a rollover once the plain text file reaches the dimension of 100 MB.
+<6> Rollover strategy defines a maximum of 30 files.
+<7> Action to execute during the rollover.
+<8> The file set to consider by the action.
+<9> Condition to execute the rollover action, so older than 7 days.
 
 The conditions matched by the rollover action can also enforce a space limitation, in such case deletes older files to match
 the requested condition, as an example:

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -67,7 +67,7 @@ By default, two triggering policies are defined--time and size.
 * The **time** policy creates one file per day.
 * The **size** policy forces the creation of a new file after the file size surpasses 100 MB.
 
-The default strategy also performs file rollovers based on a maximum number files.
+The default strategy also performs file rollovers based on a **maximum number of files**.
 When the limit of 30 files has been reached, the first (oldest) file is removed to create space for the new file.
 Subsequent files are renumbered accordingly. 
 

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -48,20 +48,30 @@ The logger is usually identified by a Java class name, such as
 path as in `org.logstash.dissect`.  For Ruby classes, like `LogStash::Outputs::Elasticsearch`,
 the logger name is obtained by lowercasing the full class name and replacing double colons with a single dot.
 
-It's strongly recommended to use the default log4j configuration that's shipped with {ls}, however the
-following section describe in detail how the rolling strategy works, so you have more control on these settings.
+NOTE: Consider using the default log4j configuration that is shipped with {ls}, as it is configured to work well for most deployments.  
+The next section describes how the rolling strategy works in case you need to make adjustments.
 
-In `log4j2.properties` file are defined three appenders to write on log files: one for plain text, one with json format,
-and another to split log lines on per pipeline basis when using the `pipeline.separate_logs` setting.
-These appenders define triggering policies and rollover strategy. The triggering policy determines if a rollover
-should be performed, while the strategy defines how the rollover should be done.
-By default definition two triggering policies are used: time and size. The time policy creates one file per day
-while the size policy forces the creation of a new file once the file size surpasses 100 MB.
+[[rollover]]
+===== Rollover settings
 
-The default strategy also performs file rollovers to a maximum number of 30 files and also deletes files older than seven days.
-The rollover limit imposes that a maximum of 30 files is created. When the 31-st has to be created a rollover happen the first
-is removed - all the other are renamed - so that 2nd becomes 1st and 30th becomes 29th, creating the space for the new file.
-Each file will have a date and if the files are older than 7 days (by default) they are removed during rollover.
+The `log4j2.properties` file has three appenders for writing to log files: 
+one for plain text, one with json format, and one to split log lines on per pipeline basis when you set the `pipeline.separate_logs` value.
+
+These appenders define: 
+
+* **triggering policies** that determine _if_ a rollover should be performed, and 
+* **rollover strategy**  to defines _how_ the rollover should be done.
+
+By default, two triggering policies are defined--time and size.
+
+* The **time** policy creates one file per day.
+* The **size** policy forces the creation of a new file after the file size surpasses 100 MB.
+
+The default strategy also performs file rollovers based on a maximum number files.
+When the limit of 30 files has been reached, the first (oldest) file is removed to create space for the new file.
+Subsequent files are renumbered accordingly. 
+
+Each file has a date, and files older than 7 days (default) are removed during rollover.
 
 [source,text]
 ----------------------------------
@@ -107,7 +117,7 @@ appender.rolling.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}.*.
 appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
 appender.rolling.strategy.action.condition.nested_condition.exceeds = 5MB <1>
 ----------------------------------
-<1> Delete files if total accumulated compressed file size is over 5MB.
+<1> Deletes files if total accumulated compressed file size is over 5MB.
 
 ==== Logging APIs
 

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -69,7 +69,15 @@ Each file has a date and if the files are older than seven days they are removed
 The conditions matched by the rollover action can also enforce a space limitation, in such case deletes older files to match
 the requested condition, as an example:
 
-
+[source,text]
+----------------------------------
+appender.rolling.type = RollingFile
+...
+appender.rolling.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}.*.log.gz
+appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
+appender.rolling.strategy.action.condition.nested_condition.exceeds = 5MB <1>
+----------------------------------
+<1> Only delete if we have accumulated too many compressed logs.
 
 ==== Logging APIs
 

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -64,51 +64,12 @@ This means that for each day, a maximum of 30 files is created. When the 31-st h
 is removed, all the other are renamed, so that 2nd becomes 1st, and 30th becomes 29th, so creating the space for the new file.
 Each file has a date and if the files are older than seven days they are removed on the rollover execution.
 
-[source,text]
-----------------------------------
-appender.rolling.type = RollingFile <1>
-appender.rolling.name = plain_rolling
-appender.rolling.fileName = ${sys:ls.logs}/logstash-plain.log <2>
-appender.rolling.filePattern = ${sys:ls.logs}/logstash-plain-%d{yyyy-MM-dd}-%i.log.gz <3>
-appender.rolling.policies.type = Policies
-appender.rolling.policies.time.type = TimeBasedTriggeringPolicy <4>
-appender.rolling.policies.time.interval = 1
-appender.rolling.policies.time.modulate = true
-appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c]%notEmpty{[%X{pipeline.id}]}%notEmpty{[%X{plugin.id}]} %m%n
-appender.rolling.policies.size.type = SizeBasedTriggeringPolicy <5>
-appender.rolling.policies.size.size = 100MB
-appender.rolling.strategy.type = DefaultRolloverStrategy
-appender.rolling.strategy.max = 30 <6>
-appender.rolling.strategy.action.type = Delete <7>
-appender.rolling.strategy.action.basepath = ${sys:ls.logs}
-appender.rolling.strategy.action.condition.type = IfFileName
-appender.rolling.strategy.action.condition.glob = logstash-plain-* <8>
-appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
-appender.rolling.strategy.action.condition.nested_condition.age = 7D <9>
-----------------------------------
-<1> The appender type, which rolls older log files.
-<2> Name of the current log file.
-<3> Name's format definition of the rolled files, in this case a date followed by an incremental number (up to 30, in this case).
-<4> Time policy to trigger a rollover at the end of the day.
-<5> Size policy to trigger a rollover once the plain text file reaches the dimension of 100 MB.
-<6> Rollover strategy defines a maximum of 30 files.
-<7> Action to execute during the rollover.
-<8> The file set to consider by the action.
-<9> Condition to execute the rollover action, so older than 7 days.
+
 
 The conditions matched by the rollover action can also enforce a space limitation, in such case deletes older files to match
 the requested condition, as an example:
 
-[source,text]
-----------------------------------
-appender.rolling.type = RollingFile
-...
-appender.rolling.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}.*.log.gz
-appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
-appender.rolling.strategy.action.condition.nested_condition.exceeds = 5MB <1>
-----------------------------------
-<1> Only delete if we have accumulated too many compressed logs.
+
 
 ==== Logging APIs
 

--- a/docs/static/logging.asciidoc
+++ b/docs/static/logging.asciidoc
@@ -55,14 +55,13 @@ In `log4j2.properties` file are defined three appenders to write on log files: o
 and another to split log lines on per pipeline basis when using the `pipeline.separate_logs` setting.
 These appenders define triggering policies and rollover strategy. The triggering policy determines if a rollover
 should be performed, while the strategy defines how the rollover should be done.
-In default definition are used two triggering policies: time and size. The time policy defines to create one file per day
-while the size policy force to create a new file every time the size surpasses a limit (100 MB by default).
+By default definition two triggering policies are used: time and size. The time policy creates one file per day
+while the size policy forces the creation of a new file once the file size surpasses 100 MB.
 
-The default strategy defines to roll logs up to a maximum number of 30 files and also specify to execute the delete action on
-files older than seven days.
-This means that for each day, a maximum of 30 files is created. When the 31-st has to be created a rollover happen, the first
-is removed, all the other are renamed, so that 2nd becomes 1st, and 30th becomes 29th, so creating the space for the new file.
-Each file has a date and if the files are older than seven days they are removed on the rollover execution.
+The default strategy also performs file rollovers to a maximum number of 30 files and also deletes files older than seven days.
+The rollover limit imposes that a maximum of 30 files is created. When the 31-st has to be created a rollover happen the first
+is removed - all the other are renamed - so that 2nd becomes 1st and 30th becomes 29th, creating the space for the new file.
+Each file will have a date and if the files are older than 7 days (by default) they are removed during rollover.
 
 [source,text]
 ----------------------------------
@@ -89,15 +88,15 @@ appender.rolling.strategy.action.condition.nested_condition.age = 7D <9>
 ----------------------------------
 <1> The appender type, which rolls older log files.
 <2> Name of the current log file.
-<3> Name's format definition of the rolled files, in this case a date followed by an incremental number (up to 30, in this case).
+<3> Name's format definition of the rolled files, in this case a date followed by an incremental number, up to 30 (by default).
 <4> Time policy to trigger a rollover at the end of the day.
-<5> Size policy to trigger a rollover once the plain text file reaches the dimension of 100 MB.
+<5> Size policy to trigger a rollover once the plain text file reaches the size of 100 MB.
 <6> Rollover strategy defines a maximum of 30 files.
 <7> Action to execute during the rollover.
 <8> The file set to consider by the action.
-<9> Condition to execute the rollover action, so older than 7 days.
+<9> Condition to execute the rollover action: older than 7 days.
 
-The conditions matched by the rollover action can also enforce a space limitation, in such case deletes older files to match
+The rollover action can also enforce a disk usage limit, deleting older files to match
 the requested condition, as an example:
 
 [source,text]
@@ -108,7 +107,7 @@ appender.rolling.strategy.action.condition.glob = pipeline_${ctx:pipeline.id}.*.
 appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
 appender.rolling.strategy.action.condition.nested_condition.exceeds = 5MB <1>
 ----------------------------------
-<1> Only delete if we have accumulated too many compressed logs.
+<1> Delete files if total accumulated compressed file size is over 5MB.
 
 ==== Logging APIs
 


### PR DESCRIPTION
**Docs PREVIEW:** https://logstash_bk_16179.docs-preview.app.elstc.co/guide/en/logstash/master/logging.html#log4j2

## Release notes

Update logging configuration to remove rolled files older than seven days.

## What does this PR do?

Updates the plain, json and pipeline appenders in default `config/log4j2.properties` to define a delete rule executed during the rollover strategy, which deletes compressed log archives older than 7 days.
Updates the documentation that the describe the logging configuration to explain how the rollover file works, how to configure the strategy in particular how also update to have space limitation condition on the rollover.

## Why is it important/What is the impact to the user?

With this commit the user doesn't have anymore problems of disk space exhaustion due to aged log files.

## Checklist


- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] test locally.

## How to test this PR locally

Change the rollover strategy to use a space limitation (for example 5MB) and use a pipeline that generates log lines, then check that during Logstash execution the files are properly deleted.

#### Log strategy definition
In `log4j2.properties` replace
```
appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
appender.rolling.strategy.action.condition.nested_condition.age = 7D
```

with:
```
appender.routing.pipeline.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
appender.routing.pipeline.strategy.action.condition.nested_condition.exceeds = 5MB
```

#### Pipeline to generate logs
Launch Logstash with following pipeline:
```
input {
  generator {
    message => '{"name": "John", "surname": "Doe"}'
    codec => json
  }
}

filter {
  ruby {
    code => 'logger.info "This is ia very long line logger by the ruby filter, there is one log line for each event and the only  goal is to generate log lines in the log file to test the log4j2 rollover startegy. In particular the size limit."'
  }	
}

output {
  sink {}
}
```

Then check the content of `logs` folder.

## Related issues

- Closes #15930
- Closes #7482 

## Use cases

As a user I don't want the archive log files clutter the local filesystem.

