### PR TITLE
move j2 template to erb in 7.17

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -13,6 +13,7 @@ gem "ruby-progressbar", "~> 1"
 gem "logstash-output-elasticsearch", ">= 10.4.2"
 gem "childprocess", "~> 4", :group => :build
 gem "fpm", "~> 1", ">= 1.14.1", :group => :build # compound due to bugfix https://github.com/jordansissel/fpm/pull/1856
+gem "erb", "~> 2", :group => :build
 gem "gems", "~> 1", :group => :build
 gem "octokit", "~> 4", :group => :build
 gem "rubyzip", "~> 1", :group => :build

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -102,7 +102,7 @@ ironbank_docker_paths:
 public-dockerfiles: public-dockerfiles_oss public-dockerfiles_full public-dockerfiles_ubi8 public-dockerfiles_ironbank
 
 public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S erb -T "-"\
+	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -116,7 +116,7 @@ public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S erb -T "-"\
+	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -130,7 +130,7 @@ public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S erb -T "-"\
+	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -144,10 +144,10 @@ public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Dockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
-	../vendor/jruby/bin/jruby -S erb -T "-"\
+	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 	  elastic_version="${ELASTIC_VERSION}" \
 	  templates/hardening_manifest.yaml.erb > $(ARTIFACTS_DIR)/ironbank/hardening_manifest.yaml && \
-	../vendor/jruby/bin/jruby -S erb -T "-"\
+	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -187,7 +187,7 @@ env2yaml:
 # Generate the Dockerfiles from ERB templates.
 dockerfile: templates/Dockerfile.erb
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
-		../vendor/jruby/bin/jruby -S erb -T "-"\
+		../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
 			created_date="${BUILD_DATE}" \
 			elastic_version="${ELASTIC_VERSION}" \
 			arch="${ARCHITECTURE}" \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,5 @@
 SHELL=/bin/bash
 ELASTIC_REGISTRY ?= docker.elastic.co
-PY_VERSION ?= 3.6.13
-export PATH := ./bin:$(HOME)/.pyenv/bin:$(HOME)/.pyenv/shims:./venv/bin:$(PATH)
 
 # Determine the version to build.
 ELASTIC_VERSION := $(shell ../vendor/jruby/bin/jruby bin/elastic-version)
@@ -24,42 +22,34 @@ DEFAULT_IMAGE_FLAVOR ?= full
 IMAGE_TAG := $(ELASTIC_REGISTRY)/logstash/logstash
 HTTPD ?= logstash-docker-artifact-server
 
-FIGLET := pyfiglet -w 160 -f puffy
-
 all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfiles
-
-lint: venv
-	flake8 tests
 
 # Build from artifacts on the local filesystem, using an http server (running
 # in a container) to provide the artifacts to the Dockerfile.
-build-from-local-full-artifacts: venv dockerfile env2yaml
+build-from-local-full-artifacts: dockerfile env2yaml
 	docker run --rm -d --name=$(HTTPD) \
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
-	pyfiglet -f puffy -w 160 "Building: full"; \
 	docker build --network=host -t $(IMAGE_TAG)-full:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-full data/logstash || \
 	  (docker kill $(HTTPD); false); \
 	docker tag $(IMAGE_TAG)-full:$(VERSION_TAG) $(IMAGE_TAG):$(VERSION_TAG);
 	docker kill $(HTTPD)
 
-build-from-local-oss-artifacts: venv dockerfile env2yaml
+build-from-local-oss-artifacts: dockerfile env2yaml
 	docker run --rm -d --name=$(HTTPD) \
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
-	pyfiglet -f puffy -w 160 "Building: oss"; \
 	docker build --network=host -t $(IMAGE_TAG)-oss:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-oss data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
-build-from-local-ubi8-artifacts: venv dockerfile env2yaml
+build-from-local-ubi8-artifacts: dockerfile env2yaml
 	docker run --rm -d --name=$(HTTPD) \
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
-	pyfiglet -f puffy -w 160 "Building: ubi8"; \
 	docker build --network=host -t $(IMAGE_TAG)-ubi8:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-ubi8 data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
@@ -111,61 +101,61 @@ ironbank_docker_paths:
 
 public-dockerfiles: public-dockerfiles_oss public-dockerfiles_full public-dockerfiles_ubi8 public-dockerfiles_ironbank
 
