### PR TITLE
[CI] Change agent for JDK availability check and add schedule also for 8.x

### DIFF
--- a/.buildkite/jdk_availability_check_pipeline.yml
+++ b/.buildkite/jdk_availability_check_pipeline.yml
@@ -1,7 +1,14 @@
 steps:
   - label: "JDK Availability check"
+    key: "jdk-availability-check"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-logstash-ci"
+      cpu: "4"
+      memory: "6Gi"
+      ephemeralStorage: "100Gi"
     command: |
       set -euo pipefail
 
-      source .buildkite/scripts/common/vm-agent.sh
+      source .buildkite/scripts/common/container-agent.sh
+      export GRADLE_OPTS="-Xmx2g -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info"
       ci/check_jdk_version_availability.sh

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -573,12 +573,6 @@ spec:
           env:
             PIPELINES_TO_TRIGGER: 'logstash-exhaustive-tests-pipeline'
             EXCLUDE_BRANCHES: 'main'
-        JDK availability check:
-          branch: main
-          cronline: 0 2 * * 1  # every Monday@2AM UTC
-          message: Weekly trigger of JDK update availability pipeline per branch
-          env:
-            PIPELINES_TO_TRIGGER: 'logstash-jdk-availability-check-pipeline'
       skip_intermediate_builds: true
       provider_settings:
         trigger_mode: none
@@ -791,6 +785,19 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      schedules:
+        Weekly JDK availability check (main):
+          branch: main
+          cronline: 0 2 * * 1  # every Monday@2AM UTC
+          message: Weekly trigger of JDK update availability pipeline per branch
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-jdk-availability-check-pipeline'
+        Weekly JDK availability check (8.x):
+          branch: 8.x
+          cronline: 0 2 * * 1  # every Monday@2AM UTC
+          message: Weekly trigger of JDK update availability pipeline per branch
+          env:
+            PIPELINES_TO_TRIGGER: 'logstash-jdk-availability-check-pipeline'
 
 # *******************************
 # SECTION END: JDK check pipeline


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]


## What does this PR do?
Switch execution agent of JDK availability check pipeline from vm-agent to container-agent.
Moves the schedule definition from the `Logstash Pipeline Scheduler` pipeline into the pipeline definition, adding a schedule also for `8.x` branch.
