### PR TITLE
make pipeline resilient to stack overflow during compilation

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -285,9 +285,8 @@ module LogStash; class JavaPipeline < AbstractPipeline
       # compiles and initializes the worker pipelines
 
       workers_init_start = Time.now
-      execution = lir_execution.buildExecution(@preserve_event_order)
       worker_loops = pipeline_workers.times
-        .map { Thread.new { init_worker_loop(execution) } }
+        .map { Thread.new { init_worker_loop } }
         .map(&:value)
       workers_init_elapsed = Time.now - workers_init_start
 
@@ -583,11 +582,11 @@ module LogStash; class JavaPipeline < AbstractPipeline
   end
 
   # @return [WorkerLoop] a new WorkerLoop instance or nil upon construction exception
-  def init_worker_loop(execution)
+  def init_worker_loop
     begin
       org.logstash.execution.WorkerLoop.new(
         filter_queue_client,   # QueueReadClient
-        execution,         # CompiledPipeline
+        lir_execution,         # CompiledPipeline
         @worker_observer,      # WorkerObserver
         # pipeline reporter counters
         @events_consumed,      # LongAdder

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -1016,6 +1016,37 @@ describe LogStash::JavaPipeline do
       it_behaves_like 'it flushes correctly'
     end
   end
+  context "Pipeline created with too many filters" do
+    let(:config) do
+      <<-EOS
+      input { dummy_input {} }
+      filter {
+        #{"          nil_flushing_filter {}\n" * 2000}
+      }
+      output { dummy_output {} }
+      EOS
+    end
+    let(:output) { ::LogStash::Outputs::DummyOutput.new }
+
+    before do
+      allow(::LogStash::Outputs::DummyOutput).to receive(:new).with(any_args).and_return(output)
+      allow(LogStash::Plugin).to receive(:lookup).with("input", "dummy_input").and_return(LogStash::Inputs::DummyBlockingInput)
+      allow(LogStash::Plugin).to receive(:lookup).with("filter", "nil_flushing_filter").and_return(NilFlushingFilterPeriodic)
+      allow(LogStash::Plugin).to receive(:lookup).with("output", "dummy_output").and_return(::LogStash::Outputs::DummyOutput)
+      allow(LogStash::Plugin).to receive(:lookup).with("codec", "plain").and_return(LogStash::Codecs::Plain)
+    end
+
+    let(:pipeline) { mock_java_pipeline_from_string(config, pipeline_settings_obj) }
+
+    it "informs the user that a stack overflow occurred" do
+      allow(pipeline.logger).to receive(:error)
+
+      pipeline.start
+      pipeline.shutdown
+
+      expect(pipeline.logger).to have_received(:error).with(/Stack overflow/, anything).at_least(:once)
+    end
+  end
   context "Periodic Flush that intermittently returns nil" do
     let(:config) do
       <<-EOS

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -1017,6 +1017,8 @@ describe LogStash::JavaPipeline do
     end
   end
   context "Pipeline created with too many filters" do
+    # create pipeline with 2000 filters
+    # 2000 filters is more than a thread stack of size 2MB can handle
     let(:config) do
       <<-EOS
       input { dummy_input {} }

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -34,7 +34,7 @@ public final class WorkerLoop implements Runnable {
 
     private static final Logger LOGGER = LogManager.getLogger(WorkerLoop.class);
 
-    private final ObservedExecution<QueueBatch> execution;
+    private final ObservedExecution<QueueBatch> observedExecution;
 
     private final QueueReadClient readClient;
 
@@ -52,7 +52,7 @@ public final class WorkerLoop implements Runnable {
 
     public WorkerLoop(
             final QueueReadClient readClient,
-            final CompiledPipeline compiledPipeline,
+            final CompiledPipeline.Execution<QueueBatch> execution,
             final WorkerObserver workerObserver,
             final LongAdder consumedCounter,
             final LongAdder filteredCounter,
@@ -62,7 +62,7 @@ public final class WorkerLoop implements Runnable {
             final boolean drainQueue,
             final boolean preserveEventOrder)
     {
-        this.execution = workerObserver.ofExecution(compiledPipeline.buildExecution(preserveEventOrder));
+        this.observedExecution = workerObserver.ofExecution(execution);
         this.readClient = readClient;
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;
@@ -110,7 +110,7 @@ public final class WorkerLoop implements Runnable {
     private boolean abortableCompute(QueueBatch batch, boolean flush, boolean shutdown) {
         boolean isNackBatch = false;
         try {
-            execution.compute(batch, flush, shutdown);
+            observedExecution.compute(batch, flush, shutdown);
         } catch (Exception ex) {
             if (ex instanceof AbortedBatchException) {
                 isNackBatch = true;

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -52,7 +52,7 @@ public final class WorkerLoop implements Runnable {
 
     public WorkerLoop(
             final QueueReadClient readClient,
-            final CompiledPipeline.Execution<QueueBatch> execution,
+            final CompiledPipeline compiledPipeline,
             final WorkerObserver workerObserver,
             final LongAdder consumedCounter,
             final LongAdder filteredCounter,
@@ -62,7 +62,7 @@ public final class WorkerLoop implements Runnable {
             final boolean drainQueue,
             final boolean preserveEventOrder)
     {
-        this.observedExecution = workerObserver.ofExecution(execution);
+        this.observedExecution = workerObserver.ofExecution(compiledPipeline.buildExecution(preserveEventOrder));
         this.readClient = readClient;
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;

--- a/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
+++ b/logstash-core/src/main/java/org/logstash/execution/WorkerLoop.java
@@ -34,7 +34,7 @@ public final class WorkerLoop implements Runnable {
 
     private static final Logger LOGGER = LogManager.getLogger(WorkerLoop.class);
 
-    private final ObservedExecution<QueueBatch> observedExecution;
+    private final ObservedExecution<QueueBatch> execution;
 
     private final QueueReadClient readClient;
 
@@ -62,7 +62,7 @@ public final class WorkerLoop implements Runnable {
             final boolean drainQueue,
             final boolean preserveEventOrder)
     {
-        this.observedExecution = workerObserver.ofExecution(compiledPipeline.buildExecution(preserveEventOrder));
+        this.execution = workerObserver.ofExecution(compiledPipeline.buildExecution(preserveEventOrder));
         this.readClient = readClient;
         this.consumedCounter = consumedCounter;
         this.filteredCounter = filteredCounter;
@@ -110,7 +110,7 @@ public final class WorkerLoop implements Runnable {
     private boolean abortableCompute(QueueBatch batch, boolean flush, boolean shutdown) {
         boolean isNackBatch = false;
         try {
-            observedExecution.compute(batch, flush, shutdown);
+            execution.compute(batch, flush, shutdown);
         } catch (Exception ex) {
             if (ex instanceof AbortedBatchException) {
                 isNackBatch = true;


### PR DESCRIPTION
A couple of thoughts on the way this is implemented:

1. There should be a first barrier to handle pipelines that are too large based on the PipelineIR compilation. The barrier would use the detection of Xss to determine how big a pipeline could be. This however doesn't reduce the need to still handle a StackOverflow if it happens.
2. The catching of StackOverflowError could also be done on the WorkerLoop. However I'd suggest that this is unrelated to the Worker initialization itself, it just so happens that `compiledPipeline.buildExecution` is computed inside the WorkerLoop class for performance reasons. So I'd prefer logging to not come from [the existing `catch`](https://github.com/elastic/logstash/blob/main/logstash-core/lib/logstash/java_pipeline.rb#L601-L606), but from a dedicated catch clause.


Solves https://github.com/elastic/logstash/issues/16320