-public-dockerfiles_full: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
-	jinja2 \
-	  -D created_date='$(BUILD_DATE)' \
-	  -D elastic_version='$(ELASTIC_VERSION)' \
-	  -D arch='${ARCHITECTURE}' \
-	  -D version_tag='$(VERSION_TAG)' \
-	  -D image_flavor='full' \
-	  -D local_artifacts='false' \
-	  -D release='$(RELEASE)' \
-	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-full && \
+public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+		created_date="${BUILD_DATE}" \
+		elastic_version="${ELASTIC_VERSION}" \
+		arch="${ARCHITECTURE}" \
+		version_tag="${VERSION_TAG}" \
+	  release="${RELEASE}" \
+		image_flavor="full" \
+		local_artifacts="false" \
+		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-full" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-full Dockerfile && \
 	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
-public-dockerfiles_oss: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
-	jinja2 \
-	  -D created_date='$(BUILD_DATE)' \
-	  -D elastic_version='$(ELASTIC_VERSION)' \
-	  -D arch='${ARCHITECTURE}' \
-	  -D version_tag='$(VERSION_TAG)' \
-	  -D image_flavor='oss' \
-	  -D local_artifacts='false' \
-	  -D release='$(RELEASE)' \
-	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-oss && \
+public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+		created_date="${BUILD_DATE}" \
+		elastic_version="${ELASTIC_VERSION}" \
+		arch="${ARCHITECTURE}" \
+		version_tag="${VERSION_TAG}" \
+	  release="${RELEASE}" \
+		image_flavor="oss" \
+		local_artifacts="false" \
+		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-oss" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
 	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
-public-dockerfiles_ubi8: venv templates/Dockerfile.j2 docker_paths $(COPY_FILES)
-	jinja2 \
-	  -D created_date='$(BUILD_DATE)' \
-	  -D elastic_version='$(ELASTIC_VERSION)' \
-	  -D arch='${ARCHITECTURE}' \
-	  -D version_tag='$(VERSION_TAG)' \
-	  -D image_flavor='ubi8' \
-	  -D local_artifacts='false' \
-	  -D release='$(RELEASE)' \
-	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-ubi8 && \
+public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+		created_date="${BUILD_DATE}" \
+		elastic_version="${ELASTIC_VERSION}" \
+		arch="${ARCHITECTURE}" \
+		version_tag="${VERSION_TAG}" \
+	  release="${RELEASE}" \
+		image_flavor="ubi8" \
+		local_artifacts="false" \
+		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-ubi8" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 Dockerfile && \
 	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
-public-dockerfiles_ironbank: templates/hardening_manifest.yaml templates/Dockerfile.j2 ironbank_docker_paths $(COPY_IRONBANK_FILES)
-	jinja2 \
-	  -D elastic_version='$(ELASTIC_VERSION)' \
-	  templates/hardening_manifest.yaml > $(ARTIFACTS_DIR)/ironbank/hardening_manifest.yaml && \
-	jinja2 \
-	  -D created_date='$(BUILD_DATE)' \
-	  -D elastic_version='$(ELASTIC_VERSION)' \
-	  -D arch='${ARCHITECTURE}' \
-	  -D version_tag='$(VERSION_TAG)' \
-	  -D image_flavor='ironbank' \
-	  -D local_artifacts='false' \
-	  -D release='$(RELEASE)' \
-	  templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-ironbank && \
+public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Dockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+	  elastic_version="${ELASTIC_VERSION}" \
+	  templates/hardening_manifest.yaml.erb > $(ARTIFACTS_DIR)/ironbank/hardening_manifest.yaml && \
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+		created_date="${BUILD_DATE}" \
+		elastic_version="${ELASTIC_VERSION}" \
+		arch="${ARCHITECTURE}" \
+		version_tag="${VERSION_TAG}" \
+	  release="${RELEASE}" \
+		image_flavor="ironbank" \
+		local_artifacts="false" \
+		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-ironbank" && \
 	cd $(ARTIFACTS_DIR)/ironbank && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-ironbank Dockerfile && \
 	tar -zcf ../logstash-ironbank-$(VERSION_TAG)-docker-build-context.tar.gz scripts Dockerfile hardening_manifest.yaml LICENSE README.md
@@ -182,39 +172,33 @@ push:
 	docker push push.$(IMAGE_TAG):$(VERSION_TAG);
 	docker rmi push.$(IMAGE_TAG):$(VERSION_TAG);
 
-# The tests are written in Python. Make a virtualenv to handle the dependencies.
-venv: requirements.txt
-	LOCAL_PY_VER=`python3 --version 2>&1`&&\
-	echo "Was using $$LOCAL_PY_VER" &&\
-	eval "$$(pyenv init -)" && eval "$$(pyenv init --path)" &&\
-	pyenv install --skip-existing $(PY_VERSION) &&\
-	pyenv local $(PY_VERSION) &&\
-	python3 -mvenv venv && \
-	for i in 0 1 2 3 4 5; do sleep "$i"; pip install -r requirements.txt && break; done &&\
-	touch venv
-
 # Compile "env2yaml", the helper for configuring logstash.yml via environment
 # variables.
 env2yaml:
 	docker run --rm \
 	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
