### PR TITLE
pipeline logging: add cause chain when logging

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -137,9 +137,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
 
     @thread = Thread.new do
       error_log_params = ->(e) {
-        default_logging_keys(
-          :exception => e,
-          :backtrace => e.backtrace,
+        exception_logging_keys(e,
           "pipeline.sources" => pipeline_source_details
         )
       }
@@ -312,7 +310,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
             @crash_detected.make_true
             @logger.error(
               "Pipeline worker error, the pipeline will be stopped",
-              default_logging_keys(:error => e.cause.message, :exception => e.cause.class, :backtrace => e.cause.backtrace)
+              exception_logging_keys(e.cause)
             )
           end
         end
@@ -422,21 +420,14 @@ module LogStash; class JavaPipeline < AbstractPipeline
       if plugin.stop?
         @logger.debug(
           "Input plugin raised exception during shutdown, ignoring it.",
-           default_logging_keys(
-             :plugin => plugin.class.config_name,
-             :exception => e.message,
-             :backtrace => e.backtrace))
+           exception_logging_keys(e, :plugin => plugin.class.config_name))
         return
       end
 
       # otherwise, report error and restart
       @logger.error(I18n.t(
         "logstash.pipeline.worker-error-debug",
-        **default_logging_keys(
-          :plugin => plugin.inspect,
-          :error => e.message,
-          :exception => e.class,
-          :stacktrace => e.backtrace.join("\n"))))
+        **exception_logging_keys(e, :plugin => plugin.inspect)))
 
       # Assuming the failure that caused this exception is transient,
       # let's sleep for a bit and execute #run again
@@ -580,10 +571,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
     rescue => e
       @logger.warn(
         "plugin raised exception while closing, ignoring",
-        default_logging_keys(
-          :plugin => plugin.class.config_name,
-          :exception => e.message,
-          :backtrace => e.backtrace))
+        exception_logging_keys(e, :plugin => plugin.class.config_name))
     end
   end
 
@@ -607,12 +595,12 @@ module LogStash; class JavaPipeline < AbstractPipeline
     rescue => e
       @logger.error(
         "Worker loop initialization error",
-        default_logging_keys(:error => e.message, :exception => e.class, :stacktrace => e.backtrace.join("\n")))
+        exception_logging_keys(e))
       nil
     rescue Java::java.lang.StackOverflowError => se
       @logger.error(
         "Stack overflow error while compiling Pipeline. Please increase thread stack size using -Xss",
-        default_logging_keys())
+        exception_logging_keys(se))
       nil
     end
   end
@@ -628,6 +616,42 @@ module LogStash; class JavaPipeline < AbstractPipeline
     keys = {:pipeline_id => pipeline_id}.merge other_keys
     keys[:thread] ||= thread.inspect if thread
     keys
+  end
+
+  def exception_logging_keys(active_exception = $!, other_keys = {})
+    base = active_exception ? unwind_cause_chain(active_exception) : {}
+    default_logging_keys(base.merge(other_keys))
+  end
+
+  ##
+  # Yields once per exception in the provided exception's cause chain
+  # @param exception [Exception]
+  # @yield_param [Exception]
+  def cause_chain(exception, &block)
+    return enum_for(:cause_chain, exception) unless block_given?
+
+    current = exception
+    while !current.nil?
+      yield current
+      cause = current.cause
+      current = (cause == current ? nil : cause)
+    end
+  end
+
+  ##
+  # unwinds the provided exception to create a deeply-nested structure
+  # representing the exception and its cause chain
+  # @param [Exception] exception
+  # @return [Hash{Symbol=>[String|Hash]}]
+  def unwind_cause_chain(exception)
+    cause_chain(exception).reverse_each.reduce(nil) do |cause, exception|
+      {
+        :exception   => exception.class.name,
+        :error       => exception.message,
+        :stacktrace  => exception.backtrace.join("\n"),
+        :cause       => cause,
+      }.compact
+    end
   end
 
   def preserve_event_order?(pipeline_workers)


### PR DESCRIPTION
## Release notes

 - Improves logging while handling exceptions in the pipeline, ensuring that chained exceptions propagate enough information to be actionable.

## What does this PR do?

Adds a helper to normalize an exception _and its cause chain_ for logging, and uses that helper to add context whenever logging an exception from the pipeline implementation

## Why is it important/What is the impact to the user?

Often an exception is caught and a _wrapper_ of that exception is re-thrown; logging only the outermost exception can make it difficult to chase down the root cause.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Logs

Before:

Log entries context contains:

 - `error`: a string with the exception's message
 - `exception`: a string with the exception's class
 - `stacktrace`: a string with the exception's newline-concatenated backtrace

