### PR TITLE
[CI] Fix acceptance test permission issue

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/generate.rb
@@ -34,13 +34,13 @@ shared_examples "logstash generate" do |logstash|
     GENERATE_TYPES.each do |type|
       context "with type #{type}" do
         it "successfully generate the plugin skeleton" do
-          command = logstash.run_command_in_path("bin/logstash-plugin generate --type #{type} --name qatest-generated")
+          command = logstash.run_sudo_command_in_path("bin/logstash-plugin generate --type #{type} --name qatest-generated")
           expect(logstash).to File.directory?("logstash-#{type}-qatest-generated")
         end
         it "successfully install the plugin" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install logstash-#{type}-qatest-generated")
-            expect(command).to install_successfully
-            expect(logstash).to have_installed?("logstash-#{type}-qatest-generated")
+          command = logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-#{type}-qatest-generated")
+          expect(command).to install_successfully
+          expect(logstash).to have_installed?("logstash-#{type}-qatest-generated")
         end
       end
     end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/install.rb
@@ -42,7 +42,7 @@ shared_examples "logstash install" do |logstash|
           after(:each) { logstash.delete_file(gem_tmp_path) }
 
           it "successfully install the plugin" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install #{gem_tmp_path}")
+            command = logstash.run_sudo_command_in_path("bin/logstash-plugin install #{gem_tmp_path}")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-dns")
             expect(logstash).not_to be_running
@@ -54,7 +54,7 @@ shared_examples "logstash install" do |logstash|
 
         context "when fetching a gem from rubygems" do
           it "successfully install the plugin" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+            command = logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest")
             expect(logstash).not_to be_running
@@ -64,7 +64,7 @@ shared_examples "logstash install" do |logstash|
           end
 
           it "successfully install the plugin when verification is disabled" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify logstash-filter-qatest")
+            command = logstash.run_sudo_command_in_path("bin/logstash-plugin install --no-verify logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest")
             expect(logstash).not_to be_running
@@ -74,7 +74,7 @@ shared_examples "logstash install" do |logstash|
           end
 
           it "fails when installing a non logstash plugin" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install  bundler")
+            command = logstash.run_sudo_command_in_path("bin/logstash-plugin install  bundler")
             expect(command).not_to install_successfully
             expect(logstash).not_to be_running
             with_running_logstash_service(logstash) do
@@ -83,7 +83,7 @@ shared_examples "logstash install" do |logstash|
           end
 
           it "allow to install a specific version" do
-            command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify --version 0.1.0 logstash-filter-qatest")
+            command = logstash.run_sudo_command_in_path("bin/logstash-plugin install --no-verify --version 0.1.0 logstash-filter-qatest")
             expect(command).to install_successfully
             expect(logstash).to have_installed?("logstash-filter-qatest", "0.1.0")
             with_running_logstash_service(logstash) do
@@ -95,7 +95,7 @@ shared_examples "logstash install" do |logstash|
 
       context "when the plugin doesnt exist" do
         it "fails to install and report an error" do
-          command = logstash.run_command_in_path("bin/logstash-plugin install --no-verify logstash-output-impossible-plugin")
+          command = logstash.run_sudo_command_in_path("bin/logstash-plugin install --no-verify logstash-output-impossible-plugin")
           expect(command.stderr).to match(/Plugin not found, aborting/)
           with_running_logstash_service(logstash) do
             expect(logstash).to be_running

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
@@ -33,11 +33,11 @@ shared_examples "integration plugins compatible" do |logstash|
 
     context "when the integration is installed" do
       before(:each) do
-        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+        logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
       end
       context "trying to install an inner plugin separately" do
         it "fails to install" do
-          result = logstash.run_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
+          result = logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
           expect(result.stderr).to match(/is already provided by/)
         end
       end
@@ -46,11 +46,11 @@ shared_examples "integration plugins compatible" do |logstash|
       # Muting test. Tracked in https://github.com/elastic/logstash/issues/10459
       xcontext "if an inner plugin is installed" do
         before(:each) do
-          logstash.run_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
+          logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-input-rabbitmq")
         end
         it "installing the integrations uninstalls the inner plugin" do
-          logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
-          result = logstash.run_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq")
+          logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+          result = logstash.run_sudo_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq")
           expect(result.stdout).to_not match(/^logstash-input-rabbitmq/)
         end
       end
@@ -70,11 +70,11 @@ shared_examples "integration plugins compatible" do |logstash|
 
     context "when the integration is installed" do
       before(:each) do
-        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+        logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
       end
       context "trying to uninstall an inner plugin" do
         it "fails to uninstall it" do
-          result = logstash.run_command_in_path("bin/logstash-plugin uninstall logstash-input-rabbitmq")
+          result = logstash.run_sudo_command_in_path("bin/logstash-plugin uninstall logstash-input-rabbitmq")
           expect(result.stderr).to match(/is already provided by/)
         end
       end
@@ -94,16 +94,16 @@ shared_examples "integration plugins compatible" do |logstash|
 
     context "when the integration is installed" do
       before(:each) do
-        logstash.run_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
+        logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-integration-rabbitmq")
       end
       context "listing an integration" do
-        let(:result) { logstash.run_command_in_path("bin/logstash-plugin list logstash-integration-rabbitmq") }
+        let(:result) { logstash.run_sudo_command_in_path("bin/logstash-plugin list logstash-integration-rabbitmq") }
         it "shows its inner plugin" do
           expect(result.stdout).to match(/logstash-input-rabbitmq/m)
         end
       end
       context "listing an inner plugin" do