-		-w /usr/src/env2yaml golang:1 go build
+		-e GOARCH=arm64 -e GOOS=linux \
+		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-arm64
+	docker run --rm \
+	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
+		-e GOARCH=amd64 -e GOOS=linux \
+		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-amd64
 
-# Generate the Dockerfiles from Jinja2 templates.
-dockerfile: venv templates/Dockerfile.j2
+# Generate the Dockerfiles from ERB templates.
+dockerfile: templates/Dockerfile.erb
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
-	  jinja2 \
-	    -D created_date='$(BUILD_DATE)' \
-	    -D elastic_version='$(ELASTIC_VERSION)' \
-	    -D arch='${ARCHITECTURE}' \
-	    -D version_tag='$(VERSION_TAG)' \
-	    -D image_flavor='$(FLAVOR)' \
-	    -D local_artifacts='true' \
-	    templates/Dockerfile.j2 > $(ARTIFACTS_DIR)/Dockerfile-$(FLAVOR); \
+		../vendor/jruby/bin/jruby -S erb -T "-"\
+			created_date="${BUILD_DATE}" \
+			elastic_version="${ELASTIC_VERSION}" \
+			arch="${ARCHITECTURE}" \
+			version_tag="${VERSION_TAG}" \
+			image_flavor="${FLAVOR}" \
+			local_artifacts="true" \
+			templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-${FLAVOR}" ; \
 	)
 
 clean:
-	rm -f ${ARTIFACTS_DIR}/env2yaml/env2yaml ${ARTIFACTS_DIR}/Dockerfile
-	rm -rf venv
+	rm -f ${ARTIFACTS_DIR}/env2yaml/env2yaml-* ${ARTIFACTS_DIR}/Dockerfile
+
 
 .PHONY: clean push

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -102,7 +102,7 @@ ironbank_docker_paths:
 public-dockerfiles: public-dockerfiles_oss public-dockerfiles_full public-dockerfiles_ubi8 public-dockerfiles_ironbank
 
 public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+	../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -116,7 +116,7 @@ public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+	../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -130,7 +130,7 @@ public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
-	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+	../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -144,10 +144,10 @@ public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Dockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
-	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+	../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 	  elastic_version="${ELASTIC_VERSION}" \
 	  templates/hardening_manifest.yaml.erb > $(ARTIFACTS_DIR)/ironbank/hardening_manifest.yaml && \
-	../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+	../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 		created_date="${BUILD_DATE}" \
 		elastic_version="${ELASTIC_VERSION}" \
 		arch="${ARCHITECTURE}" \
@@ -187,7 +187,7 @@ env2yaml:
 # Generate the Dockerfiles from ERB templates.
 dockerfile: templates/Dockerfile.erb
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
-		../vendor/jruby/bin/jruby -S bundle exec ./vendor/bundle/jruby/2.5.0/bin/erb -T "-" \
+		../vendor/jruby/bin/jruby -S ../bin/bundle exec erb -T "-" \
 			created_date="${BUILD_DATE}" \
 			elastic_version="${ELASTIC_VERSION}" \
 			arch="${ARCHITECTURE}" \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -177,12 +177,7 @@ push:
 env2yaml:
 	docker run --rm \
 	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
-		-e GOARCH=arm64 -e GOOS=linux \
-		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-arm64
-	docker run --rm \
-	  -v "$(PWD)/data/logstash/env2yaml:/usr/src/env2yaml" \
-		-e GOARCH=amd64 -e GOOS=linux \
-		-w /usr/src/env2yaml golang:1 go build -o /usr/src/env2yaml/env2yaml-amd64
+	  -w /usr/src/env2yaml golang:1 go build
 
 # Generate the Dockerfiles from ERB templates.
 dockerfile: templates/Dockerfile.erb

--- a/docker/bin/pytest
+++ b/docker/bin/pytest
@@ -1,5 +1,0 @@
-#!/bin/bash
-#
-# A wrapper for `pytest` to handle the appropriate Testinfra arguments.
-
-./venv/bin/pytest --verbose --connection=docker --hosts=logstash-test $@

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,0 @@
-flake8==3.4.1
-jinja2-cli[yaml]==0.7.0
-jinja2==2.10.1
-retrying==1.3.3
-testinfra==1.6.0
-pyfiglet

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -25,7 +25,7 @@
 <% end -%>
 <% if image_flavor == 'ironbank' -%>
 ARG BASE_REGISTRY=registry1.dsop.io
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
 ARG BASE_TAG=8.10
 ARG LOGSTASH_VERSION=<%= elastic_version %>
 ARG GOLANG_VERSION=1.17.8

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -68,34 +68,34 @@ FROM <%= base_image %>
 
 RUN for iter in {1..10}; do \
 <% if image_flavor == 'full' || image_flavor == 'oss' -%>
