### PR TITLE
Known issue for 8.15.1 related to env vars references

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -72,8 +72,11 @@ This section summarizes the changes in the following releases:
 [[known-issues-8-15-1]]
 ==== Known issues
 
-* Logstash might fail to start when using Environment or Keystore variable references in pipeline configurations due to single and double quotes are stripped from the settings. See https://github.com/elastic/logstash/issues/16437[16437] for the details.
-** We recommend downgrading to {ls} 8.15.0 or temporarily avoid using Environment or Keystore variable references.
+* **{ls} may fail to start under some circumstances.** Single and double quotes are stripped from a pipeline configuration if the configuration includes environment or keystore variable references.
+If this situation occurs, {ls} may fail to start or some plugins may use a malformed configuration.
+Check out issue https://github.com/elastic/logstash/issues/16437[#16437] for details.
++
+Workaround: Downgrade to {ls} 8.15.0, or temporarily avoid using environment and keystore variable references.
 
 [[notable-8.15.1]]
 ==== Performance improvements and notable issues fixed

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -69,6 +69,12 @@ This section summarizes the changes in the following releases:
 [[logstash-8-15-1]]
 === Logstash 8.15.1 Release Notes
 
+[[known-issues-8-15-1]]
+==== Known issues
+
+* When using Environment or Keystore variable references, single quotes are stripped from the settings or parameters where those are used. Logstash might fail to start or some plugins might use a malformed configuration.
+** We recommend downgrading to {ls} 8.15.0 or temporarily avoid using Environment or Keystore variable references.
+
 [[notable-8.15.1]]
 ==== Performance improvements and notable issues fixed
 

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -72,7 +72,7 @@ This section summarizes the changes in the following releases:
 [[known-issues-8-15-1]]
 ==== Known issues
 
-* When using Environment or Keystore variable references, single quotes are stripped from the settings or parameters where those are used. Logstash might fail to start or some plugins might use a malformed configuration.
+* Logstash might fail to start when using Environment or Keystore variable references in pipeline configurations due to single and double quotes are stripped from the settings. See https://github.com/elastic/logstash/issues/16437[16437] for the details.
 ** We recommend downgrading to {ls} 8.15.0 or temporarily avoid using Environment or Keystore variable references.
 
 [[notable-8.15.1]]


### PR DESCRIPTION
DOC/RN Change

**PREVIEW:** https://logstash_bk_16455.docs-preview.app.elstc.co/guide/en/logstash/master/logstash-8-15-1.html

## What does this PR do?

Adds a known issue section to 8.15.1 referring to https://github.com/elastic/logstash/issues/16437

IT might be useful to link the issue itself https://github.com/elastic/logstash/issues/16437