### PR TITLE
Pin fileutils version to 1.7+

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -20,6 +20,10 @@ gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4.25", :group => :build
 gem "rubyzip", "~> 1", :group => :build
 gem "stud", "~> 0.0.22", :group => :build
+# remove fileutils declaration when start using Ruby 3.2+, by default includes `fileutils-v1.7.0`
+# (https://git.ruby-lang.org/ruby.git/commit/?h=ruby_3_2&id=05caafb4731c796890027cafedaac59dc108a23a)
+# note that the reason to use 1.7.0 is due to https://github.com/logstash-plugins/logstash-integration-aws/issues/28
+gem "fileutils", "~> 1.7"
 
 gem "rubocop", :group => :development
 gem "belzebuth", :group => :development

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -90,7 +90,7 @@ Copyright © 2019 Red Hat, Inc. All rights reserved. “Red Hat,” is a registe
 All other trademarks are the property of their respective owners.
 
 ==========
-Notice for: addressable-2.8.6
+Notice for: addressable-2.8.7
 ----------
 
 Copyright © Bob Aman
@@ -722,7 +722,7 @@ Notice for: aws-eventstream-1.3.0
    limitations under the License.
 
 ==========
-Notice for: aws-partitions-1.929.0
+Notice for: aws-partitions-1.946.0
 ----------
 
 
@@ -929,7 +929,7 @@ Notice for: aws-partitions-1.929.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-cloudfront-1.90.0
+Notice for: aws-sdk-cloudfront-1.92.0
 ----------
 
 
@@ -1136,7 +1136,7 @@ Notice for: aws-sdk-cloudfront-1.90.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-cloudwatch-1.91.0
+Notice for: aws-sdk-cloudwatch-1.92.0
 ----------
 
 
@@ -1343,7 +1343,7 @@ Notice for: aws-sdk-cloudwatch-1.91.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-core-3.196.1
+Notice for: aws-sdk-core-3.197.2
 ----------
 
 
@@ -1550,7 +1550,7 @@ Notice for: aws-sdk-core-3.196.1
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-kms-1.81.0
+Notice for: aws-sdk-kms-1.85.0
 ----------
 
 
@@ -1757,7 +1757,7 @@ Notice for: aws-sdk-kms-1.81.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-resourcegroups-1.61.0
+Notice for: aws-sdk-resourcegroups-1.62.0
 ----------
 
 
@@ -1964,7 +1964,7 @@ Notice for: aws-sdk-resourcegroups-1.61.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-s3-1.151.0
+Notice for: aws-sdk-s3-1.152.3
 ----------
 
 
@@ -2171,7 +2171,7 @@ Notice for: aws-sdk-s3-1.151.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-sns-1.75.0
+Notice for: aws-sdk-sns-1.77.0
 ----------
 
 
@@ -2378,7 +2378,7 @@ Notice for: aws-sdk-sns-1.75.0
    limitations under the License.
 
 ==========
-Notice for: aws-sdk-sqs-1.74.0
+Notice for: aws-sdk-sqs-1.76.0
 ----------
 
 
@@ -5797,7 +5797,7 @@ source: https://github.com/elastic/elastic-transport-ruby/blob/v8.3.0/LICENSE
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========
-Notice for: elasticsearch-7.17.10
+Notice for: elasticsearch-7.17.11
 ----------
 
 source: https://github.com/elastic/elasticsearch-ruby/blob/v5.0.4/elasticsearch-api/LICENSE.txt
@@ -5817,7 +5817,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: elasticsearch-api-7.17.10
+Notice for: elasticsearch-api-7.17.11
 ----------
 
 source: https://github.com/elastic/elasticsearch-ruby/blob/v5.0.4/elasticsearch-transport/LICENSE.txt
@@ -5837,7 +5837,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: elasticsearch-transport-7.17.10
+Notice for: elasticsearch-transport-7.17.11
 ----------
 
 source: https://github.com/elastic/elasticsearch-ruby/blob/v5.0.4/elasticsearch/LICENSE.txt
