### PR TITLE
use gnu tar compatible minitar to generate tar artifact

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -14,6 +14,7 @@ gem "logstash-output-elasticsearch", ">= 11.14.0"
 gem "polyglot", require: false
 gem "treetop", require: false
 gem "faraday", "~> 1", :require => false # due elasticsearch-transport (elastic-transport) depending faraday '~> 1'
+gem "minitar", :group => :build
 gem "childprocess", "~> 4", :group => :build
 gem "fpm", "~> 1", ">= 1.14.1", :group => :build # compound due to bugfix https://github.com/jordansissel/fpm/pull/1856
 gem "gems", "~> 1", :group => :build

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -523,7 +523,7 @@ namespace "artifact" do
     if stat.directory?
       tar.mkdir(path_in_tar, :mode => stat.mode)
     elsif stat.symlink?
-      tar.add_symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
+      tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
     else
       tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size) do |io|
         File.open(path, 'rb') do |fd|

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -492,6 +492,7 @@ namespace "artifact" do
     require "zlib"
     require 'rubygems'
     require 'rubygems/package'
+    require 'minitar'
     ensure_logstash_version_constant_defined
     tarpath = "build/logstash#{tar_suffix}-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}#{platform}.tar.gz"
     if File.exist?(tarpath) && ENV['SKIP_PREPARE'] == "1" && !source_modified_since?(File.mtime(tarpath))
@@ -500,7 +501,7 @@ namespace "artifact" do
     end
     puts("[artifact:tar] building #{tarpath}")
     gz = Zlib::GzipWriter.new(File.new(tarpath, "wb"), Zlib::BEST_COMPRESSION)
-    Gem::Package::TarWriter.new(gz) do |tar|
+    Minitar::Writer.open(gz) do |tar|
       files(exclude_paths).each do |path|
         write_to_tar(tar, path, "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/#{path}")
       end
@@ -520,11 +521,11 @@ namespace "artifact" do
   def write_to_tar(tar, path, path_in_tar)
     stat = File.lstat(path)
     if stat.directory?
-      tar.mkdir(path_in_tar, stat.mode)
+      tar.mkdir(path_in_tar, :mode => stat.mode)
     elsif stat.symlink?
-      tar.add_symlink(path_in_tar, File.readlink(path), stat.mode)
+      tar.add_symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
     else
-      tar.add_file_simple(path_in_tar, stat.mode, stat.size) do |io|
+      tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size) do |io|
         File.open(path, 'rb') do |fd|
           chunk = nil
           size = 0


### PR DESCRIPTION
Using VERSION_QUALIFIER when building the tarball will fail since Ruby's TarWriter implements the older POSIX88 version of tar.
For the long paths being used in Logstash's plugins, mainly due to nested folders from jar-dependencies, we need the tarball to follow either the 2001 ustar format or gnu tar, which is implemented by the minitar gem.

To test, run: `VERSION_QUALIFIER=beta1 ./gradlew assembleTarDistribution`, which will fail on main but work on this PR

Kicked off exhaustive test suite: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/726