### PR TITLE
fix line used to determine ES is up

### DIFF
--- a/x-pack/qa/integration/support/helpers.rb
+++ b/x-pack/qa/integration/support/helpers.rb
@@ -48,7 +48,7 @@ def elasticsearch(options = {})
   # Launch in the background and wait for /started/ stdout
   cmd = "bin/elasticsearch #{settings_arguments.join(' ')}"
   puts "Running elasticsearch: #{cmd}"
-  response = Belzebuth.run(cmd, { :directory => get_elasticsearch_path, :wait_condition => /license.*valid/, :timeout => 15 * 60 })
+  response = Belzebuth.run(cmd, { :directory => get_elasticsearch_path, :wait_condition => /ClusterStateLicenseService.*license.*valid/, :timeout => 15 * 60 })
   unless response.successful?
     raise "Could not start Elasticsearch, response: #{response}"
   end


### PR DESCRIPTION
Before we waited for the condition /license.*valid/, that matched:
```
[2024-07-24T15:03:23,157][INFO ][o.e.l.ClusterStateLicenseService] [arkham.local] license [8a5c66ef-1863-4d24-845a-339d8ad755a5] mode [basic] - valid
```
But now it can match:
```
[2024-07-24T15:03:16,331][INFO ][o.e.f.FeatureService     ] [arkham.local] Registered local node features [data_stream.auto_sharding, data_stream.lifecycle.global_retention, data_stream.rollover.lazy, desired_node.version_deprecated, esql.agg_values, esql.async_query, esql.base64_decode_encode, esql.casting_operator, esql.counter_types, esql.disable_nullable_opts, esql.from_options, esql.metadata_fields, esql.metrics_counter_fields, esql.metrics_syntax, esql.mv_ordering_sorted_ascending, esql.mv_sort, esql.resolve_fields_api, esql.spatial_points_from_source, esql.spatial_shapes, esql.st_centroid_agg, esql.st_contains_within, esql.st_disjoint, esql.st_intersects, esql.st_x_y, esql.string_literal_auto_casting, esql.string_literal_auto_casting_extended, esql.timespan_abbreviations, features_supported, file_settings, geoip.downloader.database.configuration, health.dsl.info, health.extended_repository_indicator, knn_retriever_supported, license-trial-independent-version, mapper.index_sorting_on_nested, mapper.keyword_dimension_ignore_above, mapper.pass_through_priority, mapper.query_index_mode, mapper.range.null_values_off_by_one_fix, mapper.segment_level_fields_stats, mapper.source.synthetic_source_fallback, mapper.track_ignored_source, mapper.vectors.bit_vectors, mapper.vectors.int4_quantization, rest.capabilities_action, retrievers_supported, rrf_retriever_supported, script.hamming, search.vectors.k_param_supported, security.migration_framework, security.roles_metadata_flattened, simulate.mapping.validation, standard_retriever_supported, stats.include_disk_thresholds, text_similarity_reranker_retriever_supported, unified_highlighter_matched_fields, usage.data_tiers.precalculate_stats]
[2024-07-24T15:03:23,157][INFO ][o.e.l.ClusterStateLicenseService] [arkham.local] license [8a5c66ef-1863-4d24-845a-339d8ad755a5] mode [basic] - valid
```
The first entry happens much sooner, so the tests start before ES is ready.
This PR ensure the line we expect, from ClusterStateLicenseService, happens before the tests begin.

The change lines up with https://github.com/elastic/elasticsearch/pull/110606/files#diff-97ba6f4f3881131b999ea982aa5ab22b31bad9eaf7aa1d14beda660309ae60b7R47