### PR TITLE
Anchor the `-java` match pattern at the end of the string

### DIFF
--- a/lib/pluginmanager/pack_installer/pack.rb
+++ b/lib/pluginmanager/pack_installer/pack.rb
@@ -39,7 +39,7 @@ module LogStash module PluginManager module PackInstaller
     class GemInformation
       EXTENSION = ".gem"
       SPLIT_CHAR = "-"
-      JAVA_PLATFORM_RE = /-java/
+      JAVA_PLATFORM_RE = /-java$/
       DEPENDENCIES_DIR_RE = /dependencies/
 
       attr_reader :file, :name, :version, :platform

--- a/spec/unit/plugin_manager/pack_installer/pack_spec.rb
+++ b/spec/unit/plugin_manager/pack_installer/pack_spec.rb
@@ -113,4 +113,24 @@ describe LogStash::PluginManager::PackInstaller::Pack::GemInformation do
       expect(subject.plugin?).to be_falsey
     end
   end
+
+  context "when it is Java plugin example from an offline zip file" do
+    let(:gem) { "/tmp/randomValue/randomValue2/logstash/logstash-filter-java_filter_example-1.0.5.gem"}
+
+    it "#dependency? return false" do
+      expect(subject.dependency?).to be_falsey
+    end
+
+    it "#plugin? return true" do
+      expect(subject.plugin?).to be_truthy
+    end
+
+    it "returns the version" do
+      expect(subject.version).to eq("1.0.5")
+    end
+
+    it "returns the name" do
+      expect(subject.name).to eq("logstash-filter-java_filter_example")
+    end
+  end
 end


### PR DESCRIPTION
## Release notes
Fix offline plugin install of java plugins that contain`-java` in the name.

## What does this PR do?

Anchor the `-java` match pattern at the end of the string.  This fixes the offline install problem of the logstash-input-java_filter_example plugin.

## Why is it important/What is the impact to the user?

If a user uses the example Java plugins, for example the [logstash-input-java_filter_example](https://github.com/logstash-plugins/logstash-filter-java_filter_example), to demo or test a custom off-line package install, it will fail.

The process is to reproduce the bug is: 

1. Clone, build, and install custom plugin as documented at [How to write a Java filter plugin](https://www.elastic.co/guide/en/logstash/current/java-filter-plugin.html)
2. Pack the plugin for off-line install as documented at [Offline Plugin Management](https://www.elastic.co/guide/en/logstash/current/offline-plugins.html)
3. Install the plugin using the zip file

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] Reviewer: Is there also a bug in the Gradle build process that is not appending `-java` to the gem file names which uncovered this bug?
- [ ] Reviewer: Do I need a tag to auto back-port the branches?  Or do I have to back-port after this passes?

## How to test this PR locally

Use the steps in the why it matters and ensure it no longer fails to install from the zip file.

## Related issues

- Relates  https://github.com/elastic/logstash/commit/12cfa69215e186bcdf39006e8964f6fcbe769942
- Relates https://github.com/elastic/logstash/issues/6393
- Relates https://github.com/elastic/logstash/pull/6168
- Relates https://github.com/elastic/logstash/issues/5906

## Use cases

```
Feature: Plugin install
  Scenario: Off-line plugin install
    When the plugin name is `logstash-output-elasticsearch-5.2.0-java.gem`
    Then platform = java, version = 5.2.0, and name = logstash-output-elasticsearch
  Scenario: Off-line plugin install
    When the plugin name is `logstash-filter-java_filter_example-1.0.5.gem`
    Then platform = nil, version = 1.0.5, and name = logstash-filter-java_filter_example
```

Question for the ingest engineers:  In the second scenario, is platform supposed to be `java` or not?

## Screenshots

N/A

## Logs

The error with `export DEBUG=1` enabled:

```sh
% bin/logstash-plugin install file:///Users/REDACTED/programs/logstash-8.15.3/logstash-offline-plugins-8.15.3.zip
Using bundled JDK: /Users/REDACTED/programs/logstash8/logstash-8.15.3/jdk.app/Contents/Home
Processing jvm.options file at `/Users/REDACTED/programs/logstash8/logstash-8.15.3/config/jvm.options`
Using GEM_HOME=/Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0
Using GEM_PATH=/Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0
DEBUG: exec /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/bin/jruby /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/main.rb install file:///Users/REDACTED/programs/logstash-8.15.3/logstash-offline-plugins-8.15.3.zip
Local file: /Users/REDACTED/programs/logstash-8.15.3/logstash-offline-plugins-8.15.3.zip
Installing with strategy: LogStash::PluginManager::PackInstaller::Local
Installing file: /Users/REDACTED/programs/logstash-8.15.3/logstash-offline-plugins-8.15.3.zip
Pack uncompressed to /var/folders/bf/__3kw_514fb6r6n9l254s53r0000gn/T/studtmp-a13652bd489bf047e1126a8cc63d3c55166fdd3e13acb6f9de30bc0574d4
Installing, logstash-filter, version: java_filter_example file: /var/folders/bf/__3kw_514fb6r6n9l254s53r0000gn/T/studtmp-a13652bd489bf047e1126a8cc63d3c55166fdd3e13acb6f9de30bc0574d4/logstash/logstash-filter-java_filter_example-1.0.5.gem
Gem::Requirement::BadRequirementError: Illformed requirement ["=java_filter_example"]
       parse at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/rubygems/requirement.rb:106
  initialize at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/rubygems/requirement.rb:138
        map! at org/jruby/RubyArray.java:2835
  initialize at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/rubygems/requirement.rb:138
         new at org/jruby/RubyClass.java:949
      create at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/rubygems/requirement.rb:68
  initialize at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/rubygems/dependency.rb:56
  initialize at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/jruby/lib/ruby/stdlib/bundler/dependency.rb:31
         new at org/jruby/RubyClass.java:935
  dependency at /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/bundler/logstash_injector.rb:64
     collect at org/jruby/RubyArray.java:2798
     inject! at /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/bundler/logstash_injector.rb:51
     execute at /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/pack_installer/local.rb:57
     execute at /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/install.rb:48
         run at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
     execute at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/subcommand/execution.rb:11
         run at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
         run at /Users/REDACTED/programs/logstash8/logstash-8.15.3/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:133
      <main> at /Users/REDACTED/programs/logstash8/logstash-8.15.3/lib/pluginmanager/main.rb:64
```