-        let(:result) { logstash.run_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq") }
+        let(:result) { logstash.run_sudo_command_in_path("bin/logstash-plugin list logstash-input-rabbitmq") }
         it "matches the integration that contains it" do
           expect(result.stdout).to match(/logstash-integration-rabbitmq/m)
         end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/list.rb
@@ -35,17 +35,17 @@ shared_examples "logstash list" do |logstash|
 
     context "without a specific plugin" do
       it "display a list of plugins" do
-        result = logstash.run_command_in_path("bin/logstash-plugin list")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin list")
         expect(result.stdout.split("\n").size).to be > 1
       end
 
       it "display a list of installed plugins" do
-        result = logstash.run_command_in_path("bin/logstash-plugin list --installed")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin list --installed")
         expect(result.stdout.split("\n").size).to be > 1
       end
 
       it "list the plugins with their versions" do
-        result = logstash.run_command_in_path("bin/logstash-plugin list --verbose")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin list --verbose")
 
         stdout = StringIO.new(result.stdout)
         stdout.set_encoding(Encoding::UTF_8)
@@ -74,12 +74,12 @@ shared_examples "logstash list" do |logstash|
     context "with a specific plugin" do
       let(:plugin_name) { "logstash-input-stdin" }
       it "list the plugin and display the plugin name" do
-        result = logstash.run_command_in_path("bin/logstash-plugin list #{plugin_name}")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin list #{plugin_name}")
         expect(result).to run_successfully_and_output(/^#{plugin_name}$/)
       end
 
       it "list the plugin with his version" do
-        result = logstash.run_command_in_path("bin/logstash-plugin list --verbose #{plugin_name}")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin list --verbose #{plugin_name}")
         expect(result).to run_successfully_and_output(/^#{plugin_name} \(\d+\.\d+.\d+\)/)
       end
     end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb
@@ -32,17 +32,17 @@ shared_examples "logstash remove" do |logstash|
 
     context "when the plugin isn't installed" do
       it "fails to remove it" do
-        result = logstash.run_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
         expect(result.stderr).to match(/This plugin has not been previously installed/)
       end
     end
 
     context "when the plugin is installed" do
       it "successfully removes it" do
-        result = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
         expect(logstash).to have_installed?("logstash-filter-qatest")
 
-        result = logstash.run_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin remove logstash-filter-qatest")
         expect(logstash).not_to have_installed?("logstash-filter-qatest")
         expect(logstash).not_to be_running
         with_running_logstash_service(logstash) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
@@ -32,17 +32,17 @@ shared_examples "logstash uninstall" do |logstash|
 
     context "when the plugin isn't installed" do
       it "fails to uninstall it" do
-        result = logstash.run_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
         expect(result.stderr).to match(/This plugin has not been previously installed/)
       end
     end
 
     context "when the plugin is installed" do
       it "successfully uninstall it" do
-        result = logstash.run_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin install logstash-filter-qatest")
         expect(logstash).to have_installed?("logstash-filter-qatest")
 
-        result = logstash.run_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
+        result = logstash.run_sudo_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
         expect(logstash).not_to have_installed?("logstash-filter-qatest")
         expect(logstash).not_to be_running
         with_running_logstash_service(logstash) do

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/update.rb
@@ -33,8 +33,8 @@ shared_examples "logstash update" do |logstash|
     let(:previous_version) { "0.1.0" }
 
     before do
-      logstash.run_command_in_path("bin/logstash-plugin install --no-verify --version #{previous_version} #{plugin_name}")
-      logstash.run_command_in_path("bin/logstash-plugin list")
+      logstash.run_sudo_command_in_path("bin/logstash-plugin install --no-verify --version #{previous_version} #{plugin_name}")
+      logstash.run_sudo_command_in_path("bin/logstash-plugin list")
       expect(logstash).to have_installed?(plugin_name, previous_version)
       # Logstash won't update when we have a pinned version in the gemfile so we remove them
       logstash.replace_in_gemfile(',[[:space:]]"0.1.0"', "")
@@ -42,7 +42,7 @@ shared_examples "logstash update" do |logstash|
 
     context "update a specific plugin" do
       it "has executed successfully" do
-        cmd = logstash.run_command_in_path("bin/logstash-plugin update --no-verify #{plugin_name}")
+        cmd = logstash.run_sudo_command_in_path("bin/logstash-plugin update --no-verify #{plugin_name}")
         expect(cmd.stdout).to match(/Updating #{plugin_name}/)
         expect(logstash).to have_installed?(plugin_name, "0.1.1")
         expect(logstash).not_to have_installed?(plugin_name, previous_version)
@@ -55,7 +55,7 @@ shared_examples "logstash update" do |logstash|
 
     context "update all the plugins" do
       it "has executed successfully" do
-        logstash.run_command_in_path("bin/logstash-plugin update --no-verify")
+        logstash.run_sudo_command_in_path("bin/logstash-plugin update --no-verify")
         expect(logstash).to have_installed?(plugin_name, "0.1.1")
         expect(logstash).not_to be_running
         with_running_logstash_service(logstash) do

--- a/qa/rspec/commands.rb
+++ b/qa/rspec/commands.rb
@@ -144,6 +144,14 @@ module ServiceTester
       client.uninstall(name)
     end
 
+    def run_sudo_command_in_path(cmd)
+      client.run_sudo_command_in_path(cmd)
+    end
+
+    def run_sudo_command(cmd)
+      client.run_sudo_command(cmd)
+    end
+
     def run_command_in_path(cmd)
       client.run_command_in_path(cmd)
     end


### PR DESCRIPTION
Acceptance tests run install, uninstall and other commands as root. Starting from v9 #16558, `allow_superuser` is default to `false`, hence the existing tests fail.

This commit fixes the acceptance tests to run logstash as non-root

red acceptance test: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/869
green acceptance test: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/875

window unit test is still failing