### PR TITLE
deprecate pipeline bus v1

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBus.java
@@ -49,7 +49,7 @@ public interface PipelineBus {
             case "v2": return new PipelineBusV2();
             default:
                 LOGGER.warn("unknown pipeline-bus implementation: {}", pipelineBusImplementation);
-                return new PipelineBusV1();
+                return new PipelineBusV2();
         }
     }
 

--- a/logstash-core/src/test/java/org/logstash/log/LoggingSpyResource.java
+++ b/logstash-core/src/test/java/org/logstash/log/LoggingSpyResource.java
@@ -1,0 +1,40 @@
+package org.logstash.log;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.*;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.rules.ExternalResource;
+
+import java.util.List;
+
+public class LoggingSpyResource extends ExternalResource {
+
+    private static final String APPENDER_NAME = "spyAppender";
+
+    private final Logger loggerToSpyOn;
+    private final Level levelSnapshot;
+    private final ListAppender appender = new ListAppender(APPENDER_NAME);
+
+    public LoggingSpyResource(final org.apache.logging.log4j.Logger loggerToSpyOn) {
+        this.loggerToSpyOn = (Logger) loggerToSpyOn;
+        this.levelSnapshot = this.loggerToSpyOn.getLevel();
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        appender.start();
+        loggerToSpyOn.setLevel(Level.ALL);
+        loggerToSpyOn.addAppender(appender);
+    }
+
+    @Override
+    protected void after() {
+        loggerToSpyOn.removeAppender(appender);
+        loggerToSpyOn.setLevel(levelSnapshot);
+        appender.stop();
+    }
+
+    public List<LogEvent> getLogEvents() {
+        return List.copyOf(appender.getEvents());
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
@@ -494,7 +494,7 @@ public class PipelineBusTest {
         @Test
         public void implementationExplicitIllegal() {
             withSystemProperty("logstash.pipelinebus.implementation", "illegal", () -> {
-                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV1.class);
+                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV2.class);
                 assertThat(pipelineBusLog.getLogEvents()).anySatisfy(logEvent -> {
                     assertThat(logEvent.getMessage().getFormattedMessage()).contains("unknown pipeline-bus implementation", "illegal");
                 });

--- a/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
+++ b/logstash-core/src/test/java/org/logstash/plugins/pipeline/PipelineBusTest.java
@@ -19,16 +19,20 @@
 
 package org.logstash.plugins.pipeline;
 
+import org.apache.logging.log4j.LogManager;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyEventExtLibrary;
+import org.logstash.log.LoggingSpyResource;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -36,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -45,364 +50,368 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class PipelineBusTest {
-    static String address = "fooAddr";
-    static String otherAddress = "fooAddr";
-    static Collection<String> addresses = Arrays.asList(address, otherAddress);
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Class<? extends PipelineBus.Testable>> data() {
-        return Set.of(PipelineBusV1.Testable.class, PipelineBusV2.Testable.class);
-    }
+    @RunWith(Parameterized.class)
+    public static class ImplementationTest {
 
-    @Parameterized.Parameter
-    public Class<PipelineBus.Testable> busClass;
+        static String address = "fooAddr";
+        static String otherAddress = "fooAddr";
+        static Collection<String> addresses = Arrays.asList(address, otherAddress);
 
-    PipelineBus.Testable bus;
-    TestPipelineInput input;
-    TestPipelineOutput output;
-
-    @Before
-    public void setup() throws ReflectiveOperationException {
-        bus = busClass.getDeclaredConstructor().newInstance();
-        input = new TestPipelineInput();
-        output = new TestPipelineOutput();
-    }
-
-    @Test
-    public void subscribeUnsubscribe() throws InterruptedException {
-        assertThat(bus.listen(input, address)).isTrue();
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-        }));
-
-        bus.unlisten(input, address);
-
-        // Key should have been pruned
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-    @Test
-    public void senderRegisterUnregister() {
-        bus.registerSender(output, addresses);
-
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
-            assertThat(addressState.getOutputs()).contains(output);
-        });
-
-        bus.unregisterSender(output, addresses);
-
-        // We should have pruned this address
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-    @Test
-    public void activeSenderPreventsPrune() throws InterruptedException {
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).contains(output);
-        }));
-
-        bus.setBlockOnUnlisten(false);
-        bus.unlisten(input, address);
-
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isNull();
-            assertThat(addressState.getOutputs()).contains(output);
-        }));
-
-        bus.unregisterSender(output, addresses);
-
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-    @Test
-    public void multipleSendersPreventPrune() throws InterruptedException {
-        // begin with 1:1 single output to input
-        bus.registerSender(output, Collections.singleton(address));
-        bus.listen(input, address);
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).contains(output);
-        }));
-        bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
-        assertThat(input.eventCount.longValue()).isEqualTo(1L);
-
-        // attach another output2 as a sender
-        final TestPipelineOutput output2 = new TestPipelineOutput();
-        bus.registerSender(output2, Collections.singleton(address));
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).contains(output, output2);
-        }));
-        bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
-        bus.sendEvents(output2, Collections.singletonList(rubyEvent()), false);
-        assertThat(input.eventCount.longValue()).isEqualTo(3L);
-
-        // unlisten with first input, simulating a pipeline restart
-        assertThat(bus.isBlockOnUnlisten()).isFalse();
-        bus.unlisten(input, address);
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isNull();
-            assertThat(addressState.getOutputs()).contains(output, output2);
-        }));
-
-        // unregister one of the two senders, ensuring that the address state remains in-tact
-        bus.unregisterSender(output, Collections.singleton(address));
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isNull();
-            assertThat(addressState.getOutputs()).contains(output2);
-        }));
-
-        // listen with a new input, emulating the completion of a pipeline restart
-        final TestPipelineInput input2 = new TestPipelineInput();
-        assertThat(bus.listen(input2, address)).isTrue();
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input2);
-            assertThat(addressState.getOutputs()).contains(output2);
-        }));
-        bus.sendEvents(output2, Collections.singletonList(rubyEvent()), false);
-        assertThat(input2.eventCount.longValue()).isEqualTo(1L);
-
-        // shut down our remaining sender, ensuring address state remains in-tact
-        bus.unregisterSender(output2, Collections.singleton(address));
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input2);
-            assertThat(addressState.getOutputs()).isEmpty();
-        }));
-
-        // upon unlistening, ensure orphan address state has been cleaned up
-        bus.unlisten(input2, address);
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-
-    @Test
-    public void activeListenerPreventsPrune() throws InterruptedException {
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-        bus.unregisterSender(output, addresses);
-
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).isEmpty();
-        }));
-
-        bus.setBlockOnUnlisten(false);
-        bus.unlisten(input, address);
-
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-    @Test
-    public void registerUnregisterListenerUpdatesOutputs() {
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-
-        assertThat(bus.getAddressStates(output)).hasValueSatisfying((addressStates) -> {
-            assertThat(addressStates).hasSize(1);
-        });
-
-        bus.unregisterSender(output, addresses);
-        assertThat(bus.getAddressStates(output)).isNotPresent();
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).isEmpty();
-        });
-
-        bus.registerSender(output, addresses);
-        assertThat(bus.getAddressStates(output)).hasValueSatisfying((addressStates) -> {
-            assertThat(addressStates).hasSize(1);
-        });
-        assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
-            assertThat(addressState.getInput()).isSameAs(input);
-            assertThat(addressState.getOutputs()).contains(output);
-        });
-    }
-
-    @Test
-    public void listenUnlistenUpdatesOutputReceivers() throws InterruptedException {
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-
-        bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
-        assertThat(input.eventCount.longValue()).isEqualTo(1L);
-
-        bus.unlisten(input, address);
-
-        TestPipelineInput newInput = new TestPipelineInput();
-        bus.listen(newInput, address);
-
-        bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
-
-        // The new event went to the new input, not the old one
-        assertThat(newInput.eventCount.longValue()).isEqualTo(1L);
-        assertThat(input.eventCount.longValue()).isEqualTo(1L);
-    }
-
-    @Test
-    public void sendingEmptyListToNowhereStillReturns() {
-        bus.registerSender(output, List.of("not_an_address"));
-        bus.sendEvents(output, Collections.emptyList(), true);
-    }
-
-    @Test
-    public void missingInputEventuallySucceeds() throws InterruptedException {
-        bus.registerSender(output, addresses);
-
-        // bus.sendEvent should block at this point since there is no attached listener
-        // For this test we want to make sure that the background thread has had time to actually block
-        // since if we start the input too soon we aren't testing anything
-        // The below code attempts to make sure this happens, though it's hard to be deterministic
-        // without making sendEvent take weird arguments the non-test code really doesn't need
-        CountDownLatch sendLatch = new CountDownLatch(1);
-        Thread sendThread = new Thread(() -> {
-            sendLatch.countDown();
-            bus.sendEvents(output, Collections.singleton(rubyEvent()), true);
-        });
-        sendThread.start();
-
-        // Try to ensure that the send actually happened. The latch gets us close,
-        // the sleep takes us the full way (hopefully)
-        sendLatch.await();
-        Thread.sleep(1000);
-
-        bus.listen(input, address);
-
-        // This would block if there's an error in the code
-        sendThread.join();
-
-        assertThat(input.eventCount.longValue()).isEqualTo(1L);
-    }
-
-    @Test
-    public void whenInDefaultNonBlockingModeInputsShutdownInstantly() throws InterruptedException {
-        // Test confirms the default. If we decide to change the default we should change this test
-        assertThat(bus.isBlockOnUnlisten()).isFalse();
-
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-
-        bus.unlisten(input, address); // This test would block forever if this is not non-block
-        bus.unregisterSender(output, addresses);
-    }
-
-    @Test
-    public void whenInBlockingModeInputsShutdownLast() throws InterruptedException {
-        bus.registerSender(output, addresses);
-        bus.listen(input, address);
-
-        bus.setBlockOnUnlisten(true);
-
-        Thread unlistenThread = new Thread( () -> {
-            try {
-                bus.unlisten(input, address);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        });
-        unlistenThread.start();
-
-        // This should unblock the listener thread
-        bus.unregisterSender(output, addresses);
-        TimeUnit.SECONDS.toMillis(30);
-        unlistenThread.join(Duration.ofSeconds(30).toMillis());
-        assertThat(unlistenThread.getState()).isEqualTo(Thread.State.TERMINATED);
-
-        assertThat(bus.getAddressState(address)).isNotPresent();
-    }
-
-    @Test
-    public void blockingShutdownDeadlock() throws InterruptedException {
-        final ExecutorService executor = Executors.newFixedThreadPool(10);
-        try {
-            for (int i = 0; i < 100; i++) {
-                bus.registerSender(output, addresses);
-                bus.listen(input, address);
-                bus.setBlockOnUnlisten(true);
-
-                // we use a CountDownLatch to increase the likelihood
-                // of simultaneous execution
-                final CountDownLatch startLatch = new CountDownLatch(2);
-                final CompletableFuture<Void> unlistenFuture = CompletableFuture.runAsync(asRunnable(() -> {
-                    startLatch.countDown();
-                    startLatch.await();
-                    bus.unlisten(input, address);
-                }), executor);
-                final CompletableFuture<Void> unregisterFuture = CompletableFuture.runAsync(asRunnable(() -> {
-                    startLatch.countDown();
-                    startLatch.await();
-                    bus.unregisterSender(output, addresses);
-                }), executor);
-
-                // ensure that our tasks all exit successfully, quickly
-                assertThatCode(() -> CompletableFuture.allOf(unlistenFuture, unregisterFuture).get(1, TimeUnit.SECONDS))
-                        .withThreadDumpOnError()
-                        .withFailMessage("Expected unlisten and unregisterSender to not deadlock, but they did not return in a reasonable amount of time in the <%s>th iteration", i)
-                        .doesNotThrowAnyException();
-            }
-        } finally {
-            executor.shutdownNow();
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<Class<? extends PipelineBus.Testable>> data() {
+            return Set.of(PipelineBusV1.Testable.class, PipelineBusV2.Testable.class);
         }
-    }
 
-    @FunctionalInterface
-    interface ExceptionalRunnable<E extends Throwable> {
-        void run() throws E;
-    }
+        @Parameterized.Parameter
+        public Class<PipelineBus.Testable> busClass;
 
-    private Runnable asRunnable(final ExceptionalRunnable<?> exceptionalRunnable) {
-        return () -> {
+        PipelineBus.Testable bus;
+        TestPipelineInput input;
+        TestPipelineOutput output;
+
+        @Before
+        public void setup() throws ReflectiveOperationException {
+            bus = busClass.getDeclaredConstructor().newInstance();
+            input = new TestPipelineInput();
+            output = new TestPipelineOutput();
+        }
+
+        @Test
+        public void subscribeUnsubscribe() throws InterruptedException {
+            assertThat(bus.listen(input, address)).isTrue();
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+            }));
+
+            bus.unlisten(input, address);
+
+            // Key should have been pruned
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+        @Test
+        public void senderRegisterUnregister() {
+            bus.registerSender(output, addresses);
+
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
+                assertThat(addressState.getOutputs()).contains(output);
+            });
+
+            bus.unregisterSender(output, addresses);
+
+            // We should have pruned this address
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+        @Test
+        public void activeSenderPreventsPrune() throws InterruptedException {
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).contains(output);
+            }));
+
+            bus.setBlockOnUnlisten(false);
+            bus.unlisten(input, address);
+
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isNull();
+                assertThat(addressState.getOutputs()).contains(output);
+            }));
+
+            bus.unregisterSender(output, addresses);
+
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+        @Test
+        public void multipleSendersPreventPrune() throws InterruptedException {
+            // begin with 1:1 single output to input
+            bus.registerSender(output, Collections.singleton(address));
+            bus.listen(input, address);
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).contains(output);
+            }));
+            bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
+            assertThat(input.eventCount.longValue()).isEqualTo(1L);
+
+            // attach another output2 as a sender
+            final TestPipelineOutput output2 = new TestPipelineOutput();
+            bus.registerSender(output2, Collections.singleton(address));
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).contains(output, output2);
+            }));
+            bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
+            bus.sendEvents(output2, Collections.singletonList(rubyEvent()), false);
+            assertThat(input.eventCount.longValue()).isEqualTo(3L);
+
+            // unlisten with first input, simulating a pipeline restart
+            assertThat(bus.isBlockOnUnlisten()).isFalse();
+            bus.unlisten(input, address);
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isNull();
+                assertThat(addressState.getOutputs()).contains(output, output2);
+            }));
+
+            // unregister one of the two senders, ensuring that the address state remains in-tact
+            bus.unregisterSender(output, Collections.singleton(address));
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isNull();
+                assertThat(addressState.getOutputs()).contains(output2);
+            }));
+
+            // listen with a new input, emulating the completion of a pipeline restart
+            final TestPipelineInput input2 = new TestPipelineInput();
+            assertThat(bus.listen(input2, address)).isTrue();
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input2);
+                assertThat(addressState.getOutputs()).contains(output2);
+            }));
+            bus.sendEvents(output2, Collections.singletonList(rubyEvent()), false);
+            assertThat(input2.eventCount.longValue()).isEqualTo(1L);
+
+            // shut down our remaining sender, ensuring address state remains in-tact
+            bus.unregisterSender(output2, Collections.singleton(address));
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input2);
+                assertThat(addressState.getOutputs()).isEmpty();
+            }));
+
+            // upon unlistening, ensure orphan address state has been cleaned up
+            bus.unlisten(input2, address);
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+
+        @Test
+        public void activeListenerPreventsPrune() throws InterruptedException {
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+            bus.unregisterSender(output, addresses);
+
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).isEmpty();
+            }));
+
+            bus.setBlockOnUnlisten(false);
+            bus.unlisten(input, address);
+
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+        @Test
+        public void registerUnregisterListenerUpdatesOutputs() {
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+
+            assertThat(bus.getAddressStates(output)).hasValueSatisfying((addressStates) -> {
+                assertThat(addressStates).hasSize(1);
+            });
+
+            bus.unregisterSender(output, addresses);
+            assertThat(bus.getAddressStates(output)).isNotPresent();
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).isEmpty();
+            });
+
+            bus.registerSender(output, addresses);
+            assertThat(bus.getAddressStates(output)).hasValueSatisfying((addressStates) -> {
+                assertThat(addressStates).hasSize(1);
+            });
+            assertThat(bus.getAddressState(address)).hasValueSatisfying((addressState) -> {
+                assertThat(addressState.getInput()).isSameAs(input);
+                assertThat(addressState.getOutputs()).contains(output);
+            });
+        }
+
+        @Test
+        public void listenUnlistenUpdatesOutputReceivers() throws InterruptedException {
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+
+            bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
+            assertThat(input.eventCount.longValue()).isEqualTo(1L);
+
+            bus.unlisten(input, address);
+
+            TestPipelineInput newInput = new TestPipelineInput();
+            bus.listen(newInput, address);
+
+            bus.sendEvents(output, Collections.singletonList(rubyEvent()), false);
+
+            // The new event went to the new input, not the old one
+            assertThat(newInput.eventCount.longValue()).isEqualTo(1L);
+            assertThat(input.eventCount.longValue()).isEqualTo(1L);
+        }
+
+        @Test
+        public void sendingEmptyListToNowhereStillReturns() {
+            bus.registerSender(output, List.of("not_an_address"));
+            bus.sendEvents(output, Collections.emptyList(), true);
+        }
+
+        @Test
+        public void missingInputEventuallySucceeds() throws InterruptedException {
+            bus.registerSender(output, addresses);
+
+            // bus.sendEvent should block at this point since there is no attached listener
+            // For this test we want to make sure that the background thread has had time to actually block
+            // since if we start the input too soon we aren't testing anything
+            // The below code attempts to make sure this happens, though it's hard to be deterministic
+            // without making sendEvent take weird arguments the non-test code really doesn't need
+            CountDownLatch sendLatch = new CountDownLatch(1);
+            Thread sendThread = new Thread(() -> {
+                sendLatch.countDown();
+                bus.sendEvents(output, Collections.singleton(rubyEvent()), true);
+            });
+            sendThread.start();
+
+            // Try to ensure that the send actually happened. The latch gets us close,
+            // the sleep takes us the full way (hopefully)
+            sendLatch.await();
+            Thread.sleep(1000);
+
+            bus.listen(input, address);
+
+            // This would block if there's an error in the code
+            sendThread.join();
+
+            assertThat(input.eventCount.longValue()).isEqualTo(1L);
+        }
+
+        @Test
+        public void whenInDefaultNonBlockingModeInputsShutdownInstantly() throws InterruptedException {
+            // Test confirms the default. If we decide to change the default we should change this test
+            assertThat(bus.isBlockOnUnlisten()).isFalse();
+
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+
+            bus.unlisten(input, address); // This test would block forever if this is not non-block
+            bus.unregisterSender(output, addresses);
+        }
+
+        @Test
+        public void whenInBlockingModeInputsShutdownLast() throws InterruptedException {
+            bus.registerSender(output, addresses);
+            bus.listen(input, address);
+
+            bus.setBlockOnUnlisten(true);
+
+            Thread unlistenThread = new Thread(() -> {
+                try {
+                    bus.unlisten(input, address);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            });
+            unlistenThread.start();
+
+            // This should unblock the listener thread
+            bus.unregisterSender(output, addresses);
+            unlistenThread.join(Duration.ofSeconds(30).toMillis());
+            assertThat(unlistenThread.getState()).isEqualTo(Thread.State.TERMINATED);
+
+            assertThat(bus.getAddressState(address)).isNotPresent();
+        }
+
+        @Test
+        public void blockingShutdownDeadlock() throws InterruptedException {
+            final ExecutorService executor = Executors.newFixedThreadPool(10);
             try {
-                exceptionalRunnable.run();
-            } catch (Throwable e) {
-                throw new RuntimeException(e);
+                for (int i = 0; i < 100; i++) {
+                    bus.registerSender(output, addresses);
+                    bus.listen(input, address);
+                    bus.setBlockOnUnlisten(true);
+
+                    // we use a CountDownLatch to increase the likelihood
+                    // of simultaneous execution
+                    final CountDownLatch startLatch = new CountDownLatch(2);
+                    final CompletableFuture<Void> unlistenFuture = CompletableFuture.runAsync(asRunnable(() -> {
+                        startLatch.countDown();
+                        startLatch.await();
+                        bus.unlisten(input, address);
+                    }), executor);
+                    final CompletableFuture<Void> unregisterFuture = CompletableFuture.runAsync(asRunnable(() -> {
+                        startLatch.countDown();
+                        startLatch.await();
+                        bus.unregisterSender(output, addresses);
+                    }), executor);
+
+                    // ensure that our tasks all exit successfully, quickly
+                    assertThatCode(() -> CompletableFuture.allOf(unlistenFuture, unregisterFuture).get(1, TimeUnit.SECONDS))
+                            .withThreadDumpOnError()
+                            .withFailMessage("Expected unlisten and unregisterSender to not deadlock, but they did not return in a reasonable amount of time in the <%s>th iteration", i)
+                            .doesNotThrowAnyException();
+                }
+            } finally {
+                executor.shutdownNow();
             }
-        };
-    }
+        }
+
+        @FunctionalInterface
+        interface ExceptionalRunnable<E extends Throwable> {
+            void run() throws E;
+        }
+
+        private Runnable asRunnable(final ExceptionalRunnable<?> exceptionalRunnable) {
+            return () -> {
+                try {
+                    exceptionalRunnable.run();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
 
 
-    @Test
-    public void whenInputFailsOutputRetryOnlyNotYetDelivered() throws InterruptedException {
-        bus.registerSender(output, addresses);
-        int expectedReceiveInvocations = 2;
-        CountDownLatch sendsCoupleOfCallsLatch = new CountDownLatch(expectedReceiveInvocations);
-        int positionOfFailure = 1;
-        input = new TestFailPipelineInput(sendsCoupleOfCallsLatch, positionOfFailure);
-        bus.listen(input, address);
+        @Test
+        public void whenInputFailsOutputRetryOnlyNotYetDelivered() throws InterruptedException {
+            bus.registerSender(output, addresses);
+            int expectedReceiveInvocations = 2;
+            CountDownLatch sendsCoupleOfCallsLatch = new CountDownLatch(expectedReceiveInvocations);
+            int positionOfFailure = 1;
+            input = new TestFailPipelineInput(sendsCoupleOfCallsLatch, positionOfFailure);
+            bus.listen(input, address);
 
-        final List<JrubyEventExtLibrary.RubyEvent> events = new ArrayList<>();
-        events.add(rubyEvent());
-        events.add(rubyEvent());
-        events.add(rubyEvent());
+            final List<JrubyEventExtLibrary.RubyEvent> events = new ArrayList<>();
+            events.add(rubyEvent());
+            events.add(rubyEvent());
+            events.add(rubyEvent());
 
-        CountDownLatch senderThreadStarted = new CountDownLatch(1);
-        Thread sendThread = new Thread(() -> {
-            senderThreadStarted.countDown();
+            CountDownLatch senderThreadStarted = new CountDownLatch(1);
+            Thread sendThread = new Thread(() -> {
+                senderThreadStarted.countDown();
 
-            // Exercise
-            bus.sendEvents(output, events, true);
-        });
-        sendThread.start();
+                // Exercise
+                bus.sendEvents(output, events, true);
+            });
+            sendThread.start();
 
-        senderThreadStarted.await(); // Ensure server thread is started
+            senderThreadStarted.await(); // Ensure server thread is started
 
-        // Ensure that send actually happened a couple of times.
-        // Send method retry mechanism sleeps 1 second on each retry!
-        boolean coupleOfCallsDone = sendsCoupleOfCallsLatch.await(3, TimeUnit.SECONDS);
-        sendThread.join();
+            // Ensure that send actually happened a couple of times.
+            // Send method retry mechanism sleeps 1 second on each retry!
+            boolean coupleOfCallsDone = sendsCoupleOfCallsLatch.await(3, TimeUnit.SECONDS);
+            sendThread.join();
 
-        // Verify
-        assertThat(coupleOfCallsDone).isTrue();
-        assertThat(((TestFailPipelineInput)input).getLastBatchSize()).isEqualTo(events.size() - positionOfFailure);
-    }
+            // Verify
+            assertThat(coupleOfCallsDone).isTrue();
+            assertThat(((TestFailPipelineInput) input).getLastBatchSize()).isEqualTo(events.size() - positionOfFailure);
+        }
 
-    private JrubyEventExtLibrary.RubyEvent rubyEvent() {
-      return JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY);
+        private JrubyEventExtLibrary.RubyEvent rubyEvent() {
+            return JrubyEventExtLibrary.RubyEvent.newRubyEvent(RubyUtil.RUBY);
+        }
     }
 
     static class TestPipelineInput implements PipelineInput {
@@ -460,6 +469,64 @@ public class PipelineBusTest {
 
         int getLastBatchSize() {
             return lastBatchSize;
+        }
+    }
+
+    public static class SelectionTest {
+
+        @Rule
+        public LoggingSpyResource pipelineBusLog = new LoggingSpyResource(LogManager.getLogger("org.logstash.plugins.pipeline.PipelineBus"));
+
+        @Test
+        public void implementationExplicitV1() {
+            withSystemProperty("logstash.pipelinebus.implementation", "v1", () -> {
+                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV1.class);
+            });
+        }
+
+        @Test
+        public void implementationExplicitV2() {
+            withSystemProperty("logstash.pipelinebus.implementation", "v2", () -> {
+                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV2.class);
+            });
+        }
+
+        @Test
+        public void implementationExplicitIllegal() {
+            withSystemProperty("logstash.pipelinebus.implementation", "illegal", () -> {
+                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV1.class);
+                assertThat(pipelineBusLog.getLogEvents()).anySatisfy(logEvent -> {
+                    assertThat(logEvent.getMessage().getFormattedMessage()).contains("unknown pipeline-bus implementation", "illegal");
+                });
+            });
+        }
+
+        @Test
+        public void implementationImplicit() {
+            withSystemProperty("logstash.pipelinebus.implementation", null, () -> {
+                assertThat(PipelineBus.create()).isInstanceOf(PipelineBusV2.class);
+            });
+        }
+
+
+        static synchronized void withSystemProperty(final String propertyName,
+                                                    final String temporaryPropertyValue,
+                                                    final Runnable runnable) {
+            final String previousPropertyValue;
+            if (Objects.nonNull(temporaryPropertyValue)) {
+                previousPropertyValue = System.setProperty(propertyName, temporaryPropertyValue);
+            } else {
+                previousPropertyValue = System.clearProperty(propertyName);
+            }
+            try {
+                runnable.run();
+            } finally {
+                if (Objects.nonNull(previousPropertyValue)) {
+                    System.setProperty(propertyName, previousPropertyValue);
+                } else if (Objects.nonNull(temporaryPropertyValue)) {
+                    System.clearProperty(propertyName);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Release notes

 - Deprecates v1 of the pipeline bus; the v2 implementation has been the default since its introduction in Logstash 8.15.0

## What does this PR do?

Adds a deprecation warning if Logstash is configured to use the legacy v1 pipeline bus. The legacy implementation was replaced with a more-performant one in 8.15.0, and v1 was only left in place as an "escape hatch".

~~The ability to select v1 implementation is set to be removed on `main` in advance of 9.0 via https://github.com/elastic/logstash/pull/16644~~

## Why is it important/What is the impact to the user?

It guides users away from the original lock-heavy implementation, which was previously only available as an escape hatch and is no longer necessary.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`
2. start logstash
3. observe relevant entry in the deprecation log
