### PR TITLE
Exclude substitution refinement on pipelines.yml

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -93,7 +93,7 @@ module LogStash::Config::Mixin
 
     # Resolve environment variables references
     params.each do |name, value|
-      params[name.to_s] = deep_replace(value)
+      params[name.to_s] = deep_replace(value, true)
     end
 
     # Intercept codecs that have not been instantiated

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -187,7 +187,7 @@ module LogStash
 
     def from_yaml(yaml_path, file_name = "logstash.yml")
       settings = read_yaml(::File.join(yaml_path, file_name))
-      self.merge(deep_replace(flatten_hash(settings)), true)
+      self.merge(deep_replace(flatten_hash(settings), true), true)
       self
     end
 

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -28,8 +28,8 @@ module ::LogStash::Util::SubstitutionVariables
   SECRET_STORE = ::LogStash::Util::LazySingleton.new { load_secret_store }
   private_constant :SECRET_STORE
 
-  # Recursive method to replace substitution variable references in parameters
-  def deep_replace(value)
+  # Recursive method to replace substitution variable references in parameters and refine if required
+  def deep_replace(value, refine = false)
     if value.is_a?(Hash)
       value.each do |valueHashKey, valueHashValue|
         value[valueHashKey.to_s] = deep_replace(valueHashValue)
@@ -40,7 +40,7 @@ module ::LogStash::Util::SubstitutionVariables
           value[i] = deep_replace(single_value)
         end
       else
-        return replace_placeholders(value)
+        return replace_placeholders(value, refine)
       end
     end
   end
@@ -49,9 +49,11 @@ module ::LogStash::Util::SubstitutionVariables
   # Process following patterns : ${VAR}, ${VAR:defaultValue}
   # If value matches the pattern, returns the following precedence : Secret store value, Environment entry value, default value as provided in the pattern
   # If the value does not match the pattern, the 'value' param returns as-is
-  def replace_placeholders(value)
+  # When setting refine to true, substituted value will be cleaned against escaped single/double quotes
+  #   and generates array if resolved substituted value is array string
+  def replace_placeholders(value, refine)
     if value.kind_of?(::LogStash::Util::Password)
-      interpolated = replace_placeholders(value.value)
+      interpolated = replace_placeholders(value.value, refine)
       return ::LogStash::Util::Password.new(interpolated)
     end
     return value unless value.is_a?(String)
@@ -80,8 +82,8 @@ module ::LogStash::Util::SubstitutionVariables
       replacement.to_s
     end
 
-    # no further action need if substitution didn't happen
-    return placeholder_value unless is_placeholder_found
+    # no further action need if substitution didn't happen or refine isn't required
+    return placeholder_value unless is_placeholder_found && refine
 
     # ENV ${var} value may carry single quote or escaped double quote
     # or single/double quoted entries in array string, needs to be refined

--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -32,12 +32,12 @@ module ::LogStash::Util::SubstitutionVariables
   def deep_replace(value, refine = false)
     if value.is_a?(Hash)
       value.each do |valueHashKey, valueHashValue|
-        value[valueHashKey.to_s] = deep_replace(valueHashValue)
+        value[valueHashKey.to_s] = deep_replace(valueHashValue, refine)
       end
     else
       if value.is_a?(Array)
         value.each_with_index do |single_value, i|
-          value[i] = deep_replace(single_value)
+          value[i] = deep_replace(single_value, refine)
         end
       else
         return replace_placeholders(value, refine)

--- a/qa/integration/specs/multiple_pipeline_spec.rb
+++ b/qa/integration/specs/multiple_pipeline_spec.rb
@@ -34,7 +34,7 @@ describe "Test Logstash service when multiple pipelines are used" do
 
   let(:temporary_out_file_1) { Stud::Temporary.pathname }
   let(:temporary_out_file_2) { Stud::Temporary.pathname }
-  ENV['TEMP_FILE_PATH'] = Stud::Temporary.pathname
+  let(:temporary_out_file_3) { Stud::Temporary.pathname }
 
   let(:pipelines) {[
     {
@@ -72,6 +72,7 @@ describe "Test Logstash service when multiple pipelines are used" do
 
   it "executes the multiple pipelines" do
     logstash_service = @fixture.get_service("logstash")
+    logstash_service.env_variables = {'TEMP_FILE_PATH' => temporary_out_file_3}
     logstash_service.spawn_logstash("--path.settings", settings_dir, "--log.level=debug")
     try(retry_attempts) do
       expect(logstash_service.exited?).to be(true)

--- a/qa/integration/specs/multiple_pipeline_spec.rb
+++ b/qa/integration/specs/multiple_pipeline_spec.rb
@@ -82,8 +82,8 @@ describe "Test Logstash service when multiple pipelines are used" do
     expect(IO.readlines(temporary_out_file_1).size).to eq(1)
     expect(File.exist?(temporary_out_file_2)).to be(true)
     expect(IO.readlines(temporary_out_file_2).size).to eq(1)
-    expect(File.exist?(ENV['TEMP_FILE_PATH'])).to be(true)
-    expect(IO.readlines(ENV['TEMP_FILE_PATH']).size).to eq(1)
+    expect(File.exist?(temporary_out_file_3)).to be(true)
+    expect(IO.readlines(temporary_out_file_3).size).to eq(1)
   end
 
   context 'effectively-empty pipelines.yml file' do

--- a/qa/integration/specs/multiple_pipeline_spec.rb
+++ b/qa/integration/specs/multiple_pipeline_spec.rb
@@ -34,6 +34,7 @@ describe "Test Logstash service when multiple pipelines are used" do
 
   let(:temporary_out_file_1) { Stud::Temporary.pathname }
   let(:temporary_out_file_2) { Stud::Temporary.pathname }
+  ENV['TEMP_FILE_PATH'] = Stud::Temporary.pathname
 
   let(:pipelines) {[
     {
@@ -47,6 +48,12 @@ describe "Test Logstash service when multiple pipelines are used" do
       "pipeline.workers" => 1,
       "pipeline.batch.size" => 1,
       "config.string" => "input { generator { count => 1 } } output { file { path => \"#{temporary_out_file_2}\" } }"
+    },
+    {
+      "pipeline.id" => "config-string-with-env-var-pipeline",
+      "pipeline.workers" => 1,
+      "pipeline.batch.size" => 1,
+      "config.string" => "input { generator { count => 1 } } output { file { path => \"${TEMP_FILE_PATH}\" } }"
     }
   ]}
 
@@ -74,6 +81,8 @@ describe "Test Logstash service when multiple pipelines are used" do
     expect(IO.readlines(temporary_out_file_1).size).to eq(1)
     expect(File.exist?(temporary_out_file_2)).to be(true)
     expect(IO.readlines(temporary_out_file_2).size).to eq(1)
+    expect(File.exist?(ENV['TEMP_FILE_PATH'])).to be(true)
+    expect(IO.readlines(ENV['TEMP_FILE_PATH']).size).to eq(1)
   end
 
   context 'effectively-empty pipelines.yml file' do


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?
Continues a work of https://github.com/elastic/logstash/pull/16365 which fixed the bug of using array value with docker environment variables (such as `XPACK_MANAGEMENT_PIPELINE_ID`, `XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS`). However, if `config.string` contains ${VAR}s substituted its origin value, refinement logic cleans up the quotes used on configs, for example `output { elasticsearch { hosts => "my.host:9200"} }`, `my.host:9200` loses double quotes.
With this PR, we are excluding `pipelines.yml` and only applying refinement on ENV ${VAR}s.

## Why is it important/What is the impact to the user?
Users who are using `config.string` should have a consistent user experience.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Run exhaustive tests: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/678
- [x] Run serverless integ tests locally

## How to test this PR locally
- Pull the PR
- Use `config.string` in `pipelines.yml` with containing ${VAR} and es-output with hosts option.
- Without this change, pipeline start fails
- With this change, pipeline starts without issue

## Related issues

- 

## Use cases


## Screenshots


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
