### PR TITLE
make max inflight warning global to all pipelines

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -39,7 +39,6 @@ module LogStash; class JavaPipeline < AbstractPipeline
     :started_at,
     :thread
 
-  MAX_INFLIGHT_WARN_THRESHOLD = 10_000
   SECOND = 1
   MEMORY = "memory".freeze
 
@@ -283,10 +282,6 @@ module LogStash; class JavaPipeline < AbstractPipeline
         "pipeline.max_inflight" => max_inflight,
         "pipeline.sources" => pipeline_source_details)
       @logger.info("Starting pipeline", pipeline_log_params)
-
-      if max_inflight > MAX_INFLIGHT_WARN_THRESHOLD
-        @logger.warn("CAUTION: Recommended inflight events max exceeded! Logstash will run with up to #{max_inflight} events in memory in your current configuration. If your message sizes are large this may cause instability with the default heap size. Please consider setting a non-standard heap size, changing the batch size (currently #{batch_size}), or changing the number of pipeline workers (currently #{pipeline_workers})", default_logging_keys)
-      end
 
       filter_queue_client.set_batch_dimensions(batch_size, batch_delay)
 

--- a/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
+++ b/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
@@ -1,0 +1,54 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module LogStash
+  class PipelineResourceUsageValidator
+    include LogStash::Util::Loggable
+
+    WARN_HEAP_THRESHOLD = 10 # 10%
+
+    def initialize(max_heap_size)
+      @max_heap_size = max_heap_size
+    end
+
+    # TODO
+    # @param pipelines_registry
+    def check(pipelines_registry)
+      percentage_of_heap = compute_percentage(pipelines_registry)
+
+      if percentage_of_heap >= WARN_HEAP_THRESHOLD
+        logger.warn("For a baseline of 2KB events, the maximum heap memory consumed across #{pipelines_registry.size} pipelines may reach up to #{percentage_of_heap}% of the entire heap (more if the events are bigger). The recommended percentage is less than #{WARN_HEAP_THRESHOLD}%. Consider reducing the number of pipelines, or the batch size and worker count per pipeline.")
+      else
+        logger.debug("For a baseline of 2KB events, the maximum heap memory consumed across #{pipelines_registry.size} pipelines may reach up to #{percentage_of_heap}% of the entire heap (more if the events are bigger).")
+      end
+    end
+
+    def compute_percentage(pipelines_registry)
+      max_event_count = sum_event_count(pipelines_registry)
+      estimated_heap_usage = max_event_count * 2.0 * 1024 # assume 2KB per event
+      percentage_of_heap = ((estimated_heap_usage / @max_heap_size) * 100).round(2)
+    end
+
+    def sum_event_count(pipelines_registry)
+      pipelines_registry.loaded_pipelines.map do |pipeline_id, pipeline|
+        batch_size = pipeline.settings.get("pipeline.batch.size")
+        pipeline_workers = pipeline.settings.get("pipeline.workers")
+        batch_size * pipeline_workers
+      end.reduce(:+)
+    end
+  end
+end

--- a/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
+++ b/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
@@ -28,6 +28,8 @@ module LogStash
     # TODO
     # @param pipelines_registry
     def check(pipelines_registry)
+      return if pipelines_registry.size == 0
+
       percentage_of_heap = compute_percentage(pipelines_registry)
 
       if percentage_of_heap >= WARN_HEAP_THRESHOLD
@@ -44,11 +46,11 @@ module LogStash
     end
 
     def sum_event_count(pipelines_registry)
-      pipelines_registry.loaded_pipelines.map do |pipeline_id, pipeline|
+      pipelines_registry.loaded_pipelines.inject(0) do |sum, (pipeline_id, pipeline)|
         batch_size = pipeline.settings.get("pipeline.batch.size")
         pipeline_workers = pipeline.settings.get("pipeline.workers")
-        batch_size * pipeline_workers
-      end.reduce(:+)
+        sum + (batch_size * pipeline_workers)
+      end
     end
   end
 end

--- a/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
+++ b/logstash-core/lib/logstash/pipeline_resource_usage_validator.rb
@@ -25,8 +25,6 @@ module LogStash
       @max_heap_size = max_heap_size
     end
 
-    # TODO
-    # @param pipelines_registry
     def check(pipelines_registry)
       return if pipelines_registry.size == 0
 

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -1009,13 +1009,6 @@ describe LogStash::JavaPipeline do
       expect(logger).not_to have_received(:warn).with(warning_prefix)
     end
 
