### PR TITLE
PipelineBusV2 deadlock proofing

### DIFF
--- a/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV2.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/pipeline/PipelineBusV2.java
@@ -141,16 +141,20 @@ class PipelineBusV2 extends AbstractPipelineBus implements PipelineBus {
 
                 consumer.accept(addressState);
 
-                // If this addressState has a listener, ensure that any waiting
+                return addressState.isEmpty() ? null : addressState;
+            });
+
+            if (result == null) {
+                return null;
+            } else {
+                // If the resulting addressState had a listener, ensure that any waiting
                 // threads get notified so that they can resume immediately
-                final PipelineInput currentInput = addressState.getInput();
+                final PipelineInput currentInput = result.getInput();
                 if (currentInput != null) {
                     synchronized (currentInput) { currentInput.notifyAll(); }
                 }
-
-                return addressState.isEmpty() ? null : addressState;
-            });
-            return result == null ? null : result.getReadOnlyView();
+                return result.getReadOnlyView();
+            }
         }
 
         private AddressState.ReadOnly get(final String address) {


### PR DESCRIPTION
## Release notes

 - Fixes an issue where Logstash shutdown could stall in some cases when using pipeline-to-pipeline.

## What does this PR do?

 - Adds tests to detect deadlock betweeen `PipelineBus#unlisten` and `PipelineBus#unregisterSender`
 - Eliminates a deadlock that can occur in `PipelineBusV2`

## Why is it important/What is the impact to the user?

Failing to shut down is not good.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

 - Resolves #16657 
