### PR TITLE
Bundle integration-snmp and remove input-snmp and input-snmptrap from default plugins/docs

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -372,12 +372,12 @@
     "skip-list": true
   },
   "logstash-input-snmp": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-input-snmptrap": {
-    "default-plugins": true,
-    "skip-list": false
+    "default-plugins": false,
+    "skip-list": true
   },
   "logstash-input-sqs": {
     "default-plugins": false,
@@ -434,7 +434,7 @@
     "skip-list": false
   },
   "logstash-integration-snmp": {
-    "default-plugins": false,
+    "default-plugins": true,
     "skip-list": false
   },
   "logstash-integration-aws": {


### PR DESCRIPTION
#### Description
The new [snmp-integration-plugin](https://github.com/logstash-plugins/logstash-integration-snmp) combines the [logstash-input-snmp](https://github.com/logstash-plugins/logstash-input-snmp) and [logstash-input-snmptrap](https://github.com/logstash-plugins/logstash-input-snmptrap) plugins into one, and is meant to replace the individual plugins. This PR makes it a default plugin, and removes the individual ones from the default and docs listing.

#### Test
Clean install with default gems will create a `Gemfile` which includes the SNMP integration plugin:

```shell
./gradlew clean bootstrap assemble installDefaultGems
```