### PR TITLE
Fix: 8.15 release notes workaround ref to set system property

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -77,7 +77,7 @@ This section summarizes the changes in the following releases:
 
 **{ls} can fail to shut down under some circumstances when you are using <<pipeline-to-pipeline>>.**
 Check out issue https://github.com/elastic/logstash/issues/16657[#16657] for details.
-Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.properties`.
+Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`.
 This change reverts the `PipelineBus` to `v1`, a version that does not exhibit this issue, but may impact performance in pipeline-to-pipeline scenarios.
 
 [[notable-8.15.4]]
@@ -125,7 +125,7 @@ This change reverts the `PipelineBus` to `v1`, a version that does not exhibit t
 
 **{ls} can fail to shut down under some circumstances when you are using <<pipeline-to-pipeline>>.**
 Check out issue https://github.com/elastic/logstash/issues/16657[#16657] for details.
-Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.properties`.
+Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`.
 This change reverts the `PipelineBus` to `v1`, a version that does not exhibit this issue, but may impact performance in pipeline-to-pipeline scenarios.
 
 ==== Plugins
@@ -158,7 +158,7 @@ This change reverts the `PipelineBus` to `v1`, a version that does not exhibit t
 
 **{ls} can fail to shut down under some circumstances when you are using <<pipeline-to-pipeline>>.**
 Check out issue https://github.com/elastic/logstash/issues/16657[#16657] for details.
-Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.properties`.
+Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`.
 This change reverts the `PipelineBus` to `v1`, a version that does not exhibit this issue, but may impact performance in pipeline-to-pipeline scenarios.
 
 ==== Plugins
@@ -199,7 +199,7 @@ Workaround: Downgrade to {ls} 8.15.0, or temporarily avoid using environment and
 * **{ls} can fail to shut down under some circumstances when you are using <<pipeline-to-pipeline>>.**
 Check out issue https://github.com/elastic/logstash/issues/16657[#16657] for details.
 +
-Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.properties`.
+Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`.
 This change reverts the `PipelineBus` to `v1`, a version that does not exhibit this issue, but may impact performance in pipeline-to-pipeline scenarios.
 
 
@@ -241,7 +241,7 @@ This change reverts the `PipelineBus` to `v1`, a version that does not exhibit t
 
 **{ls} can fail to shut down under some circumstances when you are using <<pipeline-to-pipeline>>.**
 Check out issue https://github.com/elastic/logstash/issues/16657[#16657] for details.
-Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.properties`.
+Workaround: Add `-Dlogstash.pipelinebus.implementation=v1` to `config/jvm.options`.
 This change reverts the `PipelineBus` to `v1`, a version that does not exhibit this issue, but may impact performance in pipeline-to-pipeline scenarios.
 
 [[snmp-ga-8.15.0]]


### PR DESCRIPTION
## Release notes

[rn: skip] (it'd be too self-referential)

## What does this PR do?

Workaround documented in #16661 should reference `config/jvm.options`, not `config/jvm.properties` :facepalm:

## Why is it important/What is the impact to the user?

Give them a _useful_ workaround for a known issue.

## Checklist


- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
