### PR TITLE
Generate Dataset code with meaningful fields names

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ClassFields.java
@@ -43,6 +43,10 @@ final class ClassFields {
         return addField(FieldDefinition.fromValue(definitions.size(), obj));
     }
 
+    public ValueSyntaxElement add(final String fieldName, final Object obj) {
+        return addField(FieldDefinition.fromValue(fieldName, obj));
+    }
+
     /**
      * Adds a mutable field of the given type, that doesn't have a default value and is not
      * initialized by a constructor assignment.
@@ -52,6 +56,10 @@ final class ClassFields {
      */
     public ValueSyntaxElement add(final Class<?> type) {
         return addField(FieldDefinition.mutableUnassigned(definitions.size(), type));
+    }
+
+    public ValueSyntaxElement add(final String fieldName, final Class<?> type) {
+        return addField(FieldDefinition.mutableUnassigned(fieldName, type));
     }
 
     /**

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -383,14 +383,14 @@ public final class DatasetCompiler {
         final boolean shutdownOnly) {
         final MethodLevelSyntaxElement condition;
         final ValueSyntaxElement flushArgs;
-        final ValueSyntaxElement flushFinal = fields.add("flushFinalFlag", flushOpts(true));
+        final ValueSyntaxElement flushFinal = fields.add("shutdownFlushOptions", flushOpts(true));
         if (shutdownOnly) {
             condition = SyntaxFactory.and(FLUSH_ARG, SHUTDOWN_ARG);
             flushArgs = flushFinal;
         } else {
             condition = FLUSH_ARG;
             flushArgs = SyntaxFactory.ternary(
-                SHUTDOWN_ARG, flushFinal, fields.add("flushFlag", flushOpts(false))
+                SHUTDOWN_ARG, flushFinal, fields.add("flushOptions", flushOpts(false))
             );
         }
         return SyntaxFactory.ifCondition(

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/DatasetCompiler.java
@@ -383,7 +383,7 @@ public final class DatasetCompiler {
         final boolean shutdownOnly) {
         final MethodLevelSyntaxElement condition;
         final ValueSyntaxElement flushArgs;
-        final ValueSyntaxElement flushFinal = fields.add("flushFlag", flushOpts(true));
+        final ValueSyntaxElement flushFinal = fields.add("flushFinalFlag", flushOpts(true));
         if (shutdownOnly) {
             condition = SyntaxFactory.and(FLUSH_ARG, SHUTDOWN_ARG);
             flushArgs = flushFinal;

--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/FieldDefinition.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/FieldDefinition.java
@@ -46,6 +46,12 @@ final class FieldDefinition implements SyntaxElement {
         );
     }
 
+    public static FieldDefinition fromValue(final String fieldName, final Object value) {
+        return new FieldDefinition(
+                variableDefinition(value.getClass(), fieldName), false, null, value
+        );
+    }
+
     /**
      * Creates a mutable field with given type and without an assigned value.
      * @param index Index for naming
@@ -55,6 +61,12 @@ final class FieldDefinition implements SyntaxElement {
     public static FieldDefinition mutableUnassigned(final int index, final Class<?> type) {
         return new FieldDefinition(
             variableDefinition(type, index), true, null, null
+        );
+    }
+
+    public static FieldDefinition mutableUnassigned(final String fieldName, final Class<?> type) {
+        return new FieldDefinition(
+            variableDefinition(type, fieldName), true, null, null
         );
     }
 
@@ -98,4 +110,9 @@ final class FieldDefinition implements SyntaxElement {
     private static VariableDefinition variableDefinition(final Class<?> type, final int index) {
         return new VariableDefinition(type, String.format("field%d", index));
     }
+
+    private static VariableDefinition variableDefinition(final Class<?> type, final String fieldName) {
+        return new VariableDefinition(type, String.format("%sField", fieldName));
+    }
+
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Updates `FieldDefinition` to receive the name of the field from construction methods, so that it can be used during the code generation phase, instead of the existing incremental `field%n`.   
Updates `ClassFields` to propagate the explicit field name down to the `FieldDefinition`s.
Update the `DatasetCompiler` that add fields to `ClassFields` to assign a proper name to  generated Dataset's fields.

## Why is it important/What is the impact to the user?

This PR is intended to help Logstash developers or users that want to better understand the code that's autogenerated to model a pipeline, assigning more meaningful names to the fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] try some pipelines locally

## How to test this PR locally

- Edit the `config/jvm.options` adding flags to create files that contains the generated Dataset classes
```
-Dorg.codehaus.janino.source_debugging.enable=true
-Dorg.codehaus.janino.source_debugging.dir=/path/to/tmpjanino_logstash_datasets
```
- run some pipelines and check the outcome in `/path/to/tmpjanino_logstash_datasets`
- remember to wipe the output folder after each run
- verify all field names in generated classes are meaningful in the context they are used


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #16385

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
