### PR TITLE
Adds a JMH benchmark to test BufferedTokenizerExt class

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -50,7 +50,7 @@ jar {
 }
 
 ext {
-  jmh = 1.22
+  jmh = 1.37
 }
 
 dependencies {
@@ -86,8 +86,9 @@ tasks.register("jmh", JavaExec) {
   doFirst {
     args = [
             "-Djava.io.tmpdir=${buildDir.absolutePath}",
-            "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
-            "-XX:+UseCMSInitiatingOccupancyOnly", "-XX:+DisableExplicitGC",
+//            "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
+//            ""-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
+//            "-XX:+UseCMSInitiatingOccupancyOnly", "-XX:+DisableExplicitGC",
             "-XX:+HeapDumpOnOutOfMemoryError", "-Xms2g", "-Xmx2g",
             shadowJar.archivePath,
             include

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -79,18 +79,15 @@ tasks.register("jmh", JavaExec) {
 
  dependsOn=[':logstash-core-benchmarks:clean', ':logstash-core-benchmarks:shadowJar']
 
-  main = "-jar"
+  mainClass = "-jar"
 
   def include = project.properties.get('include', '')
 
   doFirst {
     args = [
             "-Djava.io.tmpdir=${buildDir.absolutePath}",
-//            "-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
-//            ""-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75",
-//            "-XX:+UseCMSInitiatingOccupancyOnly", "-XX:+DisableExplicitGC",
             "-XX:+HeapDumpOnOutOfMemoryError", "-Xms2g", "-Xmx2g",
-            shadowJar.archivePath,
+            shadowJar.archiveFile.get().asFile,
             include
     ]
   }

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
@@ -28,7 +28,6 @@ import static org.logstash.RubyUtil.RUBY;
 @Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
 @Fork(1)
 @BenchmarkMode(Mode.Throughput)
-//@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 public class BufferedTokenizerExtBenchmark {

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
@@ -1,0 +1,88 @@
+package org.logstash.benchmark;
+
+import org.jruby.RubyArray;
+import org.jruby.RubyString;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+import org.logstash.common.BufferedTokenizerExt;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.logstash.RubyUtil.RUBY;
+
+@Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+//@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class BufferedTokenizerExtBenchmark {
+
+    private BufferedTokenizerExt sut;
+    private ThreadContext context;
+    private RubyString singleTokenPerFragment;
+    private RubyString multipleTokensPerFragment;
+    private RubyString multipleTokensSpreadMultipleFragments_1;
+    private RubyString multipleTokensSpreadMultipleFragments_2;
+    private RubyString multipleTokensSpreadMultipleFragments_3;
+
+    @Setup(Level.Invocation)
+    public void setUp() {
+        sut = new BufferedTokenizerExt(RubyUtil.RUBY, RubyUtil.BUFFERED_TOKENIZER);
+        context = RUBY.getCurrentContext();
+        IRubyObject[] args = {};
+        sut.init(context, args);
+        singleTokenPerFragment = RubyUtil.RUBY.newString("a".repeat(512) + "\n");
+
+        multipleTokensPerFragment = RubyUtil.RUBY.newString("a".repeat(512) + "\n" + "b".repeat(512) + "\n" + "c".repeat(512) + "\n");
+
+        multipleTokensSpreadMultipleFragments_1 = RubyUtil.RUBY.newString("a".repeat(512) + "\n" + "b".repeat(512) + "\n" + "c".repeat(256));
+        multipleTokensSpreadMultipleFragments_2 = RubyUtil.RUBY.newString("c".repeat(256) + "\n" + "d".repeat(512) + "\n" + "e".repeat(256));
+        multipleTokensSpreadMultipleFragments_3 = RubyUtil.RUBY.newString("f".repeat(256) + "\n" + "g".repeat(512) + "\n" + "h".repeat(512) + "\n");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Benchmark
+    @OperationsPerInvocation(10_000_000)
+    public final void onlyOneTokenPerFragment(Blackhole blackhole) {
+        RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, singleTokenPerFragment);
+        blackhole.consume(tokens);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Benchmark
+    @OperationsPerInvocation(10_000_000)
+    public final void multipleTokenPerFragment(Blackhole blackhole) {
+        RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensPerFragment);
+        blackhole.consume(tokens);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Benchmark
+    @OperationsPerInvocation(10_000_000)
+    public final void multipleTokensCrossingMultipleFragments(Blackhole blackhole) {
+        RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensSpreadMultipleFragments_1);
+        blackhole.consume(tokens);
+
+        tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensSpreadMultipleFragments_2);
+        blackhole.consume(tokens);
+
+        tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensSpreadMultipleFragments_3);
+        blackhole.consume(tokens);
+    }
+}

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
@@ -57,7 +57,6 @@ public class BufferedTokenizerExtBenchmark {
 
     @SuppressWarnings("unchecked")
     @Benchmark
-    @OperationsPerInvocation(10_000_000)
     public final void onlyOneTokenPerFragment(Blackhole blackhole) {
         RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, singleTokenPerFragment);
         blackhole.consume(tokens);
@@ -65,7 +64,6 @@ public class BufferedTokenizerExtBenchmark {
 
     @SuppressWarnings("unchecked")
     @Benchmark
-    @OperationsPerInvocation(10_000_000)
     public final void multipleTokenPerFragment(Blackhole blackhole) {
         RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensPerFragment);
         blackhole.consume(tokens);
@@ -73,7 +71,6 @@ public class BufferedTokenizerExtBenchmark {
 
     @SuppressWarnings("unchecked")
     @Benchmark
-    @OperationsPerInvocation(10_000_000)
     public final void multipleTokensCrossingMultipleFragments(Blackhole blackhole) {
         RubyArray<RubyString> tokens = (RubyArray<RubyString>) sut.extract(context, multipleTokensSpreadMultipleFragments_1);
         blackhole.consume(tokens);


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Adds a JMH benchmark to measure the peformances of `BufferedTokenizerExt`.
Update also Gradle build script to remove CMS GC flags and fix deprecations for  Gradle 9.0.

## Why is it important/What is the impact to the user?

As a developer I want to have benchmark measure of `BufferedTokenizerExt`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~


## How to test

Run with:
```sh
./gradlew jmh -Pinclude="org.logstash.benchmark.BufferedTokenizerExtBenchmark.*"
```