### PR TITLE
Fix jdk21 warnings

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -167,7 +167,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private @SuppressWarnings("rawtypes") RubyArray outputs;
 
     private String lastErrorEvaluationReceived = "";
-    private DeadLetterQueueWriter javaDlqWriter;
+    private transient DeadLetterQueueWriter javaDlqWriter;
 
     public AbstractPipelineExt(final Ruby runtime, final RubyClass metaClass) {
         super(runtime, metaClass);

--- a/logstash-core/src/main/java/org/logstash/settings/BaseSetting.java
+++ b/logstash-core/src/main/java/org/logstash/settings/BaseSetting.java
@@ -93,6 +93,8 @@ public class BaseSetting<T> implements Setting<T> {
         this.strict = strict;
         this.validator = validator;
     }
+
+    @SuppressWarnings("this-escape")
     protected BaseSetting(String name, T defaultValue, boolean strict, Predicate<T> validator) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(validator);

--- a/logstash-core/src/main/java/org/logstash/settings/Coercible.java
+++ b/logstash-core/src/main/java/org/logstash/settings/Coercible.java
@@ -22,6 +22,8 @@ package org.logstash.settings;
 import java.util.function.Predicate;
 
 public abstract class Coercible<T> extends BaseSetting<T> {
+
+    @SuppressWarnings("this-escape")
     public Coercible(String name, T defaultValue, boolean strict, Predicate<T> validator) {
         super(name, strict, validator);
 

--- a/logstash-core/src/main/java/org/logstash/settings/SettingWithDeprecatedAlias.java
+++ b/logstash-core/src/main/java/org/logstash/settings/SettingWithDeprecatedAlias.java
@@ -48,6 +48,7 @@ public class SettingWithDeprecatedAlias<T> extends SettingDelegator<T> {
 
     private DeprecatedAlias<T> deprecatedAlias;
 
+    @SuppressWarnings("this-escape")
     protected SettingWithDeprecatedAlias(BaseSetting<T> canonicalSetting, String deprecatedAliasName) {
         super(canonicalSetting);
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip] 

## What does this PR do?
Suppress some warnings compared with JDK 21
- `this-escape` uses this before it is completely initialised.
- avoid a non serialisable `DeadLetterQueueWriter` field from serialisable instance.

**Don't need backports**
It's the forward port of a 2 fixes added in already present backports:
- #16490
- #16493 