### PR TITLE
Log deprecation warn if memory buffer type not defined

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -332,7 +332,7 @@
 #
 # Determine where to allocate memory buffers, for plugins that leverage them.
 # Default to direct, optionally can be switched to heap to select Java heap space.
-# pipeline.buffer.type: direct
+# pipeline.buffer.type: heap
 #
 # ------------ X-Pack Settings (not applicable for OSS build)--------------
 #

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -111,7 +111,7 @@ module LogStash
             Setting::String.new("keystore.classname", "org.logstash.secret.store.backend.JavaKeyStore"),
             Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false), # will be populated on
     Setting::NullableString.new("monitoring.cluster_uuid"),
-            Setting::String.new("pipeline.buffer.type", "direct", true, ["direct", "heap"])
+            Setting::String.new("pipeline.buffer.type", nil, false, ["direct", "heap"])
   # post_process
   ].each {|setting| SETTINGS.register(setting) }
 

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -313,7 +313,7 @@ class LogStash::Runner < Clamp::StrictCommand
     if setting("pipeline.buffer.type") == nil
       deprecation_logger.deprecated(
         "'pipeline.buffer.type' setting is not explicitly defined."\
-        "Before moving to 9.x set it to 'heap' and tune heap size upward or set it to 'direct' to maintain existing behavior."
+        "Before moving to 9.x set it to 'heap' and tune heap size upward, or set it to 'direct' to maintain existing behavior."
       )
 
       # set to direct to keep backward ecs_compatibility

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -310,9 +310,17 @@ class LogStash::Runner < Clamp::StrictCommand
     if setting("config.debug") && !logger.debug?
       logger.warn("--config.debug was specified, but log.level was not set to \'debug\'! No config info will be logged.")
     end
-    if setting("pipeline.buffer.type") != nil
-      configure_pipeline_buffer_type
+    if setting("pipeline.buffer.type") == nil
+      deprecation_logger.deprecated(
+        "'pipeline.buffer.type' setting is not explicitly defined."\
+        "Before moving to 9.x set it to 'heap' and tune heap size upward or set it to 'direct' to maintain existing behavior."
+      )
+
+      # set to direct to keep backward ecs_compatibility
+      buffer_type_setting = @settings.get_setting("pipeline.buffer.type")
+      buffer_type_setting.set("direct")
     end
+    configure_pipeline_buffer_type
 
     while (msg = LogStash::DeprecationMessage.instance.shift)
       deprecation_logger.deprecated msg


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Logs a deprecation warning if users doesn't explicitly select a value a for `pipeline.buffer.type` and resort to the default setting.

## What does this PR do?

On 8.x series log a deprecation log if the user didn't explicitly specify a selection for  `pipeline.buffer.type`. Before this change the default was silently set to `direct`, after this change if not explicitly defined, the default is still `direct` but log a deprecation log.

## Why is it important/What is the impact to the user?

A user which uses the default value for `pipeline.buffer.type` is nudged to take an explicit selection of the flag, because in the next major this setting will switch to `heap` by default and the JVM `Xmx` has to be properly adjusted to avoid  OutOfMemory errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
Run Logstash and check in deprecation logs for a message related to `pipeline.buffer.type`.
Then explicitly select a value for `pipeline.buffer.type` in `config/logstash.yaml` and verify no deprecation is present.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #16353 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
