### PR TITLE
Don't use an older JRuby with oraclelinux-7

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -147,11 +147,6 @@ rake artifact:deb artifact:rpm
 set -eo pipefail
 source .buildkite/scripts/common/vm-agent-multi-jdk.sh
 source /etc/os-release
-if [[ "$$(echo $$ID_LIKE | tr '[:upper:]' '[:lower:]')" =~ (rhel|fedora) && "$${VERSION_ID%.*}" -le 7 ]]; then
-  # jruby-9.3.10.0 unavailable on centos-7 / oel-7, see https://github.com/jruby/jruby/issues/7579#issuecomment-1425885324 / https://github.com/jruby/jruby/issues/7695
-  # we only need a working jruby to run the acceptance test framework -- the packages have been prebuilt in a previous stage
-  rbenv local jruby-9.4.8.0
-fi
 ci/acceptance_tests.sh"""),
         }
         steps.append(step)


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

A recent PR (elastic/ci-agent-images/pull/932) modernized the VM images and removed JRuby 9.4.5.0 and some older versions.

This ended up breaking exhaustive test on Oracle Linux 7 that hard coded JRuby 9.4.5.0.

PR https://github.com/elastic/logstash/pull/16489 worked around the problem by pinning to the new JRuby, but actually we don't need the conditional anymore since the original issue https://github.com/jruby/jruby/issues/7579#issuecomment-1425885324 has been resolved and none of our releasable branches (apart from 7.17 which uses `9.2.20.1`) specify `9.3.x.y` in `/.ruby-version`.

Therefore, this commit removes conditional setting of JRuby for OracleLinux 7 agents in exhaustive tests (and relies on whatever `/.ruby-version` defines).

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Why is it important/What is the impact to the user?

Removes tech debt and simplifies the CI invocation of exhaustive/acceptance tests.

## How to test this PR locally

https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/769

## Related issues

- https://github.com/jruby/jruby/issues/7579#issuecomment-1425885324
- https://github.com/jruby/jruby/issues/7695
