### PR TITLE
settings: add support for observing settings after post-process hooks

### DIFF
--- a/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
+++ b/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
@@ -52,6 +52,13 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     end
 
     include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 'does not emit a deprecation warning' do
+        expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
+        settings.get_setting(deprecated_setting_name).observe_post_process
+      end
+    end
   end
 
   context "when only the deprecated alias is set" do
@@ -70,6 +77,13 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     end
 
     include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 're-emits the deprecation warning' do
+        expect(LogStash::Settings.deprecation_logger).to receive(:deprecated).with(a_string_including(deprecated_setting_name))
+        settings.get_setting(deprecated_setting_name).observe_post_process
+      end
+    end
 
     it 'validates deprecated alias' do
       expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
@@ -107,6 +121,13 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     end
 
     include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 'does not emit a deprecation warning' do
+        expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
+        settings.get_setting(deprecated_setting_name).observe_post_process
+      end
+    end
   end
 
   context "when both the canonical setting and deprecated alias are set" do

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -144,6 +144,18 @@ describe LogStash::Settings do
     it "should preserve original settings" do
       expect(settings.get("foo")).to eq("bar")
     end
+
+    context 'when a registered setting responds to `observe_post_process`' do
+      let(:observe_post_process_setting) do
+        LogStash::Setting::Boolean.new("this.that", true).tap { |s| allow(s).to receive(:observe_post_process) }
+      end
+      subject(:settings) do
+        described_class.new.tap { |s| s.register(observe_post_process_setting) }
+      end
+      it 'it sends `observe_post_process`' do
+        expect(observe_post_process_setting).to have_received(:observe_post_process)
+      end
+    end
   end
 
   context "transient settings" do


### PR DESCRIPTION
Because logging configuration occurs after loading the `logstash.yml` settings, deprecation logs from `LogStash::Settings::DeprecatedAlias#set` are effectively emitted to a null logger and lost.

By re-emitting these deprecations after the post-process hooks, we can ensure that they make their way to the deprecation log. This change adds support for any setting that responds to `Object#observe_post_process` to receive it after all post-processing hooks have been executed.

## Release notes

Fixes an issue where the deprecation log does not contain entries related to providing deprecated settings by ensuring that they are re-emitted after the logger has been configured.

## What does this PR do?

Fixes an issue where the deprecation log does not contain entries related to providing deprecated settings by ensuring that they are re-emitted after the logger has been configured.

## Why is it important/What is the impact to the user?

Settings like `http.enabled` have been deprecated and superseded with other configuration since 7.x, but the deprecation log entries have been sent to the logger before it was configured, causing them to be lost. By re-emitting the deprecation warnings after the logger is configured we ensure that users have a chance to fix the issue and migrate to the new setting prior to the eventual removal of the deprecated ssettings.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. run logstash with a deprecated setting
```
(echo 'http.enabled: false' > config/logstash.yml) && bin/logstash --log.level=debug -e 
'input { generator { count => 1 } }'
```
2. observe the `logs/logstash-deprecation.log:
```
[2024-07-20T05:07:01,029][WARN ][deprecation.logstash.settings] The setting `http.enabled` is a deprecated alias for `api.enabled` and will be removed in a future release of Logstash. Please use api.enabled instead
```


## Related issues

Resolves: elastic/logstash#16332
