### PR TITLE
Remove CentOS 7 from CI

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -32,8 +32,6 @@ steps:
             value: "rhel-9"
           - label: "RHEL 8"
             value: "rhel-8"
-          - label: "CentOS 7"
-            value: "centos-7"
           - label: "Oracle Linux 8"
             value: "oraclelinux-8"
           - label: "Oracle Linux 7"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

CentOS 7 is EOL since June 30 2024[^1]. All repositories and mirrors are now unreachable.

This commit removes CentOS 7 from CI jobs using it.

## How to test this PR locally

BK link: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/235

## Related issues

https://github.com/elastic/ingest-dev/issues/3520

[^1]: https://www.redhat.com/en/topics/linux/centos-linux-eol
