### PR TITLE
Update deprecation warning to provide the version the ArcSight modue is removed.

### DIFF
--- a/logstash-core/lib/logstash/config/modules_common.rb
+++ b/logstash-core/lib/logstash/config/modules_common.rb
@@ -68,12 +68,7 @@ module LogStash module Config
       end
 
       specified_and_available_names
-        .select { |mn| mn != "arcsight" }
         .each { |mn| deprecation_logger.deprecated("The #{mn} module has been deprecated and will be removed in version 9.") }
-
-      if specified_and_available_names.include?("arcsight")
-        deprecation_logger.deprecated("The ArcSight module has been deprecated and will be removed in future version.")
-      end
 
       specified_and_available_names.each do |module_name|
         connect_fail_args = {}

--- a/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
+++ b/x-pack/modules/arcsight/configuration/logstash/arcsight.conf.erb
@@ -2,7 +2,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-<% deprecation_logger.deprecated("The ArcSight module has been deprecated in favor of the Elastic CEF Integration and will be removed in a future version. Learn more about the Elastic CEF Integration at https://docs.elastic.co/integrations/cef") %>
+<% deprecation_logger.deprecated("The ArcSight module has been deprecated in favor of the Elastic CEF Integration and will be removed in version 9. Learn more about the Elastic CEF Integration at https://docs.elastic.co/integrations/cef") %>
 <%
 # Define the default inputs to use and a list of valid aliases
 defined_inputs = configured_inputs(["kafka"], {"eventbroker" => "kafka", "smartconnector" => "tcp"})


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Updates the deprecation log for ArcSight module to notify it's removed in version 9, like in netflow, fb_apache and azure

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Follow the same description in #16551

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #16551 
- - Relates #16548

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
```
[2024-11-06T09:37:06,453][WARN ][deprecation.logstash.config.modulescommon] The arcsight module has been deprecated and will be removed in version 9.
```
