### PR TITLE
add retries to snyk buildkite job

### DIFF
--- a/.buildkite/snyk_report_pipeline.yml
+++ b/.buildkite/snyk_report_pipeline.yml
@@ -10,3 +10,6 @@ steps:
   - label: ":hammer: Report to Snyk"
     command:
       - .buildkite/scripts/snyk/report.sh
+    retry:
+      automatic:
+        - limit: 3


### PR DESCRIPTION
Sometimes network instability can cause the build to fail. for example:

```

HEAD is now at 5b13f973d bump lock file for 7.17 (#16341)
--
  | Checking out 8.14 branch.
  | Branch '8.14' set up to track remote branch '8.14' from 'origin'.
  | Switched to a new branch '8.14'
  | Downloading https://services.gradle.org/distributions/gradle-8.5-bin.zip
  | ............10%.............20%............30%.............40%.....
  | Exception in thread "main" java.net.SocketException: Connection reset
  | at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:328)
  | at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)
  | at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)
  | at java.base/java.net.Socket$SocketInputStream.read(Socket.java:966)


```