### PR TITLE
[CI] fix benchmark to pull snapshot version 

### DIFF
--- a/.buildkite/scripts/benchmark/main.sh
+++ b/.buildkite/scripts/benchmark/main.sh
@@ -108,7 +108,7 @@ pull_images() {
   else
     # select the SNAPSHOT artifact with the highest semantic version number
     LS_VERSION=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/versions | jq -r '.versions | map(select(endswith("-SNAPSHOT"))) | max_by(rtrimstr("-SNAPSHOT")|split(".")|map(tonumber))' )
-    BUILD_ID=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/branches/master/builds | jq -r ".builds[0]" )
+    BUILD_ID=$(curl --retry-all-errors --retry 5 --retry-delay 1 -s "https://artifacts-api.elastic.co/v1/versions/${LS_VERSION}/builds/latest" | jq -re '.build.build_id')
     ARCH=$(arch)
     IMAGE_URL="https://snapshots.elastic.co/${BUILD_ID}/downloads/logstash/logstash-$LS_VERSION-docker-image-$ARCH.tar.gz"
     IMAGE_FILENAME="$LS_VERSION.tar.gz"

--- a/.buildkite/scripts/benchmark/main.sh
+++ b/.buildkite/scripts/benchmark/main.sh
@@ -107,6 +107,9 @@ pull_images() {
     docker pull "docker.elastic.co/logstash/logstash:$LS_VERSION"
   else
     LS_VERSION=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/versions | jq -r ".versions[-1]" )
+    if [[ ! $LS_VERSION == *-SNAPSHOT ]]; then
+      LS_VERSION="${LS_VERSION}-SNAPSHOT"
+    fi
     BUILD_ID=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/branches/master/builds | jq -r ".builds[0]" )
     ARCH=$(arch)
     IMAGE_URL="https://snapshots.elastic.co/${BUILD_ID}/downloads/logstash/logstash-$LS_VERSION-docker-image-$ARCH.tar.gz"

--- a/.buildkite/scripts/benchmark/main.sh
+++ b/.buildkite/scripts/benchmark/main.sh
@@ -106,10 +106,8 @@ pull_images() {
   if [[ -n "$LS_VERSION" ]]; then
     docker pull "docker.elastic.co/logstash/logstash:$LS_VERSION"
   else
-    LS_VERSION=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/versions | jq -r ".versions[-1]" )
-    if [[ ! $LS_VERSION == *-SNAPSHOT ]]; then
-      LS_VERSION="${LS_VERSION}-SNAPSHOT"
-    fi
+    # select the SNAPSHOT artifact with the highest semantic version number
+    LS_VERSION=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/versions | jq -r '.versions | map(select(endswith("-SNAPSHOT"))) | max_by(rtrimstr("-SNAPSHOT")|split(".")|map(tonumber))' )
     BUILD_ID=$( curl --retry-all-errors --retry 5 --retry-delay 1 -s https://artifacts-api.elastic.co/v1/branches/master/builds | jq -r ".builds[0]" )
     ARCH=$(arch)
     IMAGE_URL="https://snapshots.elastic.co/${BUILD_ID}/downloads/logstash/logstash-$LS_VERSION-docker-image-$ARCH.tar.gz"


### PR DESCRIPTION
Fixes: #16307

benchmark script [fails](https://buildkite.com/elastic/logstash-benchmark-pipeline/builds/66#0190909c-074f-45f4-93bf-21654e6886e5) because it takes the version 8.15.0 rather than 8.15.0-SNAPSHOT, hence, unable to download the nightly build image