### PR TITLE
Remove obsolete code to download JDK from Adoptium website

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -707,9 +707,9 @@ def selectArch() {
 }
 
 class JDKDetails {
-    final String revision
-    final String build
-    final String vendor
+//    final String revision
+//    final String build
+//    final String vendor
     final int major
     private final String osName
     private final String extension
@@ -718,10 +718,7 @@ class JDKDetails {
     private String arch
 
     JDKDetails(versionYml, osName, jdkArch) {
-        revision = versionYml.bundled_jdk.revision
-        build = versionYml.bundled_jdk.build
-        vendor = versionYml.bundled_jdk.vendor
-        major = revision.split('\\.').first() as int
+        major = versionYml.bundled_jdk.major as int
         this.osName = osName
 
         switch (osName) {
@@ -732,7 +729,7 @@ class JDKDetails {
                 extension = "tar.gz"
         }
         arch = parseJdkArchitecture(jdkArch)
-        unpackedJdkName = "jdk-${revision}-${osName}"
+        unpackedJdkName = "jdk-${major}-${osName}"
         localPackageName = "${unpackedJdkName}-${arch}.${extension}"
     }
 
@@ -750,36 +747,17 @@ class JDKDetails {
         if (arch == "aarch64") {
             url += "_${arch}"
         }
-        println "Retrieving JDK from catalog..."
+        println "Retrieving JDK ${major} from catalog..."
         def catalogMetadataUrl = URI.create(url).toURL()
         def catalogConnection = catalogMetadataUrl.openConnection()
         catalogConnection.requestMethod = 'GET'
         assert catalogConnection.responseCode == 200
 
         def metadataRetrieved = catalogConnection.content.text
-        println "Retrieved!"
-
         def catalogMetadata = new JsonSlurper().parseText(metadataRetrieved)
-        return catalogMetadata.url
-    }
-
-    private String createAdoptDownloadUrl() {
-        String releaseName = major > 8 ?
-                "jdk-${revision}+${build}" :
-                "jdk${revision}u${build}"
-        String vendorOsName = vendorOsName(osName)
-        switch (vendor) {
-            case "adoptium":
-                return "https://api.adoptium.net/v3/binary/version/${releaseName}/${vendorOsName}/${arch}/jdk/hotspot/normal/adoptium"
-            default:
-                throw RuntimeException("Can't handle vendor: ${vendor}")
-        }
-    }
-
-    private String vendorOsName(String osName) {
-        if (osName == "darwin")
-            return "mac"
-        return osName
+        def downloadUrl = catalogMetadata.url
+        println "Retrieved! Download path: ${new URI(downloadUrl).path}"
+        return downloadUrl
     }
 
     private String parseJdkArchitecture(String jdkArch) {

--- a/versions.yml
+++ b/versions.yml
@@ -5,10 +5,8 @@ logstash-core: 8.16.0
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:
-  # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
-  vendor: "adoptium"
-  revision: 21.0.3
-  build: 9
+  # Major version of a JDK revision, for example 21.0.4+8 it's the integer 21
+  major: 21
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Remove the dead code to download JDK binaries from the Adoptium website. Updates also the `versions.yml` to reflect this change and permit the selection of just `major` number of a JDK, the full version is extracted from Elastic's JDK registry.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] tested locally

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run the command:
```sh
./gradlew clean downloadJdk -Pjdk_bundle_os=darwin -Pjdk_arch=arm64
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
-  Closes #16344

## Logs

```sh
(main) % ./gradlew clean downloadJdk -Pjdk_bundle_os=darwin -Pjdk_arch=arm64
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.7/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build
Retrieving JDK 21 from catalog...
Retrieved! Download path: /jvm-catalog.elastic.co/adoptiumjdk-21.0.4_7-darwin-aarch64.tar.gz
```