### PR TITLE
fix Windows java not found log

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -42,7 +42,7 @@ if defined LS_JAVA_HOME (
 )
 
 if not exist "%JAVACMD%" (
-  echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
+  echo could not find java; set LS_JAVA_HOME or ensure java is in PATH 1>&2
   exit /b 1
 )
 


### PR DESCRIPTION
Running logstash from source code in Windows, the log points user to setup JAVA_HOME, which should be LS_JAVA_HOME since v8

Log
```
$ bin\logstash
"Using system java: "C:\Program Files\Common Files\Oracle\Java\javapath\java.exe""
The system cannot find the path specified.
could not find java; set JAVA_HOME or ensure java is in PATH
```

Fix: https://github.com/elastic/logstash/issues/16596