### PR TITLE
Backport PR #16300 to 8.14: Remove Debian 10 from CI (#16300)

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -26,8 +26,6 @@ steps:
             value: "debian-12"
           - label: "Debian 11"
             value: "debian-11"
-          - label: "Debian 10"
-            value: "debian-10"
           - label: "RHEL 9"
             value: "rhel-9"
           - label: "RHEL 8"

--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -2,7 +2,7 @@
     "#comment": "This file lists all custom vm images. We use it to make decisions about randomized CI jobs.",
     "linux": {
         "ubuntu": ["ubuntu-2204", "ubuntu-2004"],
-        "debian": ["debian-12", "debian-11", "debian-10"],
+        "debian": ["debian-12", "debian-11"],
         "rhel": ["rhel-9", "rhel-8"],
         "oraclelinux": ["oraclelinux-8", "oraclelinux-7"],
         "rocky": ["rocky-linux-8"],

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 
-ACCEPTANCE_LINUX_OSES = ["ubuntu-2204", "ubuntu-2004", "debian-11", "debian-10", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
+ACCEPTANCE_LINUX_OSES = ["ubuntu-2204", "ubuntu-2004", "debian-11", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
 
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
**Backport PR #16300 to 8.14 branch, original message:**

---
## Release notes
[rn:skip]

## What does this PR do?

This commit removes Debian 10 (Buster) which is EOL since July 1 2024[^1] from CI.

## Related issues

Relates https://github.com/elastic/ingest-dev/issues/2872

[^1]: https://wiki.debian.org/LTS
