### PR TITLE
Doc: Update headers to indicate level of support for plugins

### DIFF
--- a/docs/include/plugin_header-integration.asciidoc
+++ b/docs/include/plugin_header-integration.asciidoc
@@ -7,6 +7,13 @@
 * Integration version: {version}
 * Released on: {release_date}
 * {changelog_url}[Changelog]
+ifeval::["{support_level}"=="t1"]
+* Level of support = https://www.elastic.co/support/matrix#logstash_plugins[Elastic Tier 1]
+endif::[]
+
+ifeval::["{support_level}"=="t2"]
+* Level of support = https://www.elastic.co/support/matrix#logstash_plugins[Elastic Tier 2]
+endif::[]
 
 For other versions, see the
 {lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].

--- a/docs/include/plugin_header.asciidoc
+++ b/docs/include/plugin_header.asciidoc
@@ -7,6 +7,22 @@
 * Released on: {release_date}
 * {changelog_url}[Changelog]
 
+ifeval::["{support_level}"=="t1"]
+* Level of support = https://www.elastic.co/support/matrix#logstash_plugins[Elastic Tier 1]
+endif::[]
+
+ifeval::["{support_level}"=="t2"]
+* Level of support = https://www.elastic.co/support/matrix#logstash_plugins[Elastic Tier 2]
+endif::[]
+
+ifeval::["{support_level}"=="comm"]
+* Level of support = Community plugin
+endif::[]
+
+ifeval::["{support_level}"=="partner"]
+* Level of support = Partner plugin
+endif::[]
+
 For other versions, see the
 {lsplugindocs}/{type}-{plugin}-index.html[Versioned plugin docs].
 


### PR DESCRIPTION
Related: #15970

For POC, we're starting with these documented support levels: 
* Elastic Tier 1 (t1)
* Elastic Tier 2 (t2)
* Community plugin (comm)
* Partner plugin (partner)

This PR adds the support level to plugin header files for the Logstash Reference (LSR):
* plugin_header.asciidoc
* plugin_header-integration.asciidoc

#### Notes
* "Advertised" and core plugins don't use a header file. Custom information is included in the source file.
* Decisions on how we'll support attributes are ongoing, and may impact this implementation. 

#### Next steps
* If this change gets picked up, it will need to be replicated for the Versioned Plugin Reference (VPR) header files in the `logstash-docs` repo: 
   * [plugin_header-integration.asciidoc](https://github.com/elastic/logstash-docs/blob/versioned_plugin_docs/docs/versioned-plugins/include/6.x/plugin_header-integration.asciidoc)
   * [plugin_header.asciidoc](https://github.com/elastic/logstash-docs/blob/versioned_plugin_docs/docs/versioned-plugins/include/6.x/plugin_header.asciidoc)