### PR TITLE
Add Ubuntu 24.04 to CI

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -18,6 +18,8 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_OS}"
         options:
+          - label: "Ubuntu 24.04"
+            value: "ubuntu-2404"
           - label: "Ubuntu 22.04"
             value: "ubuntu-2204"
           - label: "Ubuntu 20.04"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -1,7 +1,7 @@
 {
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
-        "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
+        "ubuntu": ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004"],
         "debian": ["debian-12", "debian-11", "debian-10"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 
-ACCEPTANCE_LINUX_OSES = ["ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
+ACCEPTANCE_LINUX_OSES = ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
 
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Now that we have custom VM images for Ubuntu 24.04, this commit adds CI for Ubuntu 24.04.

This is a revert of #16279

## How to test this PR locally

BK Link:

- exhaustive job: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/605
- jdk matrix job: https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/236

Unfortunately some steps in the above jobs fail as there is no 8.16.0 Elasticsearch artifact yet.
