### PR TITLE
json: remove unnecessary dup/freeze in serialization

### DIFF
--- a/logstash-core/lib/logstash/json.rb
+++ b/logstash-core/lib/logstash/json.rb
@@ -33,7 +33,7 @@ module LogStash
     end
 
     def jruby_dump(o, options = {})
-      encoding_normalized_data = normalize_encoding(o.dup).freeze
+      encoding_normalized_data = normalize_encoding(o)
 
       # TODO [guyboertje] remove these comments in 5.0
       # test for enumerable here to work around an omission in JrJackson::Json.dump to


### PR DESCRIPTION

## Release notes

 - reduces overhead of serializing data to JSON slightly

## What does this PR do?

Eliminates an unnecessary `Object#dup` and `Object#freeze` pair during JSON serialization, eliminating a very small amount of overhead. The method we are calling produces a mutated _copy_ when necessary already, and the resulting object does not need to be frozen because it is passed to a library that does not mutate its input.

## Why is it important/What is the impact to the user?

Eliminates overhead

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

 - Relates: #16702
