### PR TITLE
Bump 8.14.3

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.14.2)
+      logstash-core (= 8.14.3)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.14.2-java)
+    logstash-core (8.14.3-java)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.14.2
-logstash-core: 8.14.2
+logstash: 8.14.3
+logstash-core: 8.14.3
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
To be merged immediately following the release of 8.14.2

## PRE-MERGE CHECKLIST:

 - [ ] 8.14.2 has been released -> https://www.elastic.co/downloads/past-releases/logstash-8-14-2

## POST-MERGE CHECKLIST:

 - [ ] manual snapshot of 8.14.3
   - [ ] trigger [8.14 snapshot build](https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds?branch=8.14#new)
   - [ ] merge https://github.com/elastic/logstash/pull/16287 once `8.14.3-SNAPSHOT` is available
 - [ ] trigger [staging build of `8.14`](https://buildkite.com/elastic/logstash-dra-staging-pipeline/builds?branch=8.14#new)