### PR TITLE
deprecate java less-than 17

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -321,6 +321,9 @@ class LogStash::Runner < Clamp::StrictCommand
     if JavaVersion::CURRENT < JavaVersion::JAVA_11
       logger.warn I18n.t("logstash.runner.java.version",
                                              :java_home => java.lang.System.getProperty("java.home"))
+    elsif JavaVersion::CURRENT < JavaVersion::JAVA_17
+      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_17_minimum",
+                                           :java_home => java.lang.System.getProperty("java.home"))
     end
 
     logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -446,6 +446,12 @@ en:
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
+        version_17_minimum: >-
+          Starting from Logstash 9.0, the minimum required version of Java will be Java 17;
+          your Java version from `%{java_home}` does not meet this requirement.
+          Running Logstash with the bundled JDK is recommended.
+          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
+          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
     agent:
       sighup: >-
         SIGHUP received.

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -31,6 +31,8 @@ public class JavaVersion implements Comparable<JavaVersion> {
 
     public static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
     public static final JavaVersion JAVA_11 = parse("11");
+    public static final JavaVersion JAVA_17 = parse("17");
+
     private final List<Integer> version;
 
     private JavaVersion(List<Integer> version){


### PR DESCRIPTION
## Release notes

In a future major release of Logstash, Java 11 will not be supported. While most distributions of Logstash bundle a supported Java 17+, we now emit a deprecation warning for users who provide an outdated JDK of their own, guiding to either use the bundled JDK or to provide an updated one.

## What does this PR do?

Emits a deprecation warning at startup if-and-only-if Logstash is being run on Java < 17, so that users who provide a JDK that will not be supported in the near-to-medium future can address the issue separately from upgrading Logstash.

## Why is it important/What is the impact to the user?

Nobody likes being surprised by breaking changes :)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

## How to test this PR locally

1. run Logstash with Java 17+
   ~~~
   bin/logstash -e 'input { generator { count => 1 } }'
   ~~~
2. observe no entry in `logs/logstash-deprecation.log`
3. run Logstash with Java 11
   ~~~
   LS_JAVA_HOME=/path/to/java/11 bin/logstash -e 'input { generator { count => 1 } }'
   ~~~
4. observe relevant entry in `logs/logstash-deprecation.log`:
   > ~~~
   > [2024-08-05T20:01:56,384][WARN ][deprecation.logstash.runner] Starting from Logstash 9.0, the minimum required version of Java will be Java 17; your Java version from `/opt/homebrew/Cellar/openjdk@11/11.0.22/libexec/openjdk.jdk/Contents/Home` does not meet this requirement. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
   > ~~~

