### PR TITLE
[ci] Skip slack for retries JDK matrix jobs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -405,6 +405,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+        SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'        
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION

## Release notes
[rn:skip]

## What does this PR do?

With this commit we shush slack alerts for JDK matrix CI jobs that succeed after (automatic) retries.

## Why is it important/What is the impact to the user?

Reduces notification fatigue for non-actionable events.
