### PR TITLE
Deprecate for removal ArcSight module

### DIFF
--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -72,7 +72,7 @@ module LogStash module Config
         .each { |mn| deprecation_logger.deprecated("The #{mn} module has been deprecated and will be removed in version 9.") }
 
       if specified_and_available_names.include?("arcsight")
-        deprecation_logger.deprecated("The arcsight module has been deprecated and will be removed in future version.")
+        deprecation_logger.deprecated("The ArcSight module has been deprecated and will be removed in future version.")
       end
 
       specified_and_available_names.each do |module_name|

--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -71,6 +71,10 @@ module LogStash module Config
         .select { |mn| mn != "arcsight" }
         .each { |mn| deprecation_logger.deprecated("The #{mn} module has been deprecated and will be removed in version 9.") }
 
+      if specified_and_available_names.include?("arcsight")
+        deprecation_logger.deprecated("The arcsight module has been deprecated and will be removed in future version.")
+      end
+
       specified_and_available_names.each do |module_name|
         connect_fail_args = {}
         begin

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -2,7 +2,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-<% deprecation_logger.deprecated("The ArcSight module has been deprecated to be removed in a future release.") %>
+<% deprecation_logger.deprecated("The ArcSight module has been deprecated in favor of the Elastic CEF Integration and will be removed in a future version. Learn more about the  Elastic CEF Integration at https://docs.elastic.co/integrations/cef") %>
 <%
 # Define the default inputs to use and a list of valid aliases
 defined_inputs = configured_inputs(["kafka"], {"eventbroker" => "kafka", "smartconnector" => "tcp"})

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -2,6 +2,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+<% deprecation_logger.deprecated("The ArcSight module has been deprecated to be removed in a future release.") %>
 <%
 # Define the default inputs to use and a list of valid aliases
 defined_inputs = configured_inputs(["kafka"], {"eventbroker" => "kafka", "smartconnector" => "tcp"})

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -2,7 +2,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-<% deprecation_logger.deprecated("The ArcSight module has been deprecated in favor of the Elastic CEF Integration and will be removed in a future version. Learn more about the  Elastic CEF Integration at https://docs.elastic.co/integrations/cef") %>
+<% deprecation_logger.deprecated("The ArcSight module has been deprecated in favor of the Elastic CEF Integration and will be removed in a future version. Learn more about the Elastic CEF Integration at https://docs.elastic.co/integrations/cef") %>
 <%
 # Define the default inputs to use and a list of valid aliases
 defined_inputs = configured_inputs(["kafka"], {"eventbroker" => "kafka", "smartconnector" => "tcp"})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Add deprecation log when ArcSight module is used.


## What does this PR do?

Logs a deprecation when Logstash 8.x is started with ArsSight module.

## Why is it important/What is the impact to the user?

The module will be removed in a future version, this is a warning that user should consider.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- test when module is enabled on command line:
```sh
bin/logstash --module arcsight
```
- test when the module is configured in `config/logstash.yml`:
```yaml
modules:
  - name: arcsight
    var.elasticsearch.hosts: "http://localhost:9200"
    var.elasticsearch.api_key: "secret key"
    var.kibana.host: "http://localhost:5601"
    var.kibana.username: "elastic"
    var.kibana.password: "passw0rd"
    var.input.tcp.port: 5606
```

In both cases verify that in the `logs/logstash-deprecation.log`


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #16553

## Logs

```
[2024-10-14T12:01:23,009][WARN ][deprecation.logstash.config.modulescommon] The arcsight module has been deprecated and will be removed in future version.
```