### PR TITLE
Update z_rubycheck.rake to no longer inject Xmx1g

### DIFF
--- a/rakelib/z_rubycheck.rake
+++ b/rakelib/z_rubycheck.rake
@@ -29,7 +29,7 @@ if ENV['USE_RUBY'] != '1'
 
     # Ignore Environment JAVA_OPTS
     ENV["JAVA_OPTS"] = ""
-    exec(jruby, "-J-Xmx1g", "-S", rake, *ARGV)
+    exec(jruby, "-S", rake, *ARGV)
   end
 end
 


### PR DESCRIPTION
This allows the environment variable JRUBY_OPTS to be used for setting properties like Xmx

Fixes https://github.com/elastic/logstash/issues/16406