-export DEBIAN_FRONTEND=noninteractive && \
+    export DEBIAN_FRONTEND=noninteractive && \
 <% end -%>
-<%= package_manager %> update -y && \
+    <%= package_manager %> update -y && \
 <% if image_flavor != 'ironbank' -%>
-<%= package_manager %> upgrade -y && \
+    <%= package_manager %> upgrade -y && \
 <% end -%>
-<%= package_manager %> install -y procps findutils tar gzip curl && \
+    <%= package_manager %> install -y procps findutils tar gzip curl && \
 <% if image_flavor == 'ubi8' -%>
-<%= package_manager %> install -y openssl && \
+    <%= package_manager %> install -y openssl && \
 <% end -%>
 <% if image_flavor == 'ubi8' || image_flavor == 'ironbank' -%>
-<%= package_manager %> install -y which shadow-utils && \
+    <%= package_manager %> install -y which shadow-utils && \
 <% else -%>
-<%= package_manager %> install -y locales && \
+    <%= package_manager %> install -y locales && \
 <% end -%>
-<%= package_manager %> clean all && \
+    <%= package_manager %> clean all && \
 <% if image_flavor == 'full' || image_flavor == 'oss' -%>
-locale-gen 'en_US.UTF-8' && \
-<%= package_manager %> clean metadata && \
+    locale-gen 'en_US.UTF-8' && \
+    <%= package_manager %> clean metadata && \
 <% end -%>
-exit_code=0 && break || exit_code=$? && \
-echo "packaging error: retry $iter in 10s" && \
-<%= package_manager %> clean all && \
+    exit_code=0 && break || exit_code=$? && \
+    echo "packaging error: retry $iter in 10s" && \
+    <%= package_manager %> clean all && \
 <% if image_flavor == 'full' || image_flavor == 'oss' -%>
-<%= package_manager %> clean metadata && \
+    <%= package_manager %> clean metadata && \
 <% end -%>
-sleep 10; done; \
-(exit $exit_code)
+    sleep 10; done; \
+    (exit $exit_code)
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -26,7 +26,7 @@
 <% if image_flavor == 'ironbank' -%>
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.2
+ARG BASE_TAG=8.10
 ARG LOGSTASH_VERSION=<%= elastic_version %>
 ARG GOLANG_VERSION=1.17.8
 

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -1,37 +1,33 @@
-# This Dockerfile was generated from templates/Dockerfile.j2
-{% if local_artifacts == 'false' -%}
-{%   set url_root = 'https://artifacts.elastic.co/downloads/logstash' -%}
-{% else -%}
-{%   set url_root = 'http://localhost:8000' -%}
-{% endif -%}
-
-{% if image_flavor == 'oss' -%}
-  {% set tarball = 'logstash-oss-%s-linux-$(arch).tar.gz' % (elastic_version) -%}
-  {% set license = 'Apache 2.0' -%}
-{% else -%}
-  {% set tarball = 'logstash-%s-linux-$(arch).tar.gz' % (elastic_version) -%}
-  {% set license = 'Elastic License' -%}
-{% endif -%}
-
-{% if image_flavor == 'ubi8' -%}
-  {% set base_image = 'docker.elastic.co/ubi8/ubi-minimal' -%}
-  {% set package_manager = 'microdnf'  -%}
-  # Minimal distributions do not ship with en language packs.
-  {% set locale = 'C.UTF-8' -%}
-{% elif image_flavor == 'ironbank' -%}
-    {% set package_manager = 'yum'  -%}
-{% else -%}
-  {% set base_image = 'ubuntu:20.04'  -%}
-  {% set package_manager = 'apt-get' -%}
-  {% set locale = 'en_US.UTF-8' -%}
-{% endif -%}
-
-
-{% if image_flavor == 'ironbank' -%}
+# This Dockerfile was generated from templates/Dockerfile.erb
+<% if local_artifacts == 'false' -%>
+<%   url_root = 'https://artifacts.elastic.co/downloads/logstash' -%>
+<% else -%>
+<%   url_root = 'http://localhost:8000' -%>
+<% end -%>
+<% if image_flavor == 'oss' -%>
+<%   tarball = "logstash-oss-#{elastic_version}-linux-$(arch).tar.gz" -%>
+<%   license = 'Apache 2.0' -%>
+<% else -%>
+<%   tarball = "logstash-#{elastic_version}-linux-$(arch).tar.gz" -%>
+<%   license = 'Elastic License' -%>
+<% end -%>
+<% if image_flavor == 'ubi8' -%>
+<%   base_image = 'docker.elastic.co/ubi8/ubi-minimal' -%>
+<%   package_manager = 'microdnf' -%>
+# Minimal distributions do not ship with en language packs.
+<%   locale = 'C.UTF-8' -%>
+<% elsif image_flavor == 'ironbank' -%>
+<%   package_manager = 'yum' -%>
+<% else -%>
+<%   base_image = 'ubuntu:20.04' -%>
+<%   package_manager = 'apt-get' -%>
+<%   locale = 'en_US.UTF-8' -%>
+<% end -%>
+<% if image_flavor == 'ironbank' -%>
 ARG BASE_REGISTRY=registry1.dsop.io
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
 ARG BASE_TAG=8.10
