### PR TITLE
ensure minitar 1.x is used instead of 0.x

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -14,7 +14,7 @@ gem "logstash-output-elasticsearch", ">= 11.14.0"
 gem "polyglot", require: false
 gem "treetop", require: false
 gem "faraday", "~> 1", :require => false # due elasticsearch-transport (elastic-transport) depending faraday '~> 1'
-gem "minitar", :group => :build
+gem "minitar", "~> 1", :group => :build
 gem "childprocess", "~> 4", :group => :build
 gem "fpm", "~> 1", ">= 1.14.1", :group => :build # compound due to bugfix https://github.com/jordansissel/fpm/pull/1856
 gem "gems", "~> 1", :group => :build

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "thwait"
 
   # filetools and rakelib
-  gem.add_runtime_dependency "minitar", "~> 0.8"
+  gem.add_runtime_dependency "minitar", "~> 1"
   gem.add_runtime_dependency "rubyzip", "~> 1"
   gem.add_runtime_dependency "thread_safe", "~> 0.3.6" #(Apache 2.0 license)
 


### PR DESCRIPTION
Logstash now expects minitar to be 1.x since https://github.com/elastic/logstash/pull/16432, but the dependency wasn't constrained correctly in the Gemfile or logstash-core.gemspec.

This fixes the issue by pinning to "~> 1"