### PR TITLE
Avoid to access Java DeprecatedAlias value other than Ruby's one

### DIFF
--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -154,8 +154,7 @@ module LogStash
     def to_hash
       hash = {}
       @settings.each do |name, setting|
-        next if setting.kind_of? Setting::DeprecatedAlias
-        # next if (setting.kind_of? Setting::DeprecatedAlias) || (setting.kind_of? Java::org.logstash.settings.DeprecatedAlias)
+        next if (setting.kind_of? Setting::DeprecatedAlias) || (setting.kind_of? Java::org.logstash.settings.DeprecatedAlias)
         hash[name] = setting.value
       end
       hash

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -154,7 +154,8 @@ module LogStash
     def to_hash
       hash = {}
       @settings.each do |name, setting|
-        next if (setting.kind_of? Setting::DeprecatedAlias) || (setting.kind_of? Java::org.logstash.settings.DeprecatedAlias)
+        next if setting.kind_of? Setting::DeprecatedAlias
+        # next if (setting.kind_of? Setting::DeprecatedAlias) || (setting.kind_of? Java::org.logstash.settings.DeprecatedAlias)
         hash[name] = setting.value
       end
       hash

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -154,7 +154,7 @@ module LogStash
     def to_hash
       hash = {}
       @settings.each do |name, setting|
-        next if setting.kind_of? Setting::DeprecatedAlias
+        next if (setting.kind_of? Setting::DeprecatedAlias) || (setting.kind_of? Java::org.logstash.settings.DeprecatedAlias)
         hash[name] = setting.value
       end
       hash

--- a/logstash-core/spec/logstash/settings_spec.rb
+++ b/logstash-core/spec/logstash/settings_spec.rb
@@ -62,6 +62,28 @@ describe LogStash::Settings do
     end
   end
 
+  describe "#to_hash" do
+    let(:java_deprecated_alias) { LogStash::Setting::Boolean.new("java.actual", true).with_deprecated_alias("java.deprecated") }
+    let(:ruby_deprecated_alias) { LogStash::Setting::PortRange.new("ruby.actual", 9600..9700).with_deprecated_alias("ruby.deprecated") }
+    let(:non_deprecated) { LogStash::Setting::Boolean.new("plain_setting", false) }
+
+    before :each do
+      subject.register(java_deprecated_alias)
+      subject.register(ruby_deprecated_alias)
+      subject.register(non_deprecated)
+    end
+
+    it "filter deprecated alias settings" do
+      generated_settings_hash = subject.to_hash
+
+      expect(generated_settings_hash).not_to have_key("java.deprecated")
+      expect(generated_settings_hash).not_to have_key("ruby.deprecated")
+      expect(generated_settings_hash).to have_key("java.actual")
+      expect(generated_settings_hash).to have_key("ruby.actual")
+      expect(generated_settings_hash).to have_key("plain_setting")
+    end
+  end
+
   describe "#get_subset" do
     let(:numeric_setting_1) { LogStash::Setting.new("num.1", Numeric, 1) }
     let(:numeric_setting_2) { LogStash::Setting.new("num.2", Numeric, 2) }


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Update Settings to_hash method to also skip Java DeprecatedAlias and not just the Ruby one.
With PR #15679 was introduced `org.logstash.settings.DeprecatedAlias` which mirrors the behaviour of Ruby class `Setting::DeprecatedAlias`. The equality check at `Logstash::Settings`, as descibed in #https://github.com/elastic/logstash/issues/16505#issuecomment-2391679610, is implemented comparing the maps.
The conversion of `Settings` to the corresponding maps filtered out the Ruby implementation of DeprecatedAlias but not the Java one.
This PR adds also the Java one to the list of filter.



## Why is it important/What is the impact to the user?

When the user run Logstash using `pipelines.yml` and enable autoreloading, avoid to continuously log a warn message that's unrelated to the context of configuration change checking.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Follow the steps defined in issue #16505

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #16505

