### PR TITLE
Default buffer type to 'heap' for 9.0

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -331,8 +331,8 @@
 # pipeline.separate_logs: false
 #
 # Determine where to allocate memory buffers, for plugins that leverage them.
-# Default to direct, optionally can be switched to heap to select Java heap space.
-# pipeline.buffer.type: direct
+# Default to heap, optionally can be switched to direct to select direct memory space.
+# pipeline.buffer.type: heap
 #
 # ------------ X-Pack Settings (not applicable for OSS build)--------------
 #

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -331,7 +331,7 @@
 # pipeline.separate_logs: false
 #
 # Determine where to allocate memory buffers, for plugins that leverage them.
-# Default to heap, optionally can be switched to direct to select direct memory space.
+# Defaults to heap, optionally can be switched to direct to select direct memory space.
 # pipeline.buffer.type: heap
 #
 # ------------ X-Pack Settings (not applicable for OSS build)--------------

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -331,7 +331,7 @@
 # pipeline.separate_logs: false
 #
 # Determine where to allocate memory buffers, for plugins that leverage them.
-# Defaults to heap, optionally can be switched to direct to select direct memory space.
+# Defaults to heap,but can be switched to direct if you prefer using direct memory space instead.
 # pipeline.buffer.type: heap
 #
 # ------------ X-Pack Settings (not applicable for OSS build)--------------

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -123,10 +123,9 @@ Keep these memory requirements in mind as you calculate your ideal memory alloca
 Input plugins such as {agent}, {beats}, TCP, and HTTP will allocate buffers in Java heap memory to read events from the network.
 This is the preferred allocation method as it facilitates debugging memory usage problems (such as leaks and Out of Memory errors) through the analysis of heap dumps.
 
-However, in the past the default allocation was in direct memory, to re-enable the old behaviour {ls} provides
+Before version 9.0.0, Logstash defaulted to allocate direct memory for this purpose, instead of heap. To re-enable the previous behaviour {ls} provides
 a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate
 memory buffers for plugins that use them.
-Currently it is set to `heap` by default, but you can change it to `direct` to use direct memory space instead.
 
 Performance-wise there shouldn't be a noticeable impact in switching to `direct`, since while direct memory IO is faster,
 Logstash Event objects produced by these plugins end up being allocated on the Java Heap,

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -127,9 +127,9 @@ Before version 9.0.0, Logstash defaulted to allocate direct memory for this purp
 a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate
 memory buffers for plugins that use them.
 
-Performance-wise there shouldn't be a noticeable impact in switching to `direct`, since while direct memory IO is faster,
-Logstash Event objects produced by these plugins end up being allocated on the Java Heap,
-incurring the cost of copying from direct memory to heap memory regardless of the setting.
+There shouldn't be a noticeable performance impact in switching between `direct` and `heap`. 
+While copying bytes from OS buffers to direct memory buffers is faster, Logstash Event objects produced by these plugins end up 
+being allocated on the Java Heap incurring the cost of copying from direct memory to heap memory, regardless of the setting.
 
 [[memory-size-calculation]]
 ===== Memory sizing

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -120,16 +120,15 @@ Keep these memory requirements in mind as you calculate your ideal memory alloca
 
 [[off-heap-buffers-allocation]]
 ===== Buffer Allocation types
-Input plugins such as {agent}, {beats}, TCP, and HTTP will allocate buffers in Java heap memory to read events from the network.
-This is the preferred allocation method as it facilitates debugging memory usage problems (such as leaks and Out of Memory errors) through the analysis of heap dumps.
+Input plugins such as {agent}, {beats}, TCP, and HTTP allocate buffers in Java heap memory to read events from the network.
+Heap memory is the preferred allocation method, as it facilitates debugging memory usage problems (such as leaks and Out of Memory errors) through the analysis of heap dumps.
 
-Before version 9.0.0, Logstash defaulted to allocate direct memory for this purpose instead of heap. To re-enable the previous behaviour {ls} provides
+Before version 9.0.0, {ls} defaulted to direct memory instead of heap for this purpose. To re-enable the previous behavior {ls} provides
 a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate
 memory buffers for plugins that use them.
 
-There shouldn't be a noticeable performance impact in switching between `direct` and `heap`. 
-While copying bytes from OS buffers to direct memory buffers is faster, Logstash Event objects produced by these plugins end up 
-being allocated on the Java Heap incurring the cost of copying from direct memory to heap memory, regardless of the setting.
+Performance should not be noticeably affected if you switch between `direct` and `heap`. 
+While copying bytes from OS buffers to direct memory buffers is faster, {ls} Event objects produced by these plugins are allocated on the Java Heap, incurring the cost of copying from direct memory to heap memory, regardless of the setting.
 
 [[memory-size-calculation]]
 ===== Memory sizing

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -123,7 +123,7 @@ Keep these memory requirements in mind as you calculate your ideal memory alloca
 Input plugins such as {agent}, {beats}, TCP, and HTTP will allocate buffers in Java heap memory to read events from the network.
 This is the preferred allocation method as it facilitates debugging memory usage problems (such as leaks and Out of Memory errors) through the analysis of heap dumps.
 
