### PR TITLE
[DOC] Update math in PQ size example

### DIFF
--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -102,6 +102,14 @@ Required Queue Capacity = (Bytes Received Per Hour * Tolerated Hours of Downtime
 ------
 <1> To start, you can set the `Multiplication Factor` to `1.10`, and then refine it for specific data types as indicated in the tables below. 
 
+*Example*
+
+Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB (1024 bytes),
+which is 1000 KB per second or 3.5GB (1*1000*3600 KB) every hour.
+In order to tolerate a downstream component being unavailable
+for 12h without {ls} exerting back-pressure upstream, the persistent queue's
+`max_bytes` would have to be set to 3.5*12*1.10 = 46.2GB, or about 50GB.
+
 [[sizing-by-type]]
 ====== Queue size by data type
 
@@ -130,13 +138,7 @@ These tables show examples of overhead by event type and how that affects the mu
 | 58901 | 59693 | 792 | 1% | 1.01
 |=======================================================================
 
-*Example*
 
-Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB (1024 bytes),
-which is 1000 KB per second or 3.5GB (1*1000*3600 KB) every hour.
-In order to tolerate a downstream component being unavailable
-for 12h without {ls} exerting back-pressure upstream, the persistent queue's
-`max_bytes` would have to be set to 3.5*12*1.17 = 49.14GB, or about 50GB for plain text events.
 
 [[pq-lower-max_bytes]]
 ===== Smaller queue size

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -115,7 +115,7 @@ These tables show examples of overhead by event type and how that affects the mu
 [cols="<h,<,<m,<m,<m",options="header",]
 |=======================================================================
 | Plaintext size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
-| 11 | 213 | 202 | 1836% | 19.4
+| 11 | 213 | 202 | 1836% | 18.36
 | 1212 | 1416 | 204 | 17% | 1.17
 | 10240 | 10452 | 212 | 2% | 1.02
 |=======================================================================

--- a/docs/static/persistent-queues.asciidoc
+++ b/docs/static/persistent-queues.asciidoc
@@ -126,16 +126,17 @@ These tables show examples of overhead by event type and how that affects the mu
 | JSON document size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
 | 947 | 1133 | 186 | 20% | 1.20
 | 2707 | 3206 | 499 | 18% | 1.18
-| 6751 | 7388 | 637 | 9% | 1.9
-| 58901 | 59693 | 792 | 1% | 1.1
+| 6751 | 7388 | 637 | 9% | 1.09
+| 58901 | 59693 | 792 | 1% | 1.01
 |=======================================================================
 
 *Example*
 
-Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB,
-or 3.5GB every hour. In order to tolerate a downstream component being unavailable
+Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB (1024 bytes),
+which is 1000 KB per second or 3.5GB (1*1000*3600 KB) every hour.
+In order to tolerate a downstream component being unavailable
 for 12h without {ls} exerting back-pressure upstream, the persistent queue's
-`max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
+`max_bytes` would have to be set to 3.5*12*1.17 = 49.14GB, or about 50GB for plain text events.
 
 [[pq-lower-max_bytes]]
 ===== Smaller queue size


### PR DESCRIPTION
Corrected PQ multiplication factor values for JSON documents and the example.

## Release notes
[rn:skip]

## What does this PR do?
Corrects the math in a number of places in the documentation at <https://www.elastic.co/guide/en/logstash/8.15/persistent-queues.html>.

## Why is it important/What is the impact to the user?

The numbers listed on the page did not align with the values when plugged into a calculator.

```diff
 | Plaintext size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
-| 11 | 213 | 202 | 1836% | 19.4
+| 11 | 213 | 202 | 1836% | 18.36
```
202/11 = 18.3636363636

```diff
| JSON document size (bytes) | Serialized {ls} event size (bytes) | Overhead (bytes) | Overhead (%) | Multiplication Factor
-| 6751 | 7388 | 637 | 9% | 1.9
-| 58901 | 59693 | 792 | 1% | 1.1
+| 6751 | 7388 | 637 | 9% | 1.09
+| 58901 | 59693 | 792 | 1% | 1.01
```
637/6751 = 0.09435639165
792/58901 = 0.01344629123

```diff
*Example*

-Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB,
-or 3.5GB every hour. In order to tolerate a downstream component being unavailable
+Let's consider a {ls} instance that receives 1000 EPS and each event is 1KB (1024 bytes),
+which is 1000 KB per second or 3.5GB (1*1000*3600 KB) every hour.
+In order to tolerate a downstream component being unavailable
 for 12h without {ls} exerting back-pressure upstream, the persistent queue's
-`max_bytes` would have to be set to 3.6*12*1.10 = 47.25GB, or about 50GB.
+`max_bytes` would have to be set to 3.5*12*1.10 = 46.2GB, or about 50GB.
```

1000 events per second * 1KB = 1000 KB per second
1000 KB *60 seconds per minute * 60 minutes per hour = 3,600,000 KB pr hour
3,600,000 / 1024 / 1024 = 3.4332275391 GB  per hour

Round up as we are dealing with disk space to 3.5GB per hour.

3.5GB per hour * 12 hours * 1.10 default multiplication factor = 46.2 GB

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] Double check math and grammar

## How to test this PR locally

Redo the math yourself.

## Related issues

N/A

## Use cases

User trying to determine how much disk space is needed for PQ and doing the calculations based on the documentation.

## Screenshots

![image](https://github.com/user-attachments/assets/5d4a432d-cea4-4f86-9a56-cb9ae777d999)

## Logs

N/A
