### PR TITLE
p2p: adds opt-in pipeline bus with less synchronization

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -161,6 +161,17 @@ test {
 }
 test.dependsOn javaTests, rubyTests
 
+tasks {
+    javadoc {
+        (options as StandardJavadocDocletOptions)
+                .tags(
+                        "apiNote:a:API Note:",
+                        "implSpec:a:Implementation Requirements:",
+                        "implNote:a:Implementation Note:"
+                )
+    }
+}
+
 artifacts {
     sources(sourcesJar) {
         // Weird Gradle quirk where type will be used for the extension, but only for sources

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -58,7 +58,7 @@ class LogStash::Agent
     @convergence_lock = Mutex.new
 
     # Special bus object for inter-pipelines communications. Used by the `pipeline` input/output
-    @pipeline_bus = org.logstash.plugins.pipeline.PipelineBus.new
+    @pipeline_bus = org.logstash.plugins.pipeline.PipelineBus.create
 
     @pipelines_registry = LogStash::PipelinesRegistry.new
 

--- a/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
+++ b/logstash-core/spec/logstash/plugins/builtin/pipeline_input_output_spec.rb
@@ -24,7 +24,7 @@ describe ::LogStash::Plugins::Builtin::Pipeline do
 
   let(:execution_context) { double("execution_context")}
   let(:agent) { double("agent") }
-  let(:pipeline_bus) { org.logstash.plugins.pipeline.PipelineBus.new }
+  let(:pipeline_bus) { org.logstash.plugins.pipeline.PipelineBus.create }
 
   let(:queue) { Queue.new }
 

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/AbstractPipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/AbstractPipelineBus.java
@@ -1,0 +1,53 @@
+package org.logstash.plugins.pipeline;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.RubyUtil;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public abstract class AbstractPipelineBus implements PipelineBus {
+
+    private static final Logger LOGGER = LogManager.getLogger(AbstractPipelineBus.class);
+
+    protected static void doSendEvents(JrubyEventExtLibrary.RubyEvent[] orderedEvents, AddressState.ReadOnly addressState, boolean ensureDelivery) {
+        boolean sendWasSuccess = false;
+        ReceiveResponse lastResponse = null;
+        boolean partialProcessing;
+        int lastFailedPosition = 0;
+        do {
+            Stream<JrubyEventExtLibrary.RubyEvent> clones = Arrays.stream(orderedEvents)
+                    .skip(lastFailedPosition)
+                    .map(e -> e.rubyClone(RubyUtil.RUBY));
+
+            PipelineInput input = addressState.getInput(); // Save on calls to getInput since it's volatile
+            if (input != null) {
+                lastResponse = input.internalReceive(clones);
+                sendWasSuccess = lastResponse.wasSuccess();
+            }
+            partialProcessing = ensureDelivery && !sendWasSuccess;
+            if (partialProcessing) {
+                if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
+                    // when last call to internalReceive generated a fail for the subset of the orderedEvents
+                    // it is handling, restart from the cumulative last-failed position of the batch so that
+                    // the next attempt will operate on a subset that excludes those successfully received.
+                    lastFailedPosition += lastResponse.getSequencePosition();
+                    LOGGER.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
+                            "Will Retry. Root cause {}", addressState.getAddress(), orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());
+                } else {
+                    LOGGER.warn("Attempted to send event to '{}' but that address was unavailable. " +
+                            "Maybe the destination pipeline is down or stopping? Will Retry.", addressState.getAddress());
+                }
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    LOGGER.error("Sleep unexpectedly interrupted in bus retry loop", e);
+                }
+            }
+        } while (partialProcessing);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/AddressState.java
@@ -20,6 +20,7 @@
 
 package org.logstash.plugins.pipeline;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,9 +28,20 @@ import java.util.concurrent.ConcurrentHashMap;
  * Represents the state of an internal address.
  */
 public class AddressState {
+    private final String address;
 
     private final Set<PipelineOutput> outputs = ConcurrentHashMap.newKeySet();
     private volatile PipelineInput input = null;
+
+    private transient ReadOnly readOnlyView;
+
+    public AddressState(final String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return this.address;
+    }
 
     /**
      * Add the given output and ensure associated input's receivers are updated
@@ -90,5 +102,30 @@ public class AddressState {
 
     public Set<PipelineOutput> getOutputs() {
         return outputs;
+    }
+
+    public ReadOnly getReadOnlyView() {
+        if (readOnlyView == null) {
+            this.readOnlyView = new ReadOnly();
+        }
+        return readOnlyView;
+    }
+
+    public class ReadOnly {
+        public String getAddress() {
+            return AddressState.this.getAddress();
+        }
+        public Set<PipelineOutput> getOutputs() {
+            return Collections.unmodifiableSet(AddressState.this.getOutputs());
+        }
+        public PipelineInput getInput() {
+            return AddressState.this.getInput();
+        }
+        public boolean isRunning() {
+            return AddressState.this.isRunning();
+        }
+        public boolean isEmpty() {
+            return AddressState.this.isEmpty();
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -17,31 +17,30 @@
  * under the License.
  */
 
-
 package org.logstash.plugins.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
+import java.util.Optional;
+import java.util.Set;
 
 /**
- * This class is the communication bus for the `pipeline` inputs and outputs to talk to each other.
- * <p>
- * This class is threadsafe.
+ * A {@code PipelineBus} is the communication bus that allows {@link PipelineOutput}s to
+ * send events to {@link PipelineInput}s.
+ *
+ * @implSpec implementations must be threadsafe for all operations.
  */
-public class PipelineBus {
+public interface PipelineBus {
 
-    final ConcurrentHashMap<String, AddressState> addressStates = new ConcurrentHashMap<>();
-    final ConcurrentHashMap<PipelineOutput, ConcurrentHashMap<String, AddressState>> outputsToAddressStates = new ConcurrentHashMap<>();
-    volatile boolean blockOnUnlisten = false;
-    private static final Logger logger = LogManager.getLogger(PipelineBus.class);
+    /**
+     * API-stable entry-point for creating a {@link PipelineBus}
+     * @return a new pipeline bus
+     */
+    static PipelineBus create() {
+        return new PipelineBusV1();
+    }
 
     /**
      * Sends events from the provided output.
@@ -50,57 +49,9 @@ public class PipelineBus {
      * @param events         A collection of JRuby events
      * @param ensureDelivery set to true if you want this to retry indefinitely in the event an event send fails
      */
-    public void sendEvents(final PipelineOutput sender,
-                           final Collection<JrubyEventExtLibrary.RubyEvent> events,
-                           final boolean ensureDelivery) {
-        if (events.isEmpty()) return; // This can happen on pipeline shutdown or in some other situations
-
-        synchronized (sender) {
-            final ConcurrentHashMap<String, AddressState> addressesToInputs = outputsToAddressStates.get(sender);
-            // In case of retry on the same set events, a stable order is needed, else
-            // the risk is to reprocess twice some events. Collection can't guarantee order stability.
-            JrubyEventExtLibrary.RubyEvent[] orderedEvents = events.toArray(new JrubyEventExtLibrary.RubyEvent[0]);
-
-            addressesToInputs.forEach((address, addressState) -> {
-                boolean sendWasSuccess = false;
-                ReceiveResponse lastResponse = null;
-                boolean partialProcessing;
-                int lastFailedPosition = 0;
-                do {
-                    Stream<JrubyEventExtLibrary.RubyEvent> clones = Arrays.stream(orderedEvents)
-                            .skip(lastFailedPosition)
-                            .map(e -> e.rubyClone(RubyUtil.RUBY));
-
-                    PipelineInput input = addressState.getInput(); // Save on calls to getInput since it's volatile
-                    if (input != null) {
-                        lastResponse = input.internalReceive(clones);
-                        sendWasSuccess = lastResponse.wasSuccess();
-                    }
-                    partialProcessing = ensureDelivery && !sendWasSuccess;
-                    if (partialProcessing) {
-                        if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
-                            // when last call to internalReceive generated a fail for the subset of the orderedEvents
-                            // it is handling, restart from the cumulative last-failed position of the batch so that
-                            // the next attempt will operate on a subset that excludes those successfully received.
-                            lastFailedPosition += lastResponse.getSequencePosition();
-                            logger.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
-                                    "Will Retry. Root cause {}", address, orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());
-                        } else {
-                            logger.warn("Attempted to send event to '{}' but that address was unavailable. " +
-                                    "Maybe the destination pipeline is down or stopping? Will Retry.", address);
-                        }
-
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            logger.error("Sleep unexpectedly interrupted in bus retry loop", e);
-                        }
-                    }
-                } while (partialProcessing);
-            });
-        }
-    }
+    void sendEvents(PipelineOutput sender,
+                    Collection<JrubyEventExtLibrary.RubyEvent> events,
+                    boolean ensureDelivery);
 
     /**
      * Should be called by an output on register
@@ -108,20 +59,7 @@ public class PipelineBus {
      * @param output    output to be registered
      * @param addresses collection of addresses on which to register this sender
      */
-    public void registerSender(final PipelineOutput output, final Iterable<String> addresses) {
-        synchronized (output) {
-            addresses.forEach((String address) -> {
-                addressStates.compute(address, (k, value) -> {
-                    final AddressState state = value != null ? value : new AddressState();
-                    state.addOutput(output);
-
-                    return state;
-                });
-            });
-
-            updateOutputReceivers(output);
-        }
-    }
+    void registerSender(PipelineOutput output, Iterable<String> addresses);
 
     /**
      * Should be called by an output on close
@@ -129,39 +67,7 @@ public class PipelineBus {
      * @param output    output that will be unregistered
      * @param addresses collection of addresses this sender was registered with
      */
-    public void unregisterSender(final PipelineOutput output, final Iterable<String> addresses) {
-        synchronized (output) {
-            addresses.forEach(address -> {
-                addressStates.computeIfPresent(address, (k, state) -> {
-                    state.removeOutput(output);
-
-                    if (state.isEmpty()) return null;
-
-                    return state;
-                });
-            });
-
-            outputsToAddressStates.remove(output);
-        }
-    }
-
-    /**
-     * Updates the internal state for this output to reflect the fact that there may be a change
-     * in the inputs receiving events from it.
-     *
-     * @param output output to update
-     */
-    private void updateOutputReceivers(final PipelineOutput output) {
-        outputsToAddressStates.compute(output, (k, value) -> {
-            ConcurrentHashMap<String, AddressState> outputAddressToInputMapping = value != null ? value : new ConcurrentHashMap<>();
-
-            addressStates.forEach((address, state) -> {
-                if (state.hasOutput(output)) outputAddressToInputMapping.put(address, state);
-            });
-
-            return outputAddressToInputMapping;
-        });
-    }
+    void unregisterSender(PipelineOutput output, Iterable<String> addresses);
 
     /**
      * Listens to a given address with the provided listener
@@ -171,107 +77,35 @@ public class PipelineBus {
      * @param address Address on which to listen
      * @return true if the listener successfully subscribed
      */
-    public boolean listen(final PipelineInput input, final String address) {
-        synchronized (input) {
-            final boolean[] result = new boolean[1];
-
-            addressStates.compute(address, (k, value) -> {
-                AddressState state = value != null ? value : new AddressState();
-
-                if (state.assignInputIfMissing(input)) {
-                    state.getOutputs().forEach(this::updateOutputReceivers);
-                    result[0] = true;
-                } else {
-                    result[0] = false;
-                }
-
-                return state;
-            });
-
-            return result[0];
-        }
-    }
+    boolean listen(PipelineInput input, String address);
 
     /**
      * Stop listening on the given address with the given listener
-     * Will change behavior depending on whether {@link #isBlockOnUnlisten()} is true or not.
+     * Will change behavior depending on whether {@link #setBlockOnUnlisten(boolean)} is true or not.
      * Will call a blocking method if it is, a non-blocking one if it isn't
      *
      * @param input   Input that should stop listening
      * @param address Address on which the input should stop listening
      * @throws InterruptedException if interrupted while attempting to stop listening
      */
-    public void unlisten(final PipelineInput input, final String address) throws InterruptedException {
-        synchronized (input) {
-            if (isBlockOnUnlisten()) {
-                unlistenBlock(input, address);
-            } else {
-                unlistenNonblock(input, address);
-            }
-        }
-    }
+    void unlisten(PipelineInput input, String address) throws InterruptedException;
 
     /**
-     * Stop listening on the given address with the given listener. Blocks until upstream outputs have
-     * stopped.
+     * Configure behaviour of {@link #unlisten(PipelineInput, String)} to be blocking,
+     * which allows a DAG to shut down senders-first
      *
-     * @param input   Input that should stop listening
-     * @param address Address on which to stop listening
-     * @throws InterruptedException if interrupted while attempting to stop listening
+     * @param blockOnUnlisten true iff future invocations of {@link #unlisten} should block
      */
-    private void unlistenBlock(final PipelineInput input, final String address) throws InterruptedException {
-        final boolean[] waiting = {true};
-
-        // Block until all senders are done
-        // Outputs shutdown before their connected inputs
-        while (true) {
-            addressStates.compute(address, (k, state) -> {
-                // If this happens the pipeline was asked to shutdown
-                // twice, so there's no work to do
-                if (state == null) {
-                    waiting[0] = false;
-                    return null;
-                }
-
-                if (state.getOutputs().isEmpty()) {
-                    state.unassignInput(input);
-
-                    waiting[0] = false;
-                    return null;
-                }
-
-                return state;
-            });
-
-            if (!waiting[0]) {
-                break;
-            } else {
-                Thread.sleep(100);
-            }
-        }
-    }
+    void setBlockOnUnlisten(boolean blockOnUnlisten);
 
     /**
-     * Unlisten to use during reloads. This lets upstream outputs block while this input is missing
-     *
-     * @param input   Input that should stop listening
-     * @param address Address on which to stop listening
+     * This package-private sub-interface allows implementations to provide testable
+     * hooks without exposing them publicly
      */
     @VisibleForTesting
-    void unlistenNonblock(final PipelineInput input, final String address) {
-        addressStates.computeIfPresent(address, (k, state) -> {
-            state.unassignInput(input);
-            state.getOutputs().forEach(this::updateOutputReceivers);
-            return state.isEmpty() ? null : state;
-        });
-    }
-
-    @VisibleForTesting
-    boolean isBlockOnUnlisten() {
-        return blockOnUnlisten;
-    }
-
-    public void setBlockOnUnlisten(boolean blockOnUnlisten) {
-        this.blockOnUnlisten = blockOnUnlisten;
+    interface Testable extends PipelineBus {
+        @VisibleForTesting Optional<AddressState.ReadOnly> getAddressState(final String address);
+        @VisibleForTesting Optional<Set<AddressState.ReadOnly>> getAddressStates(final PipelineOutput sender);
+        @VisibleForTesting boolean isBlockOnUnlisten();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -20,6 +20,8 @@
 package org.logstash.plugins.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.logstash.ext.JrubyEventExtLibrary;
 
 import java.util.Collection;
@@ -34,12 +36,21 @@ import java.util.Set;
  */
 public interface PipelineBus {
 
+    Logger LOGGER = LogManager.getLogger(PipelineBus.class);
+
     /**
      * API-stable entry-point for creating a {@link PipelineBus}
      * @return a new pipeline bus
      */
     static PipelineBus create() {
-        return new PipelineBusV1();
+        final String pipelineBusImplementation = System.getProperty("logstash.pipelinebus.implementation", "v1");
+        switch (pipelineBusImplementation) {
+            case "v1": return new PipelineBusV1();
+            case "v2": return new PipelineBusV2();
+            default:
+                LOGGER.warn("unknown pipeline-bus implementation: {}", pipelineBusImplementation);
+                return new PipelineBusV1();
+        }
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -43,7 +43,7 @@ public interface PipelineBus {
      * @return a new pipeline bus
      */
     static PipelineBus create() {
-        final String pipelineBusImplementation = System.getProperty("logstash.pipelinebus.implementation", "v1");
+        final String pipelineBusImplementation = System.getProperty("logstash.pipelinebus.implementation", "v2");
         switch (pipelineBusImplementation) {
             case "v1": return new PipelineBusV1();
             case "v2": return new PipelineBusV2();

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV1.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV1.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.plugins.pipeline;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.RubyUtil;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class is the communication bus for the `pipeline` inputs and outputs to talk to each other.
+ * <p>
+ * This class is threadsafe.
+ */
+class PipelineBusV1 implements PipelineBus {
+
+    final ConcurrentHashMap<String, AddressState> addressStates = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<PipelineOutput, ConcurrentHashMap<String, AddressState>> outputsToAddressStates = new ConcurrentHashMap<>();
+    volatile boolean blockOnUnlisten = false;
+    private static final Logger logger = LogManager.getLogger(PipelineBusV1.class);
+
+    @Override
+    public void sendEvents(final PipelineOutput sender,
+                           final Collection<JrubyEventExtLibrary.RubyEvent> events,
+                           final boolean ensureDelivery) {
+        if (events.isEmpty()) return; // This can happen on pipeline shutdown or in some other situations
+
+        synchronized (sender) {
+            final ConcurrentHashMap<String, AddressState> addressesToInputs = outputsToAddressStates.get(sender);
+            // In case of retry on the same set events, a stable order is needed, else
+            // the risk is to reprocess twice some events. Collection can't guarantee order stability.
+            JrubyEventExtLibrary.RubyEvent[] orderedEvents = events.toArray(new JrubyEventExtLibrary.RubyEvent[0]);
+
+            addressesToInputs.forEach((address, addressState) -> {
+                boolean sendWasSuccess = false;
+                ReceiveResponse lastResponse = null;
+                boolean partialProcessing;
+                int lastFailedPosition = 0;
+                do {
+                    Stream<JrubyEventExtLibrary.RubyEvent> clones = Arrays.stream(orderedEvents)
+                            .skip(lastFailedPosition)
+                            .map(e -> e.rubyClone(RubyUtil.RUBY));
+
+                    PipelineInput input = addressState.getInput(); // Save on calls to getInput since it's volatile
+                    if (input != null) {
+                        lastResponse = input.internalReceive(clones);
+                        sendWasSuccess = lastResponse.wasSuccess();
+                    }
+                    partialProcessing = ensureDelivery && !sendWasSuccess;
+                    if (partialProcessing) {
+                        if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
+                            // when last call to internalReceive generated a fail for the subset of the orderedEvents
+                            // it is handling, restart from the cumulative last-failed position of the batch so that
+                            // the next attempt will operate on a subset that excludes those successfully received.
+                            lastFailedPosition += lastResponse.getSequencePosition();
+                            logger.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
+                                    "Will Retry. Root cause {}", address, orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());
+                        } else {
+                            logger.warn("Attempted to send event to '{}' but that address was unavailable. " +
+                                    "Maybe the destination pipeline is down or stopping? Will Retry.", address);
+                        }
+
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            logger.error("Sleep unexpectedly interrupted in bus retry loop", e);
+                        }
+                    }
+                } while (partialProcessing);
+            });
+        }
+    }
+
+    /**
+     * Should be called by an output on register
+     *
+     * @param output    output to be registered
+     * @param addresses collection of addresses on which to register this sender
+     */
+    @Override
+    public void registerSender(final PipelineOutput output, final Iterable<String> addresses) {
+        synchronized (output) {
+            addresses.forEach((String address) -> {
+                addressStates.compute(address, (k, value) -> {
+                    final AddressState state = value != null ? value : new AddressState(address);
+                    state.addOutput(output);
+
+                    return state;
+                });
+            });
+
+            updateOutputReceivers(output);
+        }
+    }
+
+    @Override
+    public void unregisterSender(final PipelineOutput output, final Iterable<String> addresses) {
+        synchronized (output) {
+            addresses.forEach(address -> {
+                addressStates.computeIfPresent(address, (k, state) -> {
+                    state.removeOutput(output);
+
+                    if (state.isEmpty()) return null;
+
+                    return state;
+                });
+            });
+
+            outputsToAddressStates.remove(output);
+        }
+    }
+
+    /**
+     * Updates the internal state for this output to reflect the fact that there may be a change
+     * in the inputs receiving events from it.
+     *
+     * @param output output to update
+     */
+    private void updateOutputReceivers(final PipelineOutput output) {
+        outputsToAddressStates.compute(output, (k, value) -> {
+            ConcurrentHashMap<String, AddressState> outputAddressToInputMapping = value != null ? value : new ConcurrentHashMap<>();
+
+            addressStates.forEach((address, state) -> {
+                if (state.hasOutput(output)) outputAddressToInputMapping.put(address, state);
+            });
+
+            return outputAddressToInputMapping;
+        });
+    }
+
+    @Override
+    public boolean listen(final PipelineInput input, final String address) {
+        synchronized (input) {
+            final boolean[] result = new boolean[1];
+
+            addressStates.compute(address, (k, value) -> {
+                AddressState state = value != null ? value : new AddressState(address);
+
+                if (state.assignInputIfMissing(input)) {
+                    state.getOutputs().forEach(this::updateOutputReceivers);
+                    result[0] = true;
+                } else {
+                    result[0] = false;
+                }
+
+                return state;
+            });
+
+            return result[0];
+        }
+    }
+
+    @Override
+    public void unlisten(final PipelineInput input, final String address) throws InterruptedException {
+        synchronized (input) {
+            if (this.blockOnUnlisten) {
+                unlistenBlock(input, address);
+            } else {
+                unlistenNonblock(input, address);
+            }
+        }
+    }
+
+    /**
+     * Stop listening on the given address with the given listener. Blocks until upstream outputs have
+     * stopped.
+     *
+     * @param input   Input that should stop listening
+     * @param address Address on which to stop listening
+     * @throws InterruptedException if interrupted while attempting to stop listening
+     */
+    void unlistenBlock(final PipelineInput input, final String address) throws InterruptedException {
+        final boolean[] waiting = {true};
+
+        // Block until all senders are done
+        // Outputs shutdown before their connected inputs
+        while (true) {
+            addressStates.compute(address, (k, state) -> {
+                // If this happens the pipeline was asked to shutdown
+                // twice, so there's no work to do
+                if (state == null) {
+                    waiting[0] = false;
+                    return null;
+                }
+
+                final Set<PipelineOutput> outputs = state.getOutputs();
+                if (outputs.isEmpty()) {
+                    state.unassignInput(input);
+
+                    waiting[0] = false;
+                    return null;
+                } else {
+                    logger.info(() -> String.format("input `%s` is not ready to unlisten from `%s` because the address still has attached senders (%s)", input.getId(), address, outputs.stream().map(PipelineOutput::getId).collect(Collectors.toSet())));
+                }
+
+                return state;
+            });
+
+            if (!waiting[0]) {
+                break;
+            } else {
+                Thread.sleep(100);
+            }
+        }
+    }
+
+    /**
+     * Unlisten to use during reloads. This lets upstream outputs block while this input is missing
+     *
+     * @param input   Input that should stop listening
+     * @param address Address on which to stop listening
+     */
+    void unlistenNonblock(final PipelineInput input, final String address) {
+        addressStates.computeIfPresent(address, (k, state) -> {
+            state.unassignInput(input);
+            state.getOutputs().forEach(this::updateOutputReceivers);
+            return state.isEmpty() ? null : state;
+        });
+    }
+
+    @Override
+    public void setBlockOnUnlisten(boolean blockOnUnlisten) {
+        this.blockOnUnlisten = blockOnUnlisten;
+    }
+
+    @VisibleForTesting
+    static class Testable extends PipelineBusV1 implements PipelineBus.Testable {
+
+        @Override
+        @VisibleForTesting
+        public boolean isBlockOnUnlisten() {
+            return blockOnUnlisten;
+        }
+
+        @Override
+        @VisibleForTesting
+        public Optional<AddressState.ReadOnly> getAddressState(String address) {
+            return Optional.ofNullable(addressStates.get(address)).map(AddressState::getReadOnlyView);
+        }
+
+        @Override
+        @VisibleForTesting
+        public Optional<Set<AddressState.ReadOnly>> getAddressStates(PipelineOutput sender) {
+            return Optional.ofNullable(outputsToAddressStates.get(sender))
+                    .map(ConcurrentHashMap::values)
+                    .map(as -> as.stream().map(AddressState::getReadOnlyView).collect(Collectors.toSet()));
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV1.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV1.java
@@ -22,23 +22,20 @@ package org.logstash.plugins.pipeline;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class is the communication bus for the `pipeline` inputs and outputs to talk to each other.
  * <p>
  * This class is threadsafe.
  */
-class PipelineBusV1 implements PipelineBus {
+class PipelineBusV1 extends AbstractPipelineBus implements PipelineBus {
 
     final ConcurrentHashMap<String, AddressState> addressStates = new ConcurrentHashMap<>();
     final ConcurrentHashMap<PipelineOutput, ConcurrentHashMap<String, AddressState>> outputsToAddressStates = new ConcurrentHashMap<>();
@@ -58,42 +55,7 @@ class PipelineBusV1 implements PipelineBus {
             JrubyEventExtLibrary.RubyEvent[] orderedEvents = events.toArray(new JrubyEventExtLibrary.RubyEvent[0]);
 
             addressesToInputs.forEach((address, addressState) -> {
-                boolean sendWasSuccess = false;
-                ReceiveResponse lastResponse = null;
-                boolean partialProcessing;
-                int lastFailedPosition = 0;
-                do {
-                    Stream<JrubyEventExtLibrary.RubyEvent> clones = Arrays.stream(orderedEvents)
-                            .skip(lastFailedPosition)
-                            .map(e -> e.rubyClone(RubyUtil.RUBY));
-
-                    PipelineInput input = addressState.getInput(); // Save on calls to getInput since it's volatile
-                    if (input != null) {
-                        lastResponse = input.internalReceive(clones);
-                        sendWasSuccess = lastResponse.wasSuccess();
-                    }
-                    partialProcessing = ensureDelivery && !sendWasSuccess;
-                    if (partialProcessing) {
-                        if (lastResponse != null && lastResponse.getStatus() == PipelineInput.ReceiveStatus.FAIL) {
-                            // when last call to internalReceive generated a fail for the subset of the orderedEvents
-                            // it is handling, restart from the cumulative last-failed position of the batch so that
-                            // the next attempt will operate on a subset that excludes those successfully received.
-                            lastFailedPosition += lastResponse.getSequencePosition();
-                            logger.warn("Attempted to send events to '{}' but that address reached error condition with {} events remaining. " +
-                                    "Will Retry. Root cause {}", address, orderedEvents.length - lastFailedPosition, lastResponse.getCauseMessage());
-                        } else {
-                            logger.warn("Attempted to send event to '{}' but that address was unavailable. " +
-                                    "Maybe the destination pipeline is down or stopping? Will Retry.", address);
-                        }
-
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            logger.error("Sleep unexpectedly interrupted in bus retry loop", e);
-                        }
-                    }
-                } while (partialProcessing);
+                doSendEvents(orderedEvents, addressState.getReadOnlyView(), ensureDelivery);
             });
         }
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV2.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV2.java
@@ -1,0 +1,184 @@
+package org.logstash.plugins.pipeline;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.logstash.ext.JrubyEventExtLibrary;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+class PipelineBusV2 extends AbstractPipelineBus implements PipelineBus {
+
+    // The canonical source of truth for mapping addresses to their AddressStates
+    protected final AddressStateMapping addressStates = new AddressStateMapping();
+
+    // A cached mapping from any given registered sender (PipelineOutput) to a query-only view of
+    // the AddressState-s to which it is registered.
+    protected final Map<PipelineOutput, Set<AddressState.ReadOnly>> addressStatesBySender = new ConcurrentHashMap<>();
+
+    // effectively a set-on-shutdown flag
+    protected volatile boolean blockOnUnlisten = false;
+
+    private static final Logger LOGGER = LogManager.getLogger(PipelineBusV2.class);
+
+    @Override
+    public void sendEvents(final PipelineOutput sender,
+                           final Collection<JrubyEventExtLibrary.RubyEvent> events,
+                           final boolean ensureDelivery) {
+        if (events.isEmpty()) return;
+
+        final Set<AddressState.ReadOnly> addressStates = addressStatesBySender.get(sender);
+        if (addressStates == null) {
+            throw new IllegalStateException("cannot send events from unregistered sender");
+        }
+
+        // In case of retry on the same set events, a stable order is needed, else
+        // the risk is to reprocess twice some events. Collection can't guarantee order stability.
+        JrubyEventExtLibrary.RubyEvent[] orderedEvents = events.toArray(new JrubyEventExtLibrary.RubyEvent[0]);
+
+        addressStates.forEach(addressState -> doSendEvents(orderedEvents, addressState, ensureDelivery));
+    }
+
+    @Override
+    public void registerSender(final PipelineOutput sender,
+                               final Iterable<String> addresses) {
+        Objects.requireNonNull(sender, "sender must not be null");
+        Objects.requireNonNull(addresses, "addresses must not be null");
+        addressStatesBySender.compute(sender, (po, existing) -> {
+            return StreamSupport.stream(addresses.spliterator(), false)
+                                .map((addr) -> addressStates.mutate(addr, (as) -> as.addOutput(po)))
+                                .collect(Collectors.toUnmodifiableSet());
+        });
+    }
+
+    @Override
+    public void unregisterSender(final PipelineOutput sender,
+                                 final Iterable<String> addresses) {
+        Objects.requireNonNull(sender, "sender must not be null");
+        Objects.requireNonNull(addresses, "addresses must not be null");
+        addressStatesBySender.compute(sender, (po, existing) -> {
+            addresses.forEach((addr) -> addressStates.mutate(addr, (as) -> as.removeOutput(po)));
+            return null;
+        });
+    }
+
+    @Override
+    public boolean listen(final PipelineInput listener,
+                          final String address) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        Objects.requireNonNull(address, "address must not be null");
+        final AddressState.ReadOnly result = addressStates.mutate(address, (addressState) -> {
+            addressState.assignInputIfMissing(listener);
+        });
+        return (result != null && result.getInput() == listener);
+    }
+
+    @Override
+    public void unlisten(final PipelineInput listener,
+                         final String address) throws InterruptedException {
+        Objects.requireNonNull(listener, "listener must not be null");
+        Objects.requireNonNull(address, "address must not be null");
+        if (this.blockOnUnlisten) {
+            unlistenBlocking(listener, address);
+        } else {
+            unlistenNonblock(listener, address);
+        }
+    }
+
+    private void unlistenNonblock(final PipelineInput listener,
+                                   final String address) {
+        addressStates.mutate(address, (addressState) -> addressState.unassignInput(listener));
+    }
+
+    private void unlistenBlocking(final PipelineInput listener,
+                          final String address) throws InterruptedException {
+        synchronized (Objects.requireNonNull(listener, "listener must not be null")) {
+            while(!tryUnlistenOrphan(listener, address)) {
+                listener.wait(10000);
+            }
+        }
+    }
+
+    /**
+     * Makes a singular attempt to unlisten to the address that succeeds if and only if
+     * there are no senders registered to the address
+     * @param listener the {@link PipelineInput} that to unlisten
+     * @param address the address from which to unlisten
+     * @return true iff this listener is not listening after the attempt
+     */
+    private boolean tryUnlistenOrphan(final PipelineInput listener,
+                                      final String address) {
+        final AddressState.ReadOnly result = addressStates.mutate(address, (addressState) -> {
+            final Set<PipelineOutput> outputs = addressState.getOutputs();
+            if (outputs.isEmpty()) {
+                addressState.unassignInput(listener);
+            } else {
+                LOGGER.trace(() -> String.format("input `%s` is not ready to unlisten from `%s` because the address still has attached senders (%s)", listener.getId(), address, outputs.stream().map(PipelineOutput::getId).collect(Collectors.toSet())));
+            }
+        });
+        return result == null || result.getInput() != listener;
+    }
+
+    @Override
+    public void setBlockOnUnlisten(final boolean blockOnUnlisten) {
+        this.blockOnUnlisten = blockOnUnlisten;
+    }
+
+    protected static class AddressStateMapping {
+
+        private final Map<String, AddressState> mapping = new ConcurrentHashMap<>();
+
+        public AddressState.ReadOnly mutate(final String address,
+                                            final Consumer<AddressState> consumer) {
+            final AddressState result = mapping.compute(address, (a, addressState) -> {
+                if (addressState == null) {
+                    addressState = new AddressState(address);
+                }
+
+                consumer.accept(addressState);
+
+                // If this addressState has a listener, ensure that any waiting
+                // threads get notified so that they can resume immediately
+                final PipelineInput currentInput = addressState.getInput();
+                if (currentInput != null) {
+                    synchronized (currentInput) { currentInput.notifyAll(); }
+                }
+
+                return addressState.isEmpty() ? null : addressState;
+            });
+            return result == null ? null : result.getReadOnlyView();
+        }
+
+        private AddressState.ReadOnly get(final String address) {
+            final AddressState result = mapping.get(address);
+            return result == null ? null : result.getReadOnlyView();
+        }
+    }
+
+    @VisibleForTesting
+    static class Testable extends PipelineBusV2 implements PipelineBus.Testable {
+
+        @Override
+        @VisibleForTesting
+        public boolean isBlockOnUnlisten() {
+            return this.blockOnUnlisten;
+        }
+
+        @Override
+        @VisibleForTesting
+        public Optional<AddressState.ReadOnly> getAddressState(final String address) {
+            return Optional.ofNullable(addressStates.get(address));
+        }
+
+        @Override
+        @VisibleForTesting
+        public Optional<Set<AddressState.ReadOnly>> getAddressStates(final PipelineOutput sender) {
+            return Optional.ofNullable(addressStatesBySender.get(sender));
+        }
+
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineInput.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineInput.java
@@ -40,6 +40,8 @@ public interface PipelineInput {
      */
     ReceiveResponse internalReceive(Stream<JrubyEventExtLibrary.RubyEvent> events);
 
+    String getId();
+
     /**
      * @return true if the input is running
      */

--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineOutput.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineOutput.java
@@ -24,4 +24,5 @@ package org.logstash.plugins.pipeline;
  * Represents the out endpoint of a pipeline to pipeline communication.
  * */
 public interface PipelineOutput {
+    String getId();
 }

--- a/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
 
@@ -34,10 +36,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Stream;
 
+@RunWith(Parameterized.class)
 public class PipelineBusTest {
     static String address = "fooAddr";
     static String otherAddress = "fooAddr";
     static Collection<String> addresses = Arrays.asList(address, otherAddress);
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Class<? extends PipelineBus.Testable>> data() {
+        return Set.of(PipelineBusV1.Testable.class, PipelineBusV2.Testable.class);
+    }
+
+    @Parameterized.Parameter
+    public Class<PipelineBus.Testable> busClass;
 
     PipelineBus.Testable bus;
     TestPipelineInput input;
@@ -45,7 +56,7 @@ public class PipelineBusTest {
 
     @Before
     public void setup() throws ReflectiveOperationException {
-        bus = new PipelineBusV1.Testable();
+        bus = busClass.getDeclaredConstructor().newInstance();
         input = new TestPipelineInput();
         output = new TestPipelineOutput();
     }


### PR DESCRIPTION
## Release notes

 - Improves the performance of pipeline-to-pipeline in some configurations where a single pipeline output sends to many downstream pipelines

## What does this PR do?

Adds a currently opt-in implementation of the pipeline bus that eliminates synchronizing on the sending pipeline so that a pipeline with many workers that is sending to multiple downstream pipelines can better use the resources available to it.

It does so by:
 1. Extracting an interface from the existing `PipelineBus` and renaming the current implementation to `PipelineBusV1`, along with a minor refactor to allow the implementation to make its internals queryable for tests
 2. Extracting the bulk of the complexity for retries and event transmission to `AbstractPipelineBus#doSendEvents` so that `PipelineBusV1` could be solely focused on _routing_
 3. Adds a new `PipelineBusV2` implementation that can be selected by adding `-Dlogstash.pipelinebus.implementation=v2` to `config/jvm.options` or `LS_JAVA_OPTS`

**Each of these steps occurs in a single commit in which tests pass fully.**

My intent is to follow up with making this implementation the default (opt out) and to eventually remove the original implementation. The pace of doing so will be guided by feedback.

## Why is it important/What is the impact to the user?

When using patterns like output-isolator, it is common for one pipeline output to be configured to send all events to multiple downstream pipelines, and the original implementation of the pipeline bus precludes two pipeline workers from transmitting events with the same output plugin simultaneously.

This new implementation safely _removes_ this constraint so that when available CPU is present contention is relieved.

It does _not_ substantially change the throughput when back-pressure is being propagated from a downstream pipeline (such as when its queue is full), but it does improve concurrency of the serialization overhead of downstream PQ's and smooths overall throughput when downstream pipelines are jittery.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. Configure Logstash to have the PQ on by default by setting the following in `config/logstash.yml`:
   
   ~~~ yml
   queue.type: persisted
   queue.max_bytes: 16mb
   queue.page_capacity: 8mb
   ~~~
2. Congifure a graph of pipelines, specifically with one `pipeline` output sending to multiple `pipeline` inputs in other pipelines:
   > ~~~yml
   > - pipeline.id: 00upstream
   >   pipeline.workers: 20
   >   config.string: |
   >     input {
   >       generator { threads => 10 }
   >     }
   >     output {
   >       pipeline {
   >         id => "upstream-source"
   >         send_to => [one, two, three, four]
   >       }
   >     }
   >   queue.type: memory
   > - pipeline.id: 01downstream
   >   config.string: |
   >     input {
   >       pipeline {
   >         id => "downstream-one"
   >         address => one
   >       }
   >     }
   >     filter {
   >       mutate { add_field => { "ok" => "go" } }
   >     }
   >     output {
   >       sink {}
   >     }
   > - pipeline.id: 02downstream
   >   config.string: |
   >     input {
   >       pipeline { 
   >         id => "downstream-two"
   >         address => two
   >       }
   >     }
   >     output {
   >       sink {}
   >     }
   > - pipeline.id: 03downstream
   >   config.string: |
   >     input {
   >       pipeline { 
   >         id => "downstream-three"
   >         address => three
   >       }
   >     }
   >     output {
   >       sink {}
   >     }
   > - pipeline.id: 04downstream
   >   config.string: |
   >     input {
   >       pipeline { 
   >         id => "downstream-four"
   >         address => four
   >       }
   >     }
   >     output {
   >       sink {}
   >     }
   > ~~~
3. Run Logstash, and observe the overall throughput:
   > ~~~
   > bin/logstash
   > ~~~
   > ~~~
   > export FLOW_WINDOW="last_1_minute"; watch --color '(curl --silent -XGET http://localhost:9600/_node/stats | jq --color-output --sort-keys "pick(.process.cpu, .pipelines.[].flow.input_throughput.'${FLOW_WINDOW}', .pipelines.[].flow.output_throughput.'${FLOW_WINDOW}')")'
   > ~~~
   In my case, I observed a throughput of ~35k EPS from the main pipeline while burning only 12% of available CPU, when observing the `last_5_minutes` flow window once it was populated.
   <details>
     <summary>See 35k ESP Screenshot</summary>

     ![V1 Constrained Implementation](https://github.com/elastic/logstash/assets/210924/40263338-129f-459b-849b-bd91b6ce9679)

   </details>
4. Run Logstash again, and observe the overall throughput:
   > ~~~
   > LS_JAVA_OPTS="-Dlogstash.pipelinebus.implementation=v2" bin/logstash
   > ~~~
   > ~~~
   > export FLOW_WINDOW="last_1_minute"; watch --color '(curl --silent -XGET http://localhost:9600/_node/stats | jq --color-output --sort-keys "pick(.process.cpu, .pipelines.[].flow.input_throughput.'${FLOW_WINDOW}', .pipelines.[].flow.output_throughput.'${FLOW_WINDOW}')")'
   > ~~~
   In my case I was able to observe ~126k EPS while taking advantage of 56% of available CPU.
   <details>
     <summary>See 126k EPS Screenshot</summary>

     ![V2 Concurrent Implementation](https://github.com/elastic/logstash/assets/210924/83c69c36-aa17-462b-9d07-d2a65ca1f4b5)

   </details>


## Related issues

Relates: https://github.com/elastic/logstash/issues/16171
