### PR TITLE
update jruby to 9.4.8.0

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -18,8 +18,6 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_OS}"
         options:
-          - label: "Ubuntu 24.04"
-            value: "ubuntu-2404"
           - label: "Ubuntu 22.04"
             value: "ubuntu-2204"
           - label: "Ubuntu 20.04"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -1,7 +1,7 @@
 {
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
-        "ubuntu": ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004"],
+        "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
         "debian": ["debian-12", "debian-11", "debian-10"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 
-ACCEPTANCE_LINUX_OSES = ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
+ACCEPTANCE_LINUX_OSES = ["ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
 
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rack", '~> 3'
   gem.add_runtime_dependency "sinatra", '~> 4'
   gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.4.2'
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.14.1"
   gem.add_runtime_dependency 'ruby-maven-libs', '~> 3', '>= 3.8.9'
 
 

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -102,6 +102,10 @@ namespace "artifact" do
     # exclude ruby-maven-libs 3.3.9 jars until JRuby ships with >= 3.8.9
     @exclude_paths << 'vendor/bundle/jruby/**/gems/ruby-maven-libs-3.3.9/**/*'
 
+    # remove this after JRuby includes rexml 3.3.x
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/rexml-3.2.5/**/*'
+    @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/rexml-3.2.5.gemspec'
+
     @exclude_paths
   end
 

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -25,7 +25,7 @@ buildscript {
     dependencies {
         classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-core:9.4.7.0"
+        classpath "org.jruby:jruby-core:9.4.8.0"
     }
 }
 

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.4.7.0
-  sha1: ea3b99edcb48ed436173977551a113759541c18c
+  version: 9.4.8.0
+  sha1: 57089c106c6d0ad09a00db519ab1e984ea716d13
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby
 #jruby-runtime-override:
 #  url: https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/9.3.0.0-SNAPSHOT/jruby-dist-9.3.0.0-20210723.214927-259-bin.tar.gz


### PR DESCRIPTION
https://www.jruby.org/2024/07/02/jruby-9-4-8-0.html

> Fixed a bug in the bytecode JIT causing patterns to execute incorrect branches. #8283, #8284
> jruby-openssl is updated to 0.15.0, with updated Bouncy Castle libraries to avoid CVEs in older versions.
> uri is updated to 0.12.2, mitigating CVE
> net-ftp is updated to 0.3.7 with restored functionality on JRuby.

Exhaustive test suite: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/580