### PR TITLE
add boostrap to docker build to fix missing jars

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -158,6 +158,7 @@ namespace "artifact" do
 
   desc "Build jdk bundled tar.gz of default logstash plugins with all dependencies for docker"
   task "archives_docker" => ["prepare", "generate_build_metadata"] do
+    safe_system("./gradlew bootstrap") # force the build of Logstash jars
     license_details = ['ELASTIC-LICENSE']
     @bundles_jdk = true
     create_archive_pack(license_details, "x86_64", "linux", "darwin")
@@ -222,6 +223,7 @@ namespace "artifact" do
 
   desc "Build jdk bundled OSS tar.gz of default logstash plugins with all dependencies for docker"
   task "archives_docker_oss" => ["prepare-oss", "generate_build_metadata"] do
+    safe_system("./gradlew bootstrap") # force the build of Logstash jars
     #with bundled JDKs
     @bundles_jdk = true
     license_details = ['APACHE-LICENSE-2.0', "-oss", oss_exclude_paths]


### PR DESCRIPTION
The DRA build failed because the required jars were missing, as they had been removed during the Docker build process.

failure [log](https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/1613#0192e590-eb71-4d08-8b26-1d87e2369680) 
```
...
#18 DONE 3.5s
--
  | docker kill logstash-docker-artifact-server
  | logstash-docker-artifact-server
  | ls: cannot access '*.jar': No such file or directory
  | Using system java: /opt/buildkite-agent/.java/bin/java
  | Error: Could not find or load main class org.logstash.launchers.JvmOptionsParser
  | Caused by: java.lang.ClassNotFoundException: org.logstash.launchers.JvmOptionsParser
  | ERROR: artifact:docker_oss build failed.
```
relates: #16619