### PR TITLE
Remove comments of `config.string`.

### DIFF
--- a/logstash-core/spec/logstash/config/source/multi_local_spec.rb
+++ b/logstash-core/spec/logstash/config/source/multi_local_spec.rb
@@ -146,17 +146,16 @@ describe LogStash::Config::Source::MultiLocal do
 
   describe "#pipeline_configs" do
 
-#     let(:config_string) {
-#      "input {
-#         udp {
-#           port => 5555 # intentional comment contains \"${UDP_DEV_PORT}\" variable, shouldn't break functionalities
-#           host => \"127.0.0.1\"
-#         }
-#         # another intentional comment contains \"${UDP_PROD_HOST}\" variable, shouldn't break functionalities
-#       }
-#       output {}"
-#     }
-    let(:config_string) { "input {} output {}" }
+    let(:config_string) {
+     "input {
+        udp {
+          port => 5555 # intentional comment contains \"${UDP_DEV_PORT}\" variable, shouldn't break functionalities
+          host => \"127.0.0.1\"
+        }
+        # another intentional comment contains \"${UDP_PROD_HOST}\" variable, shouldn't break functionalities
+      }
+      output {}"
+    }
     let(:retrieved_pipelines) do
       [
         { "pipeline.id" => "main", "config.string" => config_string },
@@ -173,6 +172,14 @@ describe LogStash::Config::Source::MultiLocal do
       expect(configs).to be_a(Array)
       expect(configs.first).to be_a(::LogStash::Config::PipelineConfig)
       expect(configs.last).to be_a(::LogStash::Config::PipelineConfig)
+    end
+
+    it "wipes out the comments of `config.string`" do
+      expectation = "input {\n\n        udp {\n\n          port => 5555\n\n          host => \"127.0.0.1\"\n\n        }\n\n\n      }\n\n      output {}"
+      config_without_comments = subject.send(:wipeout_comments, retrieved_pipelines)
+      config_without_comments.each do |config_line|
+        expect(config_line['config.string']).to match expectation
+      end
     end
 
     context "using non pipeline related settings" do


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Environment ${VAR} in `config.string` comments will no longer be evaluated.

## What does this PR do?
if `config.string` of pipeline config has ENV `${VAR}` in its comments and `${VAR}` is not set, pipeline may not start which is meaningless. This change introduces a logic to remove comments of `config.string`.
Note that other keys, such as pipeline.id are YAML definitions where their comments will be wiped out by `YAML:safe_load`.

## Why is it important/What is the impact to the user?
Users who have ${VAR} comments in `config.string` currently need to set `${VAR}` env variable. They are no longer required after this change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally
- pull current PR
- add following config to the `pipeline.yml`
   ```
    - pipeline.id: "test #id1" # test
      config.string: |
        input { generator { count => 10 } } #id${PIPELINE_WORKERS}"
        output {
          # pipeline.workers: "${PIPELINE_WORKERS}"
          stdout { codec => dots } # output
        } # pipeline.workers: "${PIPELINE_WORKERS}"
        # pipeline.workers: "${PIPELINE_WORKERS}"
   ```
- without this change LS would complain to set the `PIPELINE_WORKERS`
- after this change LS doesn't ask to set the `PIPELINE_WORKERS`

## Related issues

- Closes #16008 

## Use cases

## Screenshots

## Logs