-Before version 9.0.0, Logstash defaulted to allocate direct memory for this purpose, instead of heap. To re-enable the previous behaviour {ls} provides
+Before version 9.0.0, Logstash defaulted to allocate direct memory for this purpose instead of heap. To re-enable the previous behaviour {ls} provides
 a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate
 memory buffers for plugins that use them.
 

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -126,7 +126,7 @@ to provide better performance, especially when interacting with the network stac
 Under heavy load, namely large number of connections and large messages, the direct memory space can be exhausted and lead to Out of Memory (OOM) errors in off-heap space.
 
 An off-heap OOM is difficult to debug, so {ls} provides a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate memory buffers for plugins that use them. 
-Currently it is set to `direct` by default, but you can change it to `heap` to use Java heap space instead, which will be become the default in the future.
+Currently it is set to `heap` by default, but you can change it to `direct` to use direct memory space instead.
 When set to `heap`, buffer allocations used by plugins are configured to **prefer** the
 Java Heap instead of direct memory, as direct memory allocations may still be necessary depending on the plugin.
 

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -120,9 +120,8 @@ Keep these memory requirements in mind as you calculate your ideal memory alloca
 
 [[off-heap-buffers-allocation]]
 ===== Buffer Allocation types
-Plugins such as {agent}, {beats}, TCP, and HTTP inputs, use by default Java heap memory to allocate the buffers
-used to read events from the network. This is the preferred allocation type because permit to use better tools
-to investigate potential issues with leaking of memory that would result in Out of Memory (OOM) errors.
+Input plugins such as {agent}, {beats}, TCP, and HTTP will allocate buffers in Java heap memory to read events from the network.
+This is the preferred allocation method as it facilitates debugging memory usage problems (such as leaks and Out of Memory errors) through the analysis of heap dumps.
 
 However, in the past the default allocation was in direct memory, to re-enable the old behaviour {ls} provides
 a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate

--- a/docs/static/config-details.asciidoc
+++ b/docs/static/config-details.asciidoc
@@ -118,30 +118,20 @@ To summarize, we have 3 categories of memory usage, where 2 can be limited by th
 
 Keep these memory requirements in mind as you calculate your ideal memory allocation.
 
-[[reducing-off-heap-usage]]
-===== Upcoming changes to Buffer Allocation and Troubleshooting Out of Memory errors
+[[off-heap-buffers-allocation]]
+===== Buffer Allocation types
+Plugins such as {agent}, {beats}, TCP, and HTTP inputs, use by default Java heap memory to allocate the buffers
+used to read events from the network. This is the preferred allocation type because permit to use better tools
+to investigate potential issues with leaking of memory that would result in Out of Memory (OOM) errors.
 
-Plugins such as {agent}, {beats}, TCP, and HTTP inputs, currently default to using direct memory as it tends
-to provide better performance, especially when interacting with the network stack. 
-Under heavy load, namely large number of connections and large messages, the direct memory space can be exhausted and lead to Out of Memory (OOM) errors in off-heap space.
-
-An off-heap OOM is difficult to debug, so {ls} provides a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate memory buffers for plugins that use them. 
+However, in the past the default allocation was in direct memory, to re-enable the old behaviour {ls} provides
+a `pipeline.buffer.type` setting in <<logstash-settings-file>> that lets you control where to allocate
+memory buffers for plugins that use them.
 Currently it is set to `heap` by default, but you can change it to `direct` to use direct memory space instead.
-When set to `heap`, buffer allocations used by plugins are configured to **prefer** the
-Java Heap instead of direct memory, as direct memory allocations may still be necessary depending on the plugin.
 
-When set to "heap", in the event of an out-of-memory, Logstash will produce a heap dump to facilitate debugging.
-
-It is important to note that the Java heap sizing requirements will be impacted by this change since
-allocations that previously resided on the direct memory will use heap instead. 
-
-Performance-wise there shouldn't be a noticeable impact, since while direct memory IO is faster, Logstash Event objects produced by these plugins end up being allocated on the Java Heap, incurring the cost of copying from direct memory to heap memory regardless of the setting.
-
-[NOTE] 
---
-* When you set `pipeline.buffer.type` to `heap`, consider incrementing the Java heap by the 
-amount of memory that had been reserved for direct space. 
---
+Performance-wise there shouldn't be a noticeable impact in switching to `direct`, since while direct memory IO is faster,
+Logstash Event objects produced by these plugins end up being allocated on the Java Heap,
+incurring the cost of copying from direct memory to heap memory regardless of the setting.
 
 [[memory-size-calculation]]
 ===== Memory sizing

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -370,5 +370,5 @@ Setting this flag to `warn` is deprecated and will be removed in a future releas
 | `pipeline.buffer.type`
 | Determine where to allocate memory buffers, for plugins that leverage them.
 Currently defaults to `heap` but can be switched to `direct` to select direct memory space.
-| `heap` Check out <<reducing-off-heap-usage>> for more info.
+| `heap` Check out <<off-heap-buffers-allocation>> for more info.
 |=======================================================================

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -369,6 +369,6 @@ Setting this flag to `warn` is deprecated and will be removed in a future releas
 
 | `pipeline.buffer.type`
 | Determine where to allocate memory buffers, for plugins that leverage them.
-Currently defaults to `direct` but can be switched to `heap` to select Java heap space, which will become the default in the future.
-| `direct` Check out <<reducing-off-heap-usage>> for more info.
+Currently defaults to `heap` but can be switched to `direct` to select direct memory space.
+| `heap` Check out <<reducing-off-heap-usage>> for more info.
 |=======================================================================

--- a/docs/static/settings-file.asciidoc
+++ b/docs/static/settings-file.asciidoc
@@ -369,6 +369,6 @@ Setting this flag to `warn` is deprecated and will be removed in a future releas
 
 | `pipeline.buffer.type`
 | Determine where to allocate memory buffers, for plugins that leverage them.
-Currently defaults to `heap` but can be switched to `direct` to select direct memory space.
+Defaults to `heap` but can be switched to `direct` to instruct Logstash to prefer allocation of buffers in direct memory.
 | `heap` Check out <<off-heap-buffers-allocation>> for more info.
 |=======================================================================

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -111,7 +111,7 @@ module LogStash
             Setting::String.new("keystore.classname", "org.logstash.secret.store.backend.JavaKeyStore"),
             Setting::String.new("keystore.file", ::File.join(::File.join(LogStash::Environment::LOGSTASH_HOME, "config"), "logstash.keystore"), false), # will be populated on
     Setting::NullableString.new("monitoring.cluster_uuid"),
-            Setting::String.new("pipeline.buffer.type", "direct", true, ["direct", "heap"])
+            Setting::String.new("pipeline.buffer.type", "heap", true, ["direct", "heap"])
   # post_process
   ].each {|setting| SETTINGS.register(setting) }
 

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -95,7 +95,11 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   context "new model" do
     context "with webserver disabled" do
       it_behaves_like("new model monitoring event with webserver setting") do
+<<<<<<< HEAD
         let(:webserver_enabled) {false}
+=======
+         let(:webserver_enabled) {false}
+>>>>>>> df87295f0 ([Test] Fixed x-pack tests of StatsEventFactory to verify the web server binding iff the webserver setting is enabled)
       end
     end
 

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -50,7 +50,6 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   let(:pipeline_settings) { LogStash::Runner::SYSTEM_SETTINGS.clone.merge({
     "pipeline.id" => "main",
     "config.string" => config,
-    "api.enabled" => webserver_enabled,
   }) }
 
   let(:agent) { LogStash::Agent.new(pipeline_settings) }
@@ -95,11 +94,7 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   context "new model" do
     context "with webserver disabled" do
       it_behaves_like("new model monitoring event with webserver setting") do
-<<<<<<< HEAD
         let(:webserver_enabled) {false}
-=======
-         let(:webserver_enabled) {false}
->>>>>>> df87295f0 ([Test] Fixed x-pack tests of StatsEventFactory to verify the web server binding iff the webserver setting is enabled)
       end
     end
 

--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -50,6 +50,7 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   let(:pipeline_settings) { LogStash::Runner::SYSTEM_SETTINGS.clone.merge({
     "pipeline.id" => "main",
     "config.string" => config,
+    "api.enabled" => webserver_enabled,
   }) }
 
   let(:agent) { LogStash::Agent.new(pipeline_settings) }


### PR DESCRIPTION
## Release notes

Switch the default value of `pipeline.buffer.type` to use the heap memory instead of direct one.


## What does this PR do?

Change the default value of the setting `pipeline.buffer.type` from `direct` to `heap` and update consequently the documentation.

## Why is it important/What is the impact to the user?

It's part of the work to make more explicit the usage of memory used by Netty based plugins. Using heap instead of direct for Netty buffers, make easier the debug of memory issues at the cost of bigger heap size.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #16353 

## Use cases

As a developer of Netty based plugin I want to have better insight in memory usage patterns.
