### PR TITLE
[CI] fix wrong queue type in benchmark marathon

### DIFF
--- a/.buildkite/scripts/benchmark/marathon.sh
+++ b/.buildkite/scripts/benchmark/marathon.sh
@@ -26,8 +26,11 @@ main() {
   generate_logs
   check_logs
 
+  USER_QTYPE="$QTYPE"
+
   for V in "${STACK_VERSIONS[@]}" ; do
     LS_VERSION="$V"
+    QTYPE="$USER_QTYPE"
     pull_images
     create_directory
     if [[ $QTYPE == "all" ]]; then


### PR DESCRIPTION
QTYPE is set to "memory" after doing the benchmark of the first version. This commit preserves the original QTYPE