~~~
[2024-11-14T19:05:47,364][ERROR][logstash.javapipeline    ][ocp4-logs-app] Pipeline worker error, the pipeline will be stopped {:pipeline_id=>"ocp4-logs-app", :exception=>"Java::OrgLogstashAckedqueue::QueueRuntimeException", :error=>"deserialize invocation error", :stacktrace=>"org.logstash.ackedqueue.Queue.deserialize(Queue.java:753)\norg.logstash.ackedqueue.Batch.deserializeElements(Batch.java:89)\norg.logstash.ackedqueue.Batch.<init>(Batch.java:49)\norg.logstash.ackedqueue.Queue.readPageBatch(Queue.java:681)\norg.logstash.ackedqueue.Queue.readBatch(Queue.java:614)\norg.logstash.ackedqueue.ext.JRubyAckedQueueExt.readBatch(JRubyAckedQueueExt.java:158)\norg.logstash.ackedqueue.AckedReadBatch.create(AckedReadBatch.java:49)\norg.logstash.ext.JrubyAckedReadClientExt.readBatch(JrubyAckedReadClientExt.java:87)\norg.logstash.execution.WorkerLoop.run(WorkerLoop.java:82)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\njava.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.base/java.lang.reflect.Method.invoke(Method.java:569)\norg.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:300)\norg.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:164)\norg.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:32)\norg.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:193)\norg.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)\norg.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)\norg.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:118)\norg.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:58)\norg.jruby.runtime.Block.call(Block.java:144)\norg.jruby.RubyProc.call(RubyProc.java:354)\norg.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:111)\njava.base/java.lang.Thread.run(Thread.java:840)", :thread=>"#<Thread:0x46da0cfb /Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/java_pipeline.rb:138 sleep>"}
~~~

After:

Log entries context contains:

 - `error`: a string with the exception's message
 - `exception`: a string with the exception's class
 - `stacktrace`: a string with the exception's newline-concatenated backtrace
 - `cause` (optional): a hash containing the exception's cause in the same format:
   - `error`: a string with the cause's message
   - `exception`: a string with the cause class
   - `stacktrace`: a string with the cause newline-concatenated backtrace
   - `cause` (optional): a hash containing the cause's cause in the same format
     - _[...]_


~~~
[2024-11-14T19:05:47,364][ERROR][logstash.javapipeline    ][ocp4-logs-app] Pipeline worker error, the pipeline will be stopped {:pipeline_id=>"ocp4-logs-app", :exception=>"Java::OrgLogstashAckedqueue::QueueRuntimeException", :error=>"deserialize invocation error", :stacktrace=>"org.logstash.ackedqueue.Queue.deserialize(Queue.java:753)\norg.logstash.ackedqueue.Batch.deserializeElements(Batch.java:89)\norg.logstash.ackedqueue.Batch.<init>(Batch.java:49)\norg.logstash.ackedqueue.Queue.readPageBatch(Queue.java:681)\norg.logstash.ackedqueue.Queue.readBatch(Queue.java:614)\norg.logstash.ackedqueue.ext.JRubyAckedQueueExt.readBatch(JRubyAckedQueueExt.java:158)\norg.logstash.ackedqueue.AckedReadBatch.create(AckedReadBatch.java:49)\norg.logstash.ext.JrubyAckedReadClientExt.readBatch(JrubyAckedReadClientExt.java:87)\norg.logstash.execution.WorkerLoop.run(WorkerLoop.java:82)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\njava.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.base/java.lang.reflect.Method.invoke(Method.java:569)\norg.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:300)\norg.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:164)\norg.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:32)\norg.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:193)\norg.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)\norg.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)\norg.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:118)\norg.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:58)\norg.jruby.runtime.Block.call(Block.java:144)\norg.jruby.RubyProc.call(RubyProc.java:354)\norg.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:111)\njava.base/java.lang.Thread.run(Thread.java:840)", :cause=>{:exception=>"Java::JavaLang::IllegalAccessException", :error=>"fake", :stacktrace=>"org.logstash.ackedqueue.Queue.deserialize(Queue.java:750)\norg.logstash.ackedqueue.Batch.deserializeElements(Batch.java:89)\norg.logstash.ackedqueue.Batch.<init>(Batch.java:49)\norg.logstash.ackedqueue.Queue.readPageBatch(Queue.java:681)\norg.logstash.ackedqueue.Queue.readBatch(Queue.java:614)\norg.logstash.ackedqueue.ext.JRubyAckedQueueExt.readBatch(JRubyAckedQueueExt.java:158)\norg.logstash.ackedqueue.AckedReadBatch.create(AckedReadBatch.java:49)\norg.logstash.ext.JrubyAckedReadClientExt.readBatch(JrubyAckedReadClientExt.java:87)\norg.logstash.execution.WorkerLoop.run(WorkerLoop.java:82)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\njava.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\njava.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.base/java.lang.reflect.Method.invoke(Method.java:569)\norg.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:300)\norg.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:164)\norg.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:32)\norg.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:193)\norg.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:346)\norg.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)\norg.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:118)\norg.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)\norg.jruby.runtime.IRBlockBody.call(IRBlockBody.java:58)\norg.jruby.runtime.Block.call(Block.java:144)\norg.jruby.RubyProc.call(RubyProc.java:354)\norg.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:111)\njava.base/java.lang.Thread.run(Thread.java:840)"}, :thread=>"#<Thread:0x46da0cfb /Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/java_pipeline.rb:138 sleep>"}
~~~