-ARG LOGSTASH_VERSION={{ elastic_version }}
+ARG LOGSTASH_VERSION=<%= elastic_version %>
 ARG GOLANG_VERSION=1.17.8
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS env2yaml
@@ -66,99 +62,101 @@ RUN tar zxf /opt/logstash.tar.gz && \
     mv /usr/share/logstash-${LOGSTASH_VERSION} /usr/share/logstash
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
-
-{% else -%}
-FROM {{ base_image }}
-
-{% endif -%}
+<% else -%>
+FROM <%= base_image %>
+<% end -%>
 
 RUN for iter in {1..10}; do \
-{% if image_flavor == 'full' or image_flavor == 'oss' -%}
-    export DEBIAN_FRONTEND=noninteractive && \
-{% endif -%}
-    {{ package_manager }} update -y && \
-{% if image_flavor != 'ironbank' -%}
-    {{ package_manager }} upgrade -y && \
-{% endif -%}
-    {{ package_manager }} install -y procps findutils tar gzip curl && \
-{% if image_flavor == 'ubi8' or image_flavor == 'ironbank' -%}
-    {{ package_manager }} install -y which shadow-utils && \
-{% else -%}
-    {{ package_manager }} install -y locales && \
-{% endif -%}
-    {{ package_manager }} clean all && \
-{% if image_flavor == 'full' or image_flavor == 'oss' -%}
-    locale-gen 'en_US.UTF-8' && \
-    {{ package_manager }} clean metadata && \
-{% endif -%}
-    exit_code=0 && break || exit_code=$? && \
-    echo "packaging error: retry $iter in 10s" && \
-    {{ package_manager }} clean all && \
-{% if image_flavor == 'full' or image_flavor == 'oss' -%}
-    {{ package_manager }} clean metadata && \
-{% endif -%}
-    sleep 10; done; \
-    (exit $exit_code)
+<% if image_flavor == 'full' || image_flavor == 'oss' -%>
+export DEBIAN_FRONTEND=noninteractive && \
+<% end -%>
+<%= package_manager %> update -y && \
+<% if image_flavor != 'ironbank' -%>
+<%= package_manager %> upgrade -y && \
+<% end -%>
+<%= package_manager %> install -y procps findutils tar gzip curl && \
+<% if image_flavor == 'ubi8' || image_flavor == 'ironbank' -%>
+<%= package_manager %> install -y which shadow-utils && \
+<% else -%>
+<%= package_manager %> install -y locales && \
+<% end -%>
+<%= package_manager %> clean all && \
+<% if image_flavor == 'full' || image_flavor == 'oss' -%>
+locale-gen 'en_US.UTF-8' && \
+<%= package_manager %> clean metadata && \
+<% end -%>
+exit_code=0 && break || exit_code=$? && \
+echo "packaging error: retry $iter in 10s" && \
+<%= package_manager %> clean all && \
+<% if image_flavor == 'full' || image_flavor == 'oss' -%>
+<%= package_manager %> clean metadata && \
+<% end -%>
+sleep 10; done; \
+(exit $exit_code)
 
 # Provide a non-root user to run the process.
 RUN groupadd --gid 1000 logstash && \
     adduser --uid 1000 --gid 1000 \
-      {% if image_flavor != 'ironbank' %} --home {% else %} --home-dir {% endif -%} /usr/share/logstash --no-create-home \
-      logstash
+    <% if image_flavor != 'ironbank' %>--home <% else %>--home-dir <% end %>/usr/share/logstash --no-create-home \
+    logstash
 
-{% if image_flavor == 'ironbank' -%}
+<% if image_flavor == 'ironbank' -%>
 WORKDIR /usr/share/logstash
 COPY --from=env2yaml /usr/local/src/go/src/env2yaml/env2yaml /usr/local/bin/env2yaml
 COPY --from=builder --chown=1000:0 /usr/share/logstash /usr/share/logstash
