### PR TITLE
add deprecation log for `--event_api.tags.illegal`

### DIFF
--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -79,8 +79,16 @@ module Clamp
           new_flag = opts[:new_flag]
           new_value = opts.fetch(:new_value, value)
           passthrough = opts.fetch(:passthrough, false)
+          deprecated_msg = opts[:deprecated_msg]
 
-          LogStash::DeprecationMessage.instance << "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{new_flag}=#{new_value}\" instead."
+          LogStash::DeprecationMessage.instance <<
+            if new_flag
+             "DEPRECATION WARNING: The flag #{option.switches} has been deprecated, please use \"--#{new_flag}=#{new_value}\" instead."
+            elsif deprecated_msg
+              deprecated_msg
+            else
+              "DEPRECATION WARNING: The flag #{option.switches} has been deprecated and may be removed in a future release."
+            end
 
           if passthrough
             LogStash::SETTINGS.set(option.attribute_name, value)

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -92,10 +92,6 @@ class LogStash::Runner < Clamp::StrictCommand
          :default => LogStash::SETTINGS.get_default("config.field_reference.escape_style"),
          :attribute_name => "config.field_reference.escape_style"
 
-  option ["--event_api.tags.illegal"], "STRING",
-         I18n.t("logstash.runner.flag.event_api.tags.illegal"),
-         :default => LogStash::SETTINGS.get_default("event_api.tags.illegal"),
-         :attribute_name => "event_api.tags.illegal"
 
   # Module settings
   option ["--modules"], "MODULES",
@@ -266,6 +262,12 @@ class LogStash::Runner < Clamp::StrictCommand
   deprecated_option ["--http.port"], "HTTP_PORT",
     I18n.t("logstash.runner.flag.http_port"),
     :new_flag => "api.http.port", :passthrough => true # use settings to disambiguate
+
+  deprecated_option ["--event_api.tags.illegal"], "STRING",
+         I18n.t("logstash.runner.flag.event_api.tags.illegal"),
+         :default => LogStash::SETTINGS.get_default("event_api.tags.illegal"),
+         :attribute_name => "event_api.tags.illegal", :passthrough => true,
+         :deprecated_msg => I18n.t("logstash.runner.tags-illegal-deprecated")
 
   # We configure the registry and load any plugin that can register hooks
   # with logstash, this needs to be done before any operation.

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -139,9 +139,11 @@ en:
       configtest-flag-information: |-
         You may be interested in the '--configtest' flag which you can use to validate
         logstash's configuration before you choose to restart a running system.
+      tags-illegal-deprecated: >-
+        The settings '--event_api.tags.illegal' is deprecated and will be removed in version 9.
       tags-illegal-warning: >-
         Setting `event_api.tags.illegal` to `warn` allows illegal values in the reserved `tags` field, which may crash pipeline unexpectedly.
-        This flag value is deprecated and may be removed in a future release.
+        This flag value is deprecated and will be removed in version 9.
       # YAML named reference to the logstash.runner.configuration
       # so we can later alias it from logstash.agent.configuration
       configuration: &runner_configuration

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -143,7 +143,7 @@ en:
         The flag '--event_api.tags.illegal' is deprecated and will be removed in version 9.
       tags-illegal-warning: >-
         Setting `event_api.tags.illegal` to `warn` allows illegal values in the reserved `tags` field, which may crash pipeline unexpectedly.
-        This flag value is deprecated and will be removed in version 9.
+        This flag is deprecated and will be removed in version 9.
       # YAML named reference to the logstash.runner.configuration
       # so we can later alias it from logstash.agent.configuration
       configuration: &runner_configuration

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -140,7 +140,7 @@ en:
         You may be interested in the '--configtest' flag which you can use to validate
         logstash's configuration before you choose to restart a running system.
       tags-illegal-deprecated: >-
-        The settings '--event_api.tags.illegal' is deprecated and will be removed in version 9.
+        The flag '--event_api.tags.illegal' is deprecated and will be removed in version 9.
       tags-illegal-warning: >-
         Setting `event_api.tags.illegal` to `warn` allows illegal values in the reserved `tags` field, which may crash pipeline unexpectedly.
         This flag value is deprecated and will be removed in version 9.

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -380,6 +380,32 @@ describe LogStash::Runner do
       end
     end
 
+    context "event_api.tags.illegal" do
+      let(:runner_deprecation_logger_stub) { double("DeprecationLogger(Runner)").as_null_object }
+      let(:args) { ["--event_api.tags.illegal", "warn", "-e", pipeline_string] }
+      before(:each) { allow(runner).to receive(:deprecation_logger).and_return(runner_deprecation_logger_stub) }
+      DEPRECATED_MSG="The settings '--event_api.tags.illegal' is deprecated and will be removed in version 9"
+
+      it "gives deprecation message when setting to `warn`" do
+        expect(runner_deprecation_logger_stub).to receive(:deprecated)
+          .with(a_string_including "This flag value is deprecated and will be removed in version 9")
+          .with(a_string_including DEPRECATED_MSG)
+        subject.run("bin/logstash", args)
+      end
+
+      it "gives deprecation message when setting to `rename`" do
+        expect(runner_deprecation_logger_stub).to receive(:deprecated)
+          .with(a_string_including DEPRECATED_MSG)
+        subject.run("bin/logstash", args)
+      end
+
+      it "does not give deprecation message when unset" do
+        expect(runner_deprecation_logger_stub).not_to receive(:deprecated)
+          .with(a_string_including DEPRECATED_MSG)
+        subject.run("bin/logstash", ["-e", pipeline_string])
+      end
+    end
+
     context "when :pipeline_workers is not defined by the user" do
       it "should not pass the value to the pipeline" do
         expect(LogStash::Agent).to receive(:new) do |settings|

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -388,7 +388,7 @@ describe LogStash::Runner do
 
       it "gives deprecation message when setting to `warn`" do
         expect(runner_deprecation_logger_stub).to receive(:deprecated)
-          .with(a_string_including "This flag value is deprecated and will be removed in version 9")
+          .with(a_string_including "This flag is deprecated and will be removed in version 9")
           .with(a_string_including DEPRECATED_MSG)
         subject.run("bin/logstash", args)
       end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -384,7 +384,7 @@ describe LogStash::Runner do
       let(:runner_deprecation_logger_stub) { double("DeprecationLogger(Runner)").as_null_object }
       let(:args) { ["--event_api.tags.illegal", "warn", "-e", pipeline_string] }
       before(:each) { allow(runner).to receive(:deprecation_logger).and_return(runner_deprecation_logger_stub) }
-      DEPRECATED_MSG="The settings '--event_api.tags.illegal' is deprecated and will be removed in version 9"
+      DEPRECATED_MSG="The flag '--event_api.tags.illegal' is deprecated and will be removed in version 9"
 
       it "gives deprecation message when setting to `warn`" do
         expect(runner_deprecation_logger_stub).to receive(:deprecated)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

The flag `--event_api.tags.illegal` is deprecated and will be removed in version 9. This flag remains available throughout all version 8.x releases. Users who rely on this flag to allow non strings assignment to `tags` field should update their pipeline.

## What does this PR do?

- move `--event_api.tags.illegal` from option to deprecated_option
- add deprecation log when the flag is explicitly used.

## Why is it important/What is the impact to the user?



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- run `bin/logstash -e "input { stdin {} } output { stdout {} }" --event_api.tags.illegal warn`
- logstash-deprecation.log should show related log

## Related issues

- relates: #16461
- relates: https://github.com/elastic/logstash/issues/16356
