### PR TITLE
Doc: Environment variables cannot be in config.string comments.

### DIFF
--- a/docs/static/env-vars.asciidoc
+++ b/docs/static/env-vars.asciidoc
@@ -12,7 +12,7 @@ environment variable is undefined.
 * You can add environment variable references in any plugin option type: string, number, boolean, array, or hash.
 * Environment variables for list-type URI parameters can support lists of space-delimited values. Currently, other non-URI based options do not support lists of values. See <<plugin-concepts>>
 * Environment variables are immutable. If you update the environment variable, you'll have to restart Logstash to pick up the updated value.
-* References to environment variables in `config.string` comments will still be evaluated during configuration parsing and are therefore discouraged.
+* References to environment variables in `config.string` comments are evaluated during configuration parsing, and are therefore discouraged.
 Remove the `$` sign to avoid pipeline loading failures.
 
 ==== Examples

--- a/docs/static/env-vars.asciidoc
+++ b/docs/static/env-vars.asciidoc
@@ -12,7 +12,8 @@ environment variable is undefined.
 * You can add environment variable references in any plugin option type: string, number, boolean, array, or hash.
 * Environment variables for list-type URI parameters can support lists of space-delimited values. Currently, other non-URI based options do not support lists of values. See <<plugin-concepts>>
 * Environment variables are immutable. If you update the environment variable, you'll have to restart Logstash to pick up the updated value.
-* Environment variables references in `config.string` comments are not allowed. Remove the `$` sign to avoid pipeline config failures.
+* References to environment variables in `config.string` comments will still be evaluated during configuration parsing and are therefore discouraged.
+Remove the `$` sign to avoid pipeline loading failures.
 
 ==== Examples
 

--- a/docs/static/env-vars.asciidoc
+++ b/docs/static/env-vars.asciidoc
@@ -12,7 +12,7 @@ environment variable is undefined.
 * You can add environment variable references in any plugin option type: string, number, boolean, array, or hash.
 * Environment variables for list-type URI parameters can support lists of space-delimited values. Currently, other non-URI based options do not support lists of values. See <<plugin-concepts>>
 * Environment variables are immutable. If you update the environment variable, you'll have to restart Logstash to pick up the updated value.
-* Environment variables in `config.string` comments are not allowed. Remove the `$` sign to avoid pipeline config failures.
+* Environment variables references in `config.string` comments are not allowed. Remove the `$` sign to avoid pipeline config failures.
 
 ==== Examples
 

--- a/docs/static/env-vars.asciidoc
+++ b/docs/static/env-vars.asciidoc
@@ -12,6 +12,7 @@ environment variable is undefined.
 * You can add environment variable references in any plugin option type: string, number, boolean, array, or hash.
 * Environment variables for list-type URI parameters can support lists of space-delimited values. Currently, other non-URI based options do not support lists of values. See <<plugin-concepts>>
 * Environment variables are immutable. If you update the environment variable, you'll have to restart Logstash to pick up the updated value.
+* Environment variables in `config.string` comments are not allowed. Remove the `$` sign to avoid pipeline config failures.
 
 ==== Examples
 

--- a/docs/static/pipeline-configuration.asciidoc
+++ b/docs/static/pipeline-configuration.asciidoc
@@ -310,7 +310,7 @@ input { # comments can appear at the end of a line, too
   # ...
 }
 ----------------------------------
-NOTE: Due to a substitution logic, commenting environment `${var}` in `config.string` is not allowed. Remove the `$` sign to avoid pipeline config failures.
+NOTE: Comments containing environment `${var}` references in `config.string` are not allowed. Remove the `$` sign to avoid pipeline loading failures.
 
 include::event-data.asciidoc[]
 include::env-vars.asciidoc[]

--- a/docs/static/pipeline-configuration.asciidoc
+++ b/docs/static/pipeline-configuration.asciidoc
@@ -310,7 +310,7 @@ input { # comments can appear at the end of a line, too
   # ...
 }
 ----------------------------------
-NOTE: Comments containing environment variable `${var}` references in `config.string` will still be evaluated.
+NOTE: Comments containing environment variable `${var}` references in `config.string` are still evaluated.
 Remove the `$` sign to avoid pipeline loading failures.
 
 include::event-data.asciidoc[]

--- a/docs/static/pipeline-configuration.asciidoc
+++ b/docs/static/pipeline-configuration.asciidoc
@@ -310,7 +310,8 @@ input { # comments can appear at the end of a line, too
   # ...
 }
 ----------------------------------
-NOTE: Comments containing environment `${var}` references in `config.string` are not allowed. Remove the `$` sign to avoid pipeline loading failures.
+NOTE: Comments containing environment variable `${var}` references in `config.string` will still be evaluated.
+Remove the `$` sign to avoid pipeline loading failures.
 
 include::event-data.asciidoc[]
 include::env-vars.asciidoc[]

--- a/docs/static/pipeline-configuration.asciidoc
+++ b/docs/static/pipeline-configuration.asciidoc
@@ -310,7 +310,7 @@ input { # comments can appear at the end of a line, too
   # ...
 }
 ----------------------------------
-
+NOTE: Due to a substitution logic, commenting environment `${var}` in `config.string` is not allowed. Remove the `$` sign to avoid pipeline config failures.
 
 include::event-data.asciidoc[]
 include::env-vars.asciidoc[]


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Adds a limitation where environment `${VAR}`s cannot be used in `config.string`. To avoid pipeline run config failure, `$` can be removed.

## Why is it important/What is the impact to the user?
From functional point of view, users are not impacted.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- Closes #16625 
- Closes #16008 

## Use cases

## Screenshots

## Logs
