### PR TITLE
health: add `logstash.forceApiStatus: green` escape hatch

### DIFF
--- a/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
+++ b/logstash-core/src/main/java/org/logstash/health/HealthObserver.java
@@ -25,6 +25,8 @@ public class HealthObserver {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    static final String FORCE_API_STATUS_PROPERTY = "logstash.forceApiStatus";
+
     private final MultiIndicator rootIndicator = new MultiIndicator();
     private final MultiIndicator pipelinesIndicator = new MultiIndicator();
 
@@ -33,6 +35,15 @@ public class HealthObserver {
     }
 
     public final Status getStatus() {
+        // Short-term escape-hatch
+        final String forceApiStatus = System.getProperty(FORCE_API_STATUS_PROPERTY);
+        if (forceApiStatus != null) {
+            if (forceApiStatus.equals("green")) {
+                return Status.GREEN;
+            } else {
+                LOGGER.warn("Unsupported `logstash.forceApiStatus`: {} (health report status will be propagated)", forceApiStatus);
+            }
+        }
         return getReport().getStatus();
     }
 

--- a/logstash-core/src/test/java/org/logstash/health/HealthObserverTest.java
+++ b/logstash-core/src/test/java/org/logstash/health/HealthObserverTest.java
@@ -1,0 +1,93 @@
+package org.logstash.health;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.logstash.health.HealthObserver.FORCE_API_STATUS_PROPERTY;
+
+public class HealthObserverTest {
+
+    private final HealthObserver healthObserver = new HealthObserver();
+
+    @Test
+    public void testStatusWhenNotForcedPropagates() {
+        withUnsetSystemProperty(FORCE_API_STATUS_PROPERTY, () -> {
+            for (Status reportStatus : Status.values()) {
+                withIndicator(new TestIndicator(reportStatus), () -> {
+                    assertThat(String.format("Status[%s] should propagate", reportStatus), healthObserver.getStatus(), Matchers.is(reportStatus));
+                });
+            }
+        });
+    }
+
+    @Test
+    public void testStatusWhenForcedGreenEmitsGreen() {
+        withSystemProperty(FORCE_API_STATUS_PROPERTY, "green", () -> {
+            for (Status reportStatus : Status.values()) {
+                withIndicator(new TestIndicator(reportStatus), () -> {
+                    assertThat(String.format("Status[%s] should not propagate", reportStatus), healthObserver.getStatus(), Matchers.is(Status.GREEN));
+                });
+            }
+        });
+    }
+
+    @Test
+    public void testStatusWhenForcedNonsensePropagates() {
+        withSystemProperty(FORCE_API_STATUS_PROPERTY, "nonsense", () -> {
+            for (Status reportStatus : Status.values()) {
+                withIndicator(new TestIndicator(reportStatus), () -> {
+                    assertThat(String.format("Status[%s] should propagate", reportStatus), healthObserver.getStatus(), Matchers.is(reportStatus));
+                });
+            }
+        });
+    }
+
+    void withUnsetSystemProperty(final String propertyName, final Runnable action) {
+        withSystemProperty(propertyName, null, action);
+    }
+
+    void withSystemProperty(final String name, final String value, final Runnable action) {
+        synchronized (System.class) {
+            final String oldValue;
+            if (Objects.isNull(value)) {
+                oldValue = System.clearProperty(name);
+            } else {
+                oldValue = System.setProperty(name, value);
+            }
+            try {
+                action.run();
+            } finally {
+                if (oldValue != null) {
+                    System.setProperty(name, oldValue);
+                } else {
+                    System.clearProperty(name);
+                }
+            }
+        }
+    }
+
+    void withIndicator(Indicator<?> indicator, Runnable runnable) {
+        this.healthObserver.getIndicator().attachIndicator("single", indicator);
+        try {
+            runnable.run();
+        } finally {
+            this.healthObserver.getIndicator().detachIndicator("single", indicator);
+        }
+    }
+
+    static class TestIndicator implements Indicator<Indicator.Report> {
+        private final Status status;
+
+        public TestIndicator(final Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public Report report(ReportContext reportContext) {
+            return () -> this.status;
+        }
+    }
+}


### PR DESCRIPTION
## Release notes

 - Adds an escape hatch to prevent the new health API's status from affecting the status field of other API responses; by setting the `logstash.forceApiStatus` system property to `green`, you can force the other APIs to continue to use hard-coded green value.

## What does this PR do?

Observes a new system property `logstash.forceApiStatus`, and avoids propagating the detected health status if the user sets the property value to `green`.

## Why is it important/What is the impact to the user?

Because external tooling may rely on the previously-hard-coded `green` status in Logstash API responses, we add a way to force API responses to continue using the hard-coded `green` instead of propagating the actual health status.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. Add the following to your `config/jvm.options`:
   ~~~
   -Dlogstash.forceApiStatus=green
   ~~~
2. Start Logstash with a pipeline that will take a while to load:
   ~~~
   bin/logstash -e 'filter { ruby { init => "sleep 100" code => "" } }'
   ~~~
3. Observe non-`green` status in the health API
   ~~~
   curl -X GET "127.0.0.1:9600/_health_report"
   ~~~
4. Observe `green` status in the node info and node stats APIs:
   ~~~
   curl -X GET "127.0.0.1:9600/_node"
   curl -X GET "127.0.0.1:9600/_node/stats"
   ~~~

Repeat _without_ the flag set, and observe that degraded status propagates to the other APIs.