@@ -6100,7 +6100,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ==========
-Notice for: ffi-1.16.3
+Notice for: ffi-1.17.0
 ----------
 
 source: https://github.com/ffi/ffi/blob/1.9.23/LICENSE
@@ -6156,6 +6156,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+==========
+Notice for: fileutils-1.7.2
+----------
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 ==========
 Notice for: fugit-1.11.0
 ----------
@@ -6292,7 +6318,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========
-Notice for: http-cookie-1.0.5
+Notice for: http-cookie-1.0.6
 ----------
 
 source: https://github.com/sparklemotion/http-cookie/blob/v1.0.3/LICENSE.txt
@@ -9357,7 +9383,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: jruby-openssl-0.14.5
+Notice for: jruby-openssl-0.14.6
 ----------
 
 source: https://github.com/jruby/jruby-openssl/blob/v0.9.21/LICENSE.txt
@@ -9445,7 +9471,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
-Notice for: jwt-2.8.1
+Notice for: jwt-2.8.2
 ----------
 
 source: https://github.com/jwt/ruby-jwt/blob/v2.2.2/LICENSE
@@ -9870,7 +9896,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: net-imap-0.4.11
+Notice for: net-imap-0.4.13
 ----------
 
 # source: https://github.com/ruby/net-imap/blob/v0.3.7/LICENSE.txt
@@ -10057,7 +10083,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: nokogiri-1.16.5
+Notice for: nokogiri-1.16.6
 ----------
 
 source: https://github.com/sparklemotion/nokogiri/blob/v1.8.2/LICENSE.md
@@ -10774,7 +10800,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========
-Notice for: public_suffix-5.0.5
+Notice for: public_suffix-5.1.1
 ----------
 
 Copyright (c) 2009-2018 Simone Carletti <weppos@weppos.net>
@@ -10860,7 +10886,7 @@ THE SOFTWARE.
 
 Made in Japan.
 ==========
-Notice for: racc-1.7.3
+Notice for: racc-1.8.0
 ----------
 
 source: https://github.com/ruby/racc/blob/master/COPYING
@@ -10889,7 +10915,7 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
-Notice for: rack-3.0.11
+Notice for: rack-3.1.3
 ----------
 
 The MIT License (MIT)
@@ -11066,7 +11092,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
-Notice for: rexml-3.2.8
+Notice for: rexml-3.3.0
 ----------
 
 source: https://github.com/ruby/rexml/blob/v3.2.5/LICENSE.txt
@@ -11337,7 +11363,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: sequel-5.80.0
+Notice for: sequel-5.81.0
 ----------
 
 Copyright (c) 2007-2008 Sharon Rosner
@@ -11412,30 +11438,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
-==========
-Notice for: snmp-1.3.2
-----------
-
-Copyright (c) 2004-2014 David R. Halliday
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 ==========
 Notice for: spoon-0.0.6
@@ -11585,6 +11587,33 @@ claims asserted against, such Contributor by reason of your accepting any such w
 additional liability.
 
 END OF TERMS AND CONDITIONS
+
+==========
+Notice for: strscan-3.1.0
+----------
+
+Copyright (C) 1999-2006 Minero Aoki. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 ==========
 Notice for: stud-0.0.23

--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -74,6 +74,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "ffi:",https://github.com/ffi/ffi,BSD-3-CLAUSE
 "ffi-binary-libfixposix:",https://github.com/byteit101/subspawn,Ruby
 "filesize:",https://github.com/dominikh,MIT
+"fileutils:",https://github.com/ruby/fileutils,BSD-2-Clause
 "fugit:",https://github.com/floraison/fugit,MIT
 "gelfd2:",https://github.com/ptqa/gelfd2,Apache-2.0
 "gems:",https://github.com/rubygems/gems,MIT