-    context "with a too large inflight count" do
-      let(:batch_size) { LogStash::JavaPipeline::MAX_INFLIGHT_WARN_THRESHOLD + 1 }
-
-      it "should raise a max inflight warning if the max_inflight count is exceeded" do
-        expect(logger).to have_received(:warn).with(warning_prefix, hash_including(:pipeline_id => anything))
-      end
-    end
   end
 
   context "compiled filter functions" do

--- a/logstash-core/spec/logstash/pipeline_resource_usage_validator_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_resource_usage_validator_spec.rb
@@ -1,0 +1,48 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "spec_helper"
+require "logstash/pipeline_resource_usage_validator"
+require_relative '../support/helpers'
+
+describe LogStash::PipelineResourceUsageValidator do
+  let(:max_heap_size) { 1 * 1024 * 1024 * 1024 } # 1 GB
+  subject { LogStash::PipelineResourceUsageValidator.new(max_heap_size) }
+  let(:logger) { subject.logger }
+  let(:pipelines_registry) { double(:pipelines_registry) }
+
+  before(:each) do
+    allow(subject).to receive(:compute_percentage).and_return(usage_percentage)
+    allow(pipelines_registry).to receive(:size).and_return(10)
+  end
+
+  context "when memory usage goes above 10% heap" do
+    let(:usage_percentage) { 45 }
+    it "logs a warning message"  do
+      expect(logger).to receive(:warn) #.with(/a/)
+      subject.check(pipelines_registry)
+    end
+  end
+
+  context "when memory usage is below 10% heap" do
+    let(:usage_percentage) { 5 }
+    it "logs a debug message" do
+      expect(logger).to receive(:debug) #.with(/a/)
+      subject.check(pipelines_registry)
+    end
+  end
+end

--- a/logstash-core/spec/logstash/pipeline_resource_usage_validator_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_resource_usage_validator_spec.rb
@@ -24,16 +24,17 @@ describe LogStash::PipelineResourceUsageValidator do
   subject { LogStash::PipelineResourceUsageValidator.new(max_heap_size) }
   let(:logger) { subject.logger }
   let(:pipelines_registry) { double(:pipelines_registry) }
+  let(:pipeline_count) { 10 }
 
   before(:each) do
     allow(subject).to receive(:compute_percentage).and_return(usage_percentage)
-    allow(pipelines_registry).to receive(:size).and_return(10)
+    allow(pipelines_registry).to receive(:size).and_return(pipeline_count)
   end
 
   context "when memory usage goes above 10% heap" do
     let(:usage_percentage) { 45 }
     it "logs a warning message"  do
-      expect(logger).to receive(:warn) #.with(/a/)
+      expect(logger).to receive(:warn).with(/may reach up to #{usage_percentage}.*Consider.*pipeline.$/)
       subject.check(pipelines_registry)
     end
   end
@@ -41,7 +42,17 @@ describe LogStash::PipelineResourceUsageValidator do
   context "when memory usage is below 10% heap" do
     let(:usage_percentage) { 5 }
     it "logs a debug message" do
-      expect(logger).to receive(:debug) #.with(/a/)
+      expect(logger).to receive(:debug).with(/may reach up to #{usage_percentage}.*bigger\).$/)
+      subject.check(pipelines_registry)
+    end
+  end
+
+  context "when there are no pipelines" do
+    let(:pipeline_count) { 0 }
+    let(:usage_percentage) { 0 }
+    it "should not log" do
+      expect(logger).to_not receive(:warn)
+      expect(logger).to_not receive(:debug)
       subject.check(pipelines_registry)
     end
   end


### PR DESCRIPTION


```yml            
- pipeline.id: test_01
  config.string: "input { heartbeat {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
- pipeline.id: test_02
  config.string: "input { heartbeat {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
- pipeline.id: test_03
  config.string: "input { heartbeat {} } filter { sleep { time => 1 } } output { stdout { codec => dots } }"
```

```
~/elastic/logstash improve_max_inflight_warning ❯ bin/logstash -r -b 125 --debug | grep resource                 
[2024-10-24T11:44:44,941][DEBUG][logstash.pipelineresourceusagevalidator] For a baseline of 2KB events, the maximum heap memory consumed across 3 pipelines may reach up to 0.72% of the entire heap (more if the events are bigger).
```

```
~/elastic/logstash improve_max_inflight_warning ❯ bin/logstash -r -b 12500 --debug | grep resource
[2024-10-24T11:45:13,008][WARN ][logstash.pipelineresourceusagevalidator] For a baseline of 2KB events, the maximum heap memory consumed across 3 pipelines may reach up to 71.53% of the entire heap (more if the events are bigger). The recommended percentage is less than 10%. Consider reducing the number of pipelines, or the batch size and worker count per pipeline.
```

closes https://github.com/elastic/logstash/issues/8622