### PR TITLE
Exclude inner event field from ConditionalEvaluationError serialization

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/ConditionalEvaluationError.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/ConditionalEvaluationError.java
@@ -7,7 +7,10 @@ import org.logstash.Event;
  * */
 public class ConditionalEvaluationError extends RuntimeException {
     private static final long serialVersionUID = -8633589068902565868L;
-    private final Event failedEvent;
+
+    // This class is serializable because of inheritance from Throwable, however it's not expected
+    // to be ever transmitted on wire on stored in some binary storage.
+    private final transient Event failedEvent;
 
     ConditionalEvaluationError(Throwable cause, Event failedEvent) {
         super(cause);


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Make inner field of `ConditionalEvaluationError` transient to be avoided during serialization.

## Why is it important/What is the impact to the user?

Fix ConditionalEvaluationError to do not include the event that errored in its serialiaxed form, because it's not expected that this class is ever serialized.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run with JDK 21

## How to test this PR locally

Sets your default JDK to a 21 version and run
```
./gradlew clean assemble
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 



## Logs

```
andrea:logstash_andsel (main) % ./gradlew clean assemble
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.7/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build

> Task :downloadJRuby
Download https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.8.0/jruby-dist-9.4.8.0-bin.tar.gz

> Task :logstash-core:compileJava FAILED
Note: Processing Log4j annotations
Note: Annotations processed
Note: Processing Log4j annotations
Note: No elements to process
/Users/andrea/workspace/logstash_andsel/logstash-core/src/main/java/org/logstash/config/ir/compiler/ConditionalEvaluationError.java:10: warning: [serial] non-transient instance field of a serializable class declared with a non-serializable type
    private final Event failedEvent;
                        ^
error: warnings found and -Werror specified
1 error
1 warning
```