### PR TITLE
Pin rexml gem version to 3.2.6

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -25,6 +25,7 @@ gem "rubocop", :group => :development
 gem "belzebuth", :group => :development
 gem "benchmark-ips", :group => :development
 gem "ci_reporter_rspec", "~> 1", :group => :development
+gem "rexml", "3.2.6", :group => :development
 gem "flores", "~> 0.0.8", :group => :development
 gem "json-schema", "~> 2", :group => :development
 gem "logstash-devutils", "~> 2.6.0", :group => :development


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Pin `rexml` gem version to 3.2.6 as the newst releases are breaking the build/CI (to be investigated):

```
checking for onig_region_memsize() in ruby.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/home/runner/work/logstash/logstash/vendor/jruby/bin/jruby
RuntimeError: The compiler failed to generate an executable file.
You have to install development tools first.

try_do at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:456
try_link0 at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:541
try_link at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:556
try_func at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:765
have_func at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:1051
checking_for at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:942
postpone at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:350
open at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:320
postpone at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:350
open at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:320
postpone at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:346
checking_for at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:941
have_func at
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/mkmf.rb:1050
        <main> at extconf.rb:4

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/gems/shared/extensions/universal-java-11/3.1.0/strscan-1.0.3/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/gems/shared/gems/strscan-1.0.3
for inspection.
Results logged to
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/gems/shared/extensions/universal-java-11/3.1.0/strscan-1.0.3/gem_make.out

/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:102:in
`run'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:28:in
`build'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:171:in
`build_extension'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:205:in
`block in build_extensions'
  org/jruby/RubyArray.java:1981:in `each'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:202:in
`build_extensions'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/installer.rb:843:in
`build_extensions'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:72:in
`build_extensions'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:28:in
`install'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/source/rubygems.rb:207:in
`install'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:54:in
`install'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:186:in
`do_install'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:177:in
`block in worker_pool'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:62:in
`apply_func'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:57:in
`block in process_queue'
  org/jruby/RubyKernel.java:1722:in `loop'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:54:in
`process_queue'
/home/runner/work/logstash/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:91:in
`block in create_threads'

An error occurred while installing strscan (1.0.3), and Bundler cannot continue.

In Gemfile:
  ci_reporter_rspec was resolved to 1.0.0, which depends on
    ci_reporter was resolved to 2.1.0, which depends on
      rexml was resolved to 3.2.9, which depends on
        strscan
```