### PR TITLE
Revert "add ubuntu 24.04 to CI (#16263)"

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -18,8 +18,6 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_OS}"
         options:
-          - label: "Ubuntu 24.04"
-            value: "ubuntu-2404"
           - label: "Ubuntu 22.04"
             value: "ubuntu-2204"
           - label: "Ubuntu 20.04"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -1,7 +1,7 @@
 {
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
-        "ubuntu": ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004"],
+        "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
         "debian": ["debian-12", "debian-11", "debian-10"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 
-ACCEPTANCE_LINUX_OSES = ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
+ACCEPTANCE_LINUX_OSES = ["ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
 
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
This reverts commit a0bcd61ad3d164b5928f073ee28cd1c7656db44e.

We're clearly still missing something to have ubuntu 24.04 testable on buildkite

<img width="942" alt="Screenshot 2024-07-02 at 17 35 14" src="https://github.com/elastic/logstash/assets/31809/3900d4c7-e772-462c-8f3d-29e173cc29a1">
