### PR TITLE
Fixes the issue where LS wipes out all quotes from docker env variables.

### DIFF
--- a/logstash-core/lib/logstash/util/substitution_variables.rb
+++ b/logstash-core/lib/logstash/util/substitution_variables.rb
@@ -87,7 +87,8 @@ module ::LogStash::Util::SubstitutionVariables
 
     # ENV ${var} value may carry single quote or escaped double quote
     # or single/double quoted entries in array string, needs to be refined
-    refined_value = placeholder_value.gsub(/[\\"\\']/, '')
+    refined_value = strip_enclosing_char(placeholder_value, "'")
+    refined_value = strip_enclosing_char(refined_value, '"')
     if refined_value.start_with?('[') && refined_value.end_with?(']')
       # remove square brackets, split by comma and cleanup leading/trailing whitespace
       refined_value[1..-2].split(',').map(&:strip)
@@ -95,6 +96,20 @@ module ::LogStash::Util::SubstitutionVariables
       refined_value
     end
   end # def replace_placeholders
+
+  private
+
+  # removes removed_char of string_value if string_value is wrapped with removed_char
+  def strip_enclosing_char(string_value, remove_char)
+    return string_value unless string_value.is_a?(String)
+    return string_value if string_value.empty?
+
+    if string_value.start_with?(remove_char) && string_value.end_with?(remove_char)
+      string_value[1..-2] # Remove the first and last characters
+    else
+      string_value
+    end
+  end
 
   class << self
     private

--- a/logstash-core/spec/logstash/util/substitution_variables_spec.rb
+++ b/logstash-core/spec/logstash/util/substitution_variables_spec.rb
@@ -1,0 +1,63 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "spec_helper"
+require "logstash/util/substitution_variables"
+
+describe LogStash::Util::SubstitutionVariables do
+
+  subject { Class.new { extend LogStash::Util::SubstitutionVariables } }
+
+  context "ENV or Keystore ${VAR} with single/double quotes" do
+    # single or double quotes come from ENV/Keystore ${VAR} value
+    let(:xpack_monitoring_host) { '"http://node1:9200"' }
+    let(:xpack_monitoring_hosts) { "'[\"http://node3:9200\", \"http://node4:9200\"]'" }
+    let(:xpack_management_pipeline_id) { '"*"' }
+    let(:config_string) {
+      "'input {
+        stdin { }
+        beats { port => 5040 }
+      }
+      output {
+        elasticsearch {
+          hosts => [\"https://es:9200\"]
+          user => \"elastic\"
+          password => 'changeme'
+        }
+      }'"
+    }
+
+    # this happens mostly when running LS with docker
+    it "stripes out quotes" do
+      expect(subject.send(:strip_enclosing_char, xpack_monitoring_host, '"')).to eql('http://node1:9200')
+      expect(subject.send(:strip_enclosing_char, xpack_monitoring_hosts, "'")).to eql('["http://node3:9200", "http://node4:9200"]')
+      expect(subject.send(:strip_enclosing_char, xpack_management_pipeline_id, '"')).to eql('*')
+      # make sure we keep the hosts, user and password param enclosed quotes
+      expect(subject.send(:strip_enclosing_char, config_string, "'")).to eql('input {
+        stdin { }
+        beats { port => 5040 }
+      }
+      output {
+        elasticsearch {
+          hosts => ["https://es:9200"]
+          user => "elastic"
+          password => \'changeme\'
+        }
+      }')
+    end
+  end
+end

--- a/qa/docker/shared_examples/xpack.rb
+++ b/qa/docker/shared_examples/xpack.rb
@@ -27,6 +27,17 @@ shared_examples_for 'a container with xpack features' do |flavor|
     context 'with running with env vars' do
       let(:env) {
         [
+          'CONFIG_STRING=input {
+              stdin { }
+              beats { port => 5040 }
+            }
+            output {
+              elasticsearch {
+                hosts => ["https://es:9200"]
+                user => "elastic"
+                password => "changeme"
+              }
+            }',
           'XPACK_MONITORING_ENABLED=true',
           'XPACK_MONITORING_ELASTICSEARCH_HOSTS="http://node1:9200"',
           'XPACK_MANAGEMENT_ENABLED=true',


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?
Fixes the issue where LS wipes out all quotes from docker env variables. This is an issue when running LS on docker with `CONFIG_STRING`, needs to keep quotes with env variable.


## Why is it important/What is the impact to the user?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes #16433
- Closes #16437 

## Use cases


## Screenshots

## Logs
