### PR TITLE
[Bugfix] Resolve the array and char (single | double quote) escaped values of ${ENV}

### DIFF
--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -85,10 +85,10 @@ module ::LogStash::Util::SubstitutionVariables
 
     # ENV ${var} value may carry single quote or escaped double quote
     # or single/double quoted entries in array string, needs to be refined
-    refined_value = placeholder_value.gsub(/[\\"\\']/, '')
+    refined_value = placeholder_value.strip.gsub(/[\\"\\']/, '')
     if refined_value.start_with?('[') && refined_value.end_with?(']')
-      string_array = refined_value[1..-2] # removes the covered [] bracket
-      string_array.include?(',') ? string_array.split(',').map(&:strip) : string_array
+      # remove square brackets, split by comma and cleanup leading/trailing whitespace
+      refined_value[1..-2].split(',').map(&:strip)
     else
       refined_value
     end

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -74,9 +74,13 @@ module ::LogStash::Util::SubstitutionVariables
         raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Replacement variable `#{name}` is not defined in a Logstash secret store " +
             "or as an Environment entry and there is no default value given."
       end
-      # if array string, remove literal brackets and make array
-      replacements = replacement.gsub(/[\[\]]/, '')
-      return replacements.split(', ').map(&:strip)
+      # if ENV carries array string, remove literal brackets and make array
+      if replacement.is_a?(String) && replacement.start_with?('[') && replacement.end_with?(']')
+        replacements = replacement.gsub(/[\[\]]/, '')
+        return replacements.split(', ').map(&:strip)
+      else
+        replacement.to_s
+      end
     end
   end # def replace_placeholders
 

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -85,7 +85,7 @@ module ::LogStash::Util::SubstitutionVariables
 
     # ENV ${var} value may carry single quote or escaped double quote
     # or single/double quoted entries in array string, needs to be refined
-    refined_value = placeholder_value.strip.gsub(/[\\"\\']/, '')
+    refined_value = placeholder_value.gsub(/[\\"\\']/, '')
     if refined_value.start_with?('[') && refined_value.end_with?(']')
       # remove square brackets, split by comma and cleanup leading/trailing whitespace
       refined_value[1..-2].split(',').map(&:strip)

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -74,7 +74,9 @@ module ::LogStash::Util::SubstitutionVariables
         raise LogStash::ConfigurationError, "Cannot evaluate `#{placeholder}`. Replacement variable `#{name}` is not defined in a Logstash secret store " +
             "or as an Environment entry and there is no default value given."
       end
-      replacement.to_s
+      # if array string, remove literal brackets and make array
+      replacements = replacement.gsub(/[\[\]]/, '')
+      return replacements.split(', ').map(&:strip)
     end
   end # def replace_placeholders
 

--- a/qa/docker/shared_examples/xpack.rb
+++ b/qa/docker/shared_examples/xpack.rb
@@ -2,21 +2,61 @@ shared_examples_for 'a container with xpack features' do |flavor|
 
   before do
     @image = find_image(flavor)
-    @container = start_container(@image, {'ENV' => env})
   end
 
   after do
     cleanup_container(@container)
   end
 
-  context 'when configuring xpack settings' do
-    let(:env) { %w(xpack.monitoring.enabled=false xpack.monitoring.elasticsearch.hosts=["http://node1:9200","http://node2:9200"]) }
+  describe 'when configuring xpack settings' do
 
-    it 'persists monitoring environment var keys' do
-      # persisting actual value of the environment keys bring the issue where keystore looses its power
-      # visit https://github.com/elastic/logstash/issues/15766 for details
-      expect(get_settings(@container)['xpack.monitoring.enabled']).to eq("${xpack.monitoring.enabled}")
-      expect(get_settings(@container)['xpack.monitoring.elasticsearch.hosts']).to eq("${xpack.monitoring.elasticsearch.hosts}")
+    context 'when persists env var keys into logstash.yml' do
+      let(:env) { %w(XPACK_MONITORING_ENABLED=false XPACK_MONITORING_ELASTICSEARCH_HOSTS=["http://node1:9200","http://node2:9200"]) }
+
+      before do
+        @container = start_container(@image, {'ENV' => env})
+      end
+
+      it 'saves keys instead actual value which will be resolved from keystore | env later' do
+        settings = get_settings(@container)
+        expect(settings['xpack.monitoring.enabled']).to eq("${XPACK_MONITORING_ENABLED}")
+        expect(settings['xpack.monitoring.elasticsearch.hosts']).to eq("${XPACK_MONITORING_ELASTICSEARCH_HOSTS}")
+      end
+    end
+
+    context 'with running with env vars' do
+      let(:env) {
+        [
+          'XPACK_MONITORING_ENABLED=true',
+          'XPACK_MONITORING_ELASTICSEARCH_HOSTS="http://node1:9200"',
+          'XPACK_MANAGEMENT_ENABLED=true',
+          'XPACK_MANAGEMENT_PIPELINE_ID=["*"]', # double quotes intentionally placed
+          'XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS=["http://node3:9200", "http://node4:9200"]'
+        ]
+      }
+
+      it 'persists var keys into logstas.yaml and uses their resolved actual values' do
+        container = create_container(@image, {'ENV' => env})
+
+        sleep(15) # wait for container run
+
+        settings = get_settings(container)
+
+        expect(settings['xpack.monitoring.enabled']).to eq("${XPACK_MONITORING_ENABLED}")
+        expect(settings['xpack.monitoring.elasticsearch.hosts']).to eq("${XPACK_MONITORING_ELASTICSEARCH_HOSTS}")
+        expect(settings['xpack.management.enabled']).to eq("${XPACK_MANAGEMENT_ENABLED}")
+        expect(settings['xpack.management.pipeline.id']).to eq("${XPACK_MANAGEMENT_PIPELINE_ID}")
+        expect(settings['xpack.management.elasticsearch.hosts']).to eq("${XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS}")
+
+        # get container logs
+        container_logs = container.logs(stdout: true)
+
+        # check if logs contain node3 & node4 values actually resolved and used
+        expect(container_logs.include?('pipeline_id=>["*"]')).to be true
+        # note that, we are not spinning up ES nodes, so values can be in errors or in pool update logs
+        expect(container_logs.include?('http://node3:9200')).to be true
+        expect(container_logs.include?('http://node4:9200')).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

A bug (introduced in 8.13.1) fix to use array value with docker environment variables (such as `XPACK_MANAGEMENT_PIPELINE_ID`, `XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS`).

## What does this PR do?
Fixes the bug introduced by #16026. After 8.13.1, running Logstash on docker with list environment variable (example: `-e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS='[es.host.1, es.host.2:9500]'`) doesn't work. Current change fixes this issue.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- run `rake artifact:docker` to build docker image
- use the hash value created by rake and replace `b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874` with your hash value

- ENV var carries list:

```
docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID="['*']" -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS="['https://es1:9200', 'https://es2:9200']" -e XPACK_MONITORING_ENABLED=false sha256:b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874

docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID='["*"]' -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS='["https://es1:9200", "https://es2:9200"]' -e XPACK_MONITORING_ENABLED=false b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874
```

- ENV var carries single value:
```
docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID="*" -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS="https://es1:9200" -e XPACK_MONITORING_ENABLED=false b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874

docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID='*' -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS='https://es1:9200' -e XPACK_MONITORING_ENABLED=false -it b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874

docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID="'*'" -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS="https://es1:9200" -e XPACK_MONITORING_ENABLED=false -it b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874
			
docker run --rm --name=local-ls-docker -p 9600:9600 -e API_ENABLED=true -e XPACK_MANAGEMENT_ENABLED=true -e XPACK_MANAGEMENT_PIPELINE_ID='"*"' -e XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS="https://es1:9200" -e XPACK_MONITORING_ENABLED=false -it b6c644b81357d29d9ae30b788fad327ece26d363c3541e566c543dc9dc084874
```

- To run docker acceptance test, use following commands
```
./gradlew clean bootstrap assemble installDefaultGems && rake artifact:docker
cd qa
bundle install
# make sure docker engine is running
bundle exec rspec docker/spec/full/container_spec.rb
```

## Related issues

- Closes #16200 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
