### PR TITLE
Keeps global settings aligned across entities used in the test for StatsEventFactory

### DIFF
--- a/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics/stats_event_factory_spec.rb
@@ -59,6 +59,8 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   let(:agent_task) { start_agent(agent) }
 
   before :each do
+    @existing_api_enabled = LogStash::SETTINGS.get_value("api.enabled")
+    LogStash::SETTINGS.set_value("api.enabled", webserver_enabled)
     agent
     agent_task
 
@@ -86,6 +88,7 @@ describe LogStash::Inputs::Metrics::StatsEventFactory do
   after :each do
     agent.shutdown
     agent_task.wait
+    LogStash::SETTINGS.set_value("api.enabled", @existing_api_enabled)
     LogStash::SETTINGS.set_value("monitoring.enabled", false)
   end
 


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Forward port the commit 609155a61b693d7e38945b8e4a4aae4b7c27411b used to fix the non clean backport PR #16531 of #16525
`LogStash:SETTINGS` is used in the constructor of `LogStash::Inputs::Metrics::StatsEventFactory` to query the value of `api.enabled`. This PR keeps updated the value for the setting provided to the Agent constructor and to the StatsEventFactory.

## Why is it important/What is the impact to the user?

Fixes a potential flaky test, due to shared (`LogStash:SETTINGS`)  fixture across the test base.


