### PR TITLE
account for the 8.x branch in DRA publishing task

### DIFF
--- a/.buildkite/scripts/dra/publish.sh
+++ b/.buildkite/scripts/dra/publish.sh
@@ -15,8 +15,9 @@ RELEASE_VER=`cat versions.yml | sed -n 's/^logstash\:[[:space:]]\([[:digit:]]*\.
 if [ -n "$(git ls-remote --heads origin $RELEASE_VER)" ] ; then
     RELEASE_BRANCH=$RELEASE_VER
 else
-    RELEASE_BRANCH=main
+    RELEASE_BRANCH="${BUILDKITE_BRANCH:="main"}"
 fi
+echo "RELEASE BRANCH: $RELEASE_BRANCH"
 
 if [ -n "$VERSION_QUALIFIER_OPT" ]; then
   # Qualifier is passed from CI as optional field and specify the version postfix


### PR DESCRIPTION
The current DRA publishing task computes the branch from the version contained in the version.yml
This is done by taking the major.minor and confirming that a branch exists with that name.
However this pattern won't be applicable for 8.x, as that branch currently points to 8.16.0 and there is no 8.16 branch.

The problem was that, when DRA was run for 8.x branch, the branch lookup would fail and default to "main", overriding the "main" branch dra builds.

This commit fixes the issue by falling back to reading the buildkite injected BUILDKITE_BRANCH variable instead of immediately defaulting to "main" if there's no branch match.
