### PR TITLE
Fix QA failure introduced by Health API changes and update rspec dependency of the QA package.

### DIFF
--- a/qa/Gemfile
+++ b/qa/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem "rspec", "~> 3.1.0"
+gem "rspec", "~> 3.5"
 gem "rake"
 gem "stud"
 gem "pry", :group => :test

--- a/qa/Gemfile
+++ b/qa/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem "rspec", "~> 3.5"
+gem "rspec", "~> 3.13"
 gem "rake"
 gem "stud"
 gem "pry", :group => :test

--- a/qa/docker/spec/spec_helper.rb
+++ b/qa/docker/spec/spec_helper.rb
@@ -38,7 +38,8 @@ end
 def wait_for_logstash(container)
   Stud.try(40.times, [NoMethodError, Docker::Error::ConflictError, RSpec::Expectations::ExpectationNotMetError, TypeError]) do
     expect(logstash_available?(container)).to be true
-    expect(get_logstash_status(container)).to eql 'green'
+    # unknown or red status may be also meaningful while testing
+    expect(%w(unknown green yellow red).include?(get_logstash_status(container))).to be true
   end
 end
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Addresses two issues:
1. Rspec 3.1.7 cannot properly transform the errors happened while testing. Upgrades rspec dependency of the QA package to resolve the issue;
2. Node stats API status now reflects Health report. One test case was failing due to the change, fixes it.

## Why is it important/What is the impact to the user?
No impact to end users.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues
- 

## Use cases

## Screenshots

## Logs
- Before change: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/795#019272ae-7194-4467-91ae-d07708d6e85b/6424-7571
- After the change: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/796#019272e9-3f2d-43c6-af5e-e6cc0a2793c2