--- a/tools/dependencies-report/src/main/resources/notices/fileutils-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/fileutils-NOTICE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Pins the `fileutils` to 1.7+ version to apply the [file removal logic updates](https://github.com/ruby/fileutils/commit/ec5d3b84ea1e1d1b13c7dcb5bbe6cd5208c20a49).
Refer to the issue Logstash is facing: 
- https://github.com/logstash-plugins/logstash-integration-aws/issues/28
- https://github.com/ruby/fileutils/issues/111

## Why is it important/What is the impact to the user?
The users who are on Windows OS and using `aws-integration` plugin S3 output feature, are having an issue that many temporary files are left that fileutil couldn't remove. With this change, temp dirs will be removed properly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist
- [ ]

## How to test this PR locally
_Testing this behavior is very hard_. In order to reproduce, as I remember, I did run for 2-3 days to get following exception (see [the details](https://github.com/logstash-plugins/logstash-integration-aws/issues/28)):
```
An error occurred in the `on_complete` 
uploader {:exception=>Errno::ENOTEMPTY, :message=>"Directory not empty - D:/Logstash/temp/718dd509-c0f5-4da5-
b4b4-92608579e799", :path=>"D:\\Logstash\\temp/718dd509-c0f5-4da5-b4b4-
92608579e799/2023/05/25/ls.s3.b21c1c38-1dc2-443e-8491-847968549a30.2023-05-25T09.42.part0.txt.gz", 
:backtrace=>["org/jruby/RubyDir.java:471:in `rmdir'", "C:/Program 
...
```

Exhaustive pipeline status: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/546
To locally test:
- Setup an environment
  - Windows OS with antivirus
  - Clone LS repo with current change and build. I have build artifacts (`rake artifact:all`) and copied generated artifact to Windows host.
  - Setup the pipeline which uploads files to S3
     ```
        input {
          generator {
                id => "generator-id"
                ecs_compatibility => disabled
                count => 1000000
                threads => 10
                codec => json
                lines => [
                    '{"fileset":{"module":"system","name":"asa"},"system":{"auth":{"timestamp":"May 17  05:17:00","ssh":{"source":{"ip":"54.160.29.55"}}}},"event":{"category":"cisco-category", "type":"cisco-type", "data":{"User-Name":"mashhur"}},"client":{"ar_net":"54.160.29.55", "ongisac_ip":"54.160.29.55", "ip":"54.160.29.55"}, "destination": {"ar_net":"54.160.29.55", "ongisac_ip":"54.160.29.55"}, "source": {"ar_net":"54.160.29.55", "ongisac_ip":"54.160.29.55"}, "url":{"ongisac_domain": "ip-172-31-4-132"}, "DstIP":"54.160.29.55","SrcIP":"54.160.29.55","orginalClientSrcIP":"54.160.29.55","ReferencedHost":"ip-172-31-4-132", "dns":{"question": {"ongisac_domain":"example.com/my-path?query=value"}}}'
                ]
              }
        }
        output {
            s3 {
                access_key_id => "{yourAccessID}"
                secret_access_key => "{yourAccessKey}"
                region => "aws-region-n"
                bucket => "buckjet-name"
                codec => "json_lines"
                canned_acl => "private"
                prefix => "test-%{+YYYY.MM.dd}"
                additional_settings => {
                    "force_path_style" => true
                }
                upload_queue_size => 10
                upload_workers_count => 10
                rotation_strategy => "size_and_time"
        	size_file => 500 # make faster rotation, so that upload happens frequently
        	time_file => 1
                temporary_directory => "/elastic/s3-output/temp"
                validate_credentials_on_root_bucket => false
            }
        }
      ```
- Run Logstash multiple times
Note that, I have been running for over 2-days so far didn't face the issue.

## Related issues

- 

## Use cases
- `aws-integration` plugin with s3-output in use, on Windows OS, has especially file scanning tools like antivirus


## Screenshots


## Logs
```
PS C:\ls> .\bin\logstash -f .\config\s3.config.txt
"Using bundled JDK: C:\ls\jdk\bin\java.exe"
Sending Logstash logs to C:/ls/logs which is now configured via log4j2.properties
[2024-06-21T22:16:00,584][INFO ][logstash.runner          ] Log4j configuration path used is: C:\ls\config\log4j2.properties
[2024-06-21T22:16:00,597][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.15.0", "jruby.version"=>"jruby 9.4.7.0 (3.1.4) 2024-04-29 597ff08ac1 OpenJDK 64-Bit Server VM 21.0.3+9-LTS on 21.0.3+9-LTS +indy +jit [x86_64-mswin32]"}
[2024-06-21T22:16:00,597][INFO ][logstash.runner          ] JVM bootstrap flags: [-Xms1g, -Xmx1g, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djruby.compile.invokedynamic=true, -XX:+HeapDumpOnOutOfMemoryError, -Djava.security.egd=file:/dev/urandom, -Dlog4j2.isThreadContextMapInheritable=true, -Dlogstash.jackson.stream-read-constraints.max-string-length=200000000, -Dlogstash.jackson.stream-read-constraints.max-number-length=10000, -Djruby.regexp.interruptible=true, -Djdk.io.File.enableADS=true, --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED, --add-opens=java.base/java.security=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.nio.channels=ALL-UNNAMED, --add-opens=java.base/sun.nio.ch=ALL-UNNAMED, --add-opens=java.management/sun.management=ALL-UNNAMED, -Dio.netty.allocator.maxOrder=11]
[2024-06-21T22:16:00,597][INFO ][logstash.runner          ] Jackson default value override `logstash.jackson.stream-read-constraints.max-string-length` configured to `200000000`
[2024-06-21T22:16:00,597][INFO ][logstash.runner          ] Jackson default value override `logstash.jackson.stream-read-constraints.max-number-length` configured to `10000`
[2024-06-21T22:16:00,678][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
[2024-06-21T22:16:02,119][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600, :ssl_enabled=>false}
[2024-06-21T22:16:02,913][INFO ][org.reflections.Reflections] Reflections took 175 ms to scan 1 urls, producing 138 keys and 481 values
[2024-06-21T22:16:03,062][INFO ][logstash.codecs.json     ] ECS compatibility is enabled but `target` option was not specified. This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant or non-conflicting, feel free to ignore this message)
[2024-06-21T22:16:06,613][INFO ][logstash.codecs.jsonlines] ECS compatibility is enabled but `target` option was not specified. This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant or non-conflicting, feel free to ignore this message)
[2024-06-21T22:16:08,726][INFO ][logstash.javapipeline    ] Pipeline `main` is configured with `pipeline.ecs_compatibility: v8` setting. All plugins in this pipeline will default to `ecs_compatibility => v8` unless explicitly configured otherwise.
[2024-06-21T22:16:09,025][INFO ][logstash.javapipeline    ][main] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>8, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>1000, "pipeline.sources"=>["C:/ls/config/s3.config.txt"], :thread=>"#<Thread:0x4f976cae C:/ls/logstash-core/lib/logstash/java_pipeline.rb:134 run>"}
[2024-06-21T22:16:10,164][INFO ][logstash.javapipeline    ][main] Pipeline Java execution initialization time {"seconds"=>1.14}
[2024-06-21T22:16:10,171][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
[2024-06-21T22:16:10,190][INFO ][logstash.agent           ] Pipelines running {:count=>1, :running_pipelines=>[:main], :non_running_pipelines=>[]}
[2024-06-21T22:16:15,688][INFO ][logstash.javapipeline    ][main] Pipeline terminated {"pipeline.id"=>"main"}
[2024-06-21T22:16:15,848][INFO ][logstash.pipelinesregistry] Removed pipeline from registry successfully {:pipeline_id=>:main}
[2024-06-21T22:16:15,860][INFO ][logstash.runner          ] Logstash shut down.
PS C:\ls>
```
