### PR TITLE
Use jruby-9.4.8.0 in exhaustive CIs.

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -150,7 +150,7 @@ source /etc/os-release
 if [[ "$$(echo $$ID_LIKE | tr '[:upper:]' '[:lower:]')" =~ (rhel|fedora) && "$${VERSION_ID%.*}" -le 7 ]]; then
   # jruby-9.3.10.0 unavailable on centos-7 / oel-7, see https://github.com/jruby/jruby/issues/7579#issuecomment-1425885324 / https://github.com/jruby/jruby/issues/7695
   # we only need a working jruby to run the acceptance test framework -- the packages have been prebuilt in a previous stage
-  rbenv local jruby-9.4.5.0
+  rbenv local jruby-9.4.8.0
 fi
 ci/acceptance_tests.sh"""),
         }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
BK Agent recently added a jruby-9.4.8.0 support and we need to use this version in the CI pipelines. This change adds a change to reflect into exhaustive pipeline.

## Why is it important/What is the impact to the user?
N.A

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues
- 

## Use cases

## Screenshots

## Logs