-{% endif -%}
+<% end -%>
 
 # Add Logstash itself.
 RUN \
-{% if image_flavor != 'ironbank' -%} curl -Lo - {{ url_root }}/{{ tarball }} | \
+<% if image_flavor != 'ironbank' %> curl -Lo - <%= url_root %>/<%= tarball %> | \
     tar zxf - -C /usr/share && \
-    mv /usr/share/logstash-{{ elastic_version }} /usr/share/logstash && \
-{% endif -%}
+    mv /usr/share/logstash-<%= elastic_version %> /usr/share/logstash && \
+<% end -%>
     chown --recursive logstash:logstash /usr/share/logstash/ && \
     chown -R logstash:root /usr/share/logstash && \
     chmod -R g=u /usr/share/logstash && \
     mkdir /licenses/ && \
     mv /usr/share/logstash/NOTICE.TXT /licenses/NOTICE.TXT && \
     mv /usr/share/logstash/LICENSE.txt /licenses/LICENSE.txt && \
+<% if image_flavor != 'ironbank' -%>
     find /usr/share/logstash -type d -exec chmod g+s {} \; && \
+<% end -%>
     ln -s /usr/share/logstash /opt/logstash
 
-{% if image_flavor != 'ironbank' -%}
+<% if image_flavor != 'ironbank' -%>
 WORKDIR /usr/share/logstash
-{% endif -%}
+<% end -%>
 ENV ELASTIC_CONTAINER true
 ENV PATH=/usr/share/logstash/bin:$PATH
 
 # Provide a minimal configuration, so that simple invocations will provide
 # a good experience.
-{% if image_flavor != 'ironbank' -%}
-ADD config/pipelines.yml config/pipelines.yml
-{% if image_flavor == 'oss' -%}
-ADD config/logstash-oss.yml config/logstash.yml
-{% else -%}
-ADD config/logstash-full.yml config/logstash.yml
-{% endif -%}
-ADD config/log4j2.properties config/
-ADD pipeline/default.conf pipeline/logstash.conf
+<% if image_flavor != 'ironbank' -%>
+COPY config/pipelines.yml config/pipelines.yml
+<% if image_flavor == 'oss' -%>
+COPY config/logstash-oss.yml config/logstash.yml
+<% else -%>
+COPY config/logstash-full.yml config/logstash.yml
+<% end -%>
+COPY config/log4j2.properties config/
+COPY config/log4j2.file.properties config/
+COPY pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Ensure Logstash gets the correct locale by default.
-ENV LANG={{ locale }} LC_ALL={{ locale }}
-ADD env2yaml/env2yaml /usr/local/bin/
+ENV LANG=<%= locale %> LC_ALL=<%= locale %>
+COPY env2yaml/env2yaml /usr/local/bin/
 # Place the startup wrapper script.
-ADD bin/docker-entrypoint /usr/local/bin/
-{% else -%}
+COPY bin/docker-entrypoint /usr/local/bin/
+<% else -%>
 COPY scripts/config/pipelines.yml config/pipelines.yml
 COPY scripts/config/logstash.yml config/logstash.yml
 COPY scripts/config/log4j2.properties config/
+COPY scripts/config/log4j2.file.properties config/
 COPY scripts/pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Place the startup wrapper script.
 COPY scripts/bin/docker-entrypoint /usr/local/bin/
-{% endif -%}
+<% end -%>
 
 RUN chmod 0755 /usr/local/bin/docker-entrypoint
 
@@ -166,33 +164,32 @@ USER 1000
 
 EXPOSE 9600 5044
 
-{% if image_flavor != 'ironbank' -%}
+<% if image_flavor != 'ironbank' -%>
 LABEL  org.label-schema.schema-version="1.0" \
   org.label-schema.vendor="Elastic" \
   org.opencontainers.image.vendor="Elastic" \
   org.label-schema.name="logstash" \
   org.opencontainers.image.title="logstash" \
-  org.label-schema.version="{{ elastic_version }}" \
-  org.opencontainers.image.version="{{ elastic_version }}" \
+  org.label-schema.version="<%= elastic_version %>" \
+  org.opencontainers.image.version="<%= elastic_version %>" \
   org.label-schema.url="https://www.elastic.co/products/logstash" \
   org.label-schema.vcs-url="https://github.com/elastic/logstash" \
-  org.label-schema.license="{{ license }}" \
-  org.opencontainers.image.licenses="{{ license }}" \
+  org.label-schema.license="<%= license %>" \
+  org.opencontainers.image.licenses="<%= license %>" \
   org.opencontainers.image.description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
-  org.label-schema.build-date={{ created_date }} \
-{% if image_flavor == 'ubi8' -%}
-  license="{{ license }}" \
+  org.label-schema.build-date=<%= created_date %> \
+<% if image_flavor == 'ubi8' -%>  license="<%= license %>" \
   description="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
   name="logstash" \
   maintainer="info@elastic.co" \
   summary="Logstash is a free and open server-side data processing pipeline that ingests data from a multitude of sources, transforms it, and then sends it to your favorite 'stash.'" \
   vendor="Elastic" \
-{% endif -%}
-  org.opencontainers.image.created={{ created_date }}
-{% endif -%}
+<% end -%>
+  org.opencontainers.image.created=<%= created_date %>
+<% end -%>
 
-{% if image_flavor == 'ironbank' -%}
+<% if image_flavor == 'ironbank' -%>
 HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD curl -I -f --max-time 5 http://localhost:9600 || exit 1
-{% endif -%}
+<% end -%>
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -11,7 +11,7 @@
 <%   tarball = "logstash-#{elastic_version}-linux-$(arch).tar.gz" -%>
 <%   license = 'Elastic License' -%>
 <% end -%>
-<% if image_flavor == 'ubi8' -%>
+<% if image_flavor == 'ubi8' %>
 <%   base_image = 'docker.elastic.co/ubi8/ubi-minimal' -%>
 <%   package_manager = 'microdnf' -%>
 # Minimal distributions do not ship with en language packs.
@@ -26,7 +26,7 @@
 <% if image_flavor == 'ironbank' -%>
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=8.10
+ARG BASE_TAG=9.2
 ARG LOGSTASH_VERSION=<%= elastic_version %>
 ARG GOLANG_VERSION=1.17.8
 
@@ -75,6 +75,9 @@ export DEBIAN_FRONTEND=noninteractive && \
 <%= package_manager %> upgrade -y && \
 <% end -%>
 <%= package_manager %> install -y procps findutils tar gzip curl && \
+<% if image_flavor == 'ubi8' -%>
+<%= package_manager %> install -y openssl && \
+<% end -%>
 <% if image_flavor == 'ubi8' || image_flavor == 'ironbank' -%>
 <%= package_manager %> install -y which shadow-utils && \
 <% else -%>
@@ -100,7 +103,7 @@ RUN groupadd --gid 1000 logstash && \
     <% if image_flavor != 'ironbank' %>--home <% else %>--home-dir <% end %>/usr/share/logstash --no-create-home \
     logstash
 
-<% if image_flavor == 'ironbank' -%>
+<% if image_flavor == 'ironbank' %>
 WORKDIR /usr/share/logstash
 COPY --from=env2yaml /usr/local/src/go/src/env2yaml/env2yaml /usr/local/bin/env2yaml
 COPY --from=builder --chown=1000:0 /usr/share/logstash /usr/share/logstash
@@ -123,7 +126,7 @@ RUN \
 <% end -%>
     ln -s /usr/share/logstash /opt/logstash
 
-<% if image_flavor != 'ironbank' -%>
+<% if image_flavor != 'ironbank' %>
 WORKDIR /usr/share/logstash
 <% end -%>
 ENV ELASTIC_CONTAINER true

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -142,7 +142,6 @@ COPY config/logstash-oss.yml config/logstash.yml
 COPY config/logstash-full.yml config/logstash.yml
 <% end -%>
 COPY config/log4j2.properties config/
-COPY config/log4j2.file.properties config/
 COPY pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Ensure Logstash gets the correct locale by default.
@@ -154,7 +153,6 @@ COPY bin/docker-entrypoint /usr/local/bin/
 COPY scripts/config/pipelines.yml config/pipelines.yml
 COPY scripts/config/logstash.yml config/logstash.yml
 COPY scripts/config/log4j2.properties config/
-COPY scripts/config/log4j2.file.properties config/
 COPY scripts/pipeline/default.conf pipeline/logstash.conf
 RUN chown --recursive logstash:root config/ pipeline/
 # Place the startup wrapper script.

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -43,6 +43,16 @@ resources:
   url: <artifact_path>/logstash-<%= elastic_version %>-linux-x86_64.tar.gz
   validation:
     type: sha512
+- filename: go1.17.8.linux-amd64.tar.gz
+  url: https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
+  validation:
+    type: sha256
+    value: 980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99
+- filename: v2.3.0.tar.gz
+  url: https://github.com/go-yaml/yaml/archive/v2.3.0.tar.gz
+  validation:
+    type: sha512
+    value: ba934e9cb5ebd2346d3897308b71d13bc6471a8dbc0dc0d46a02644ee6b6553d20c20393471b81025b572a9b03e3326bde9c3e8be156474f1a1f91ff027b6a4f
     value: <INSERT SHA512 VALUE FROM https://artifacts.elastic.co/downloads/logstash/logstash-<%= elastic_version %>-linux-x86_64.tar.gz.sha512>
 
 # List of project maintainers

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -55,7 +55,6 @@ resources:
   validation:
     type: sha512
     value: ba934e9cb5ebd2346d3897308b71d13bc6471a8dbc0dc0d46a02644ee6b6553d20c20393471b81025b572a9b03e3326bde9c3e8be156474f1a1f91ff027b6a4f
-    value: <INSERT SHA512 VALUE FROM https://artifacts.elastic.co/downloads/logstash/logstash-<%= elastic_version %>-linux-x86_64.tar.gz.sha512>
 
 # List of project maintainers
 maintainers:

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -8,15 +8,15 @@ name: "elastic/logstash/logstash"
 # The most specific version should be the first tag and will be shown
 # on ironbank.dsop.io
 tags:
-- "{{ elastic_version }}"
+- "<%= elastic_version %>"
 - "latest"
 
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi8"
   BASE_TAG: "8.10"
-  LOGSTASH_VERSION: "{{ elastic_version }}"
-  GOLANG_VERSION: "1.17.8"
+  LOGSTASH_VERSION: "<%= elastic_version %>"
+  GOLANG_VERSION: "1.21.8"
 
 # Docker image labels
 labels:
@@ -29,7 +29,7 @@ labels:
   org.opencontainers.image.url: "https://www.elastic.co/products/logstash"
   ## Name of the distributing entity, organization or individual
   org.opencontainers.image.vendor: "Elastic"
-  org.opencontainers.image.version: "{{ elastic_version }}"
+  org.opencontainers.image.version: "<%= elastic_version %>"
   ## Keywords to help with search (ex. "cicd,gitops,golang")
   # mil.dso.ironbank.image.keywords: "FIXME"
   ## This value can be "opensource" or "commercial"
@@ -39,27 +39,14 @@ labels:
 
 # List of resources to make available to the offline build context
 resources:
-- filename: logstash-{{ elastic_version }}-linux-x86_64.tar.gz
-  url: <artifact_path>/logstash-{{ elastic_version }}-linux-x86_64.tar.gz
+- filename: logstash-<%= elastic_version %>-linux-x86_64.tar.gz
+  url: <artifact_path>/logstash-<%= elastic_version %>-linux-x86_64.tar.gz
   validation:
     type: sha512
-    value: <INSERT SHA512 VALUE FROM https://artifacts.elastic.co/downloads/logstash/logstash-{{ elastic_version }}-linux-x86_64.tar.gz.sha512>
-- filename: go1.17.8.linux-amd64.tar.gz
-  url: https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
-  validation:
-    type: sha256
-    value: 980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99
-- filename: v2.3.0.tar.gz
-  url: https://github.com/go-yaml/yaml/archive/v2.3.0.tar.gz
-  validation:
-    type: sha512
-    value: ba934e9cb5ebd2346d3897308b71d13bc6471a8dbc0dc0d46a02644ee6b6553d20c20393471b81025b572a9b03e3326bde9c3e8be156474f1a1f91ff027b6a4f
+    value: <INSERT SHA512 VALUE FROM https://artifacts.elastic.co/downloads/logstash/logstash-<%= elastic_version %>-linux-x86_64.tar.gz.sha512>
 
 # List of project maintainers
 maintainers:
-- name: "Nassim Kammah"
-  username: "nkammah"
-  email: "nassim.kammah@elastic.co"
 - name: "Joao Duarte"
   username: "joaodiasduarte"
   email: "joao@elastic.co"

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -43,6 +43,8 @@ resources:
   url: <artifact_path>/logstash-<%= elastic_version %>-linux-x86_64.tar.gz
   validation:
     type: sha512
+    value: <INSERT SHA512 VALUE FROM https://artifacts.elastic.co/downloads/logstash/logstash-<%= elastic_version %>-linux-x86_64.tar.gz.sha512>
+
 - filename: go1.17.8.linux-amd64.tar.gz
   url: https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
   validation:

--- a/docker/tox.ini
+++ b/docker/tox.ini
@@ -1,5 +1,0 @@
-# pytest fixtures (which are wonderful) trigger false positives for these
-# pyflakes checks.
-[flake8]
-ignore = F401,F811
-max-line-length = 120


### PR DESCRIPTION
This should simplify CI infrastructure by not requiring python.

Exhaustive test suite with docker acceptance tests passing here: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/576