### PR TITLE
Update license checker with new dependency

### DIFF
--- a/tools/dependencies-report/src/main/resources/licenseMapping.csv
+++ b/tools/dependencies-report/src/main/resources/licenseMapping.csv
@@ -100,6 +100,7 @@ dependency,dependencyUrl,licenseOverride,copyright,sourceURL
 "jruby-stdin-channel:","https://github.com/colinsurprenant/jruby-stdin-channel",Apache-2.0
 "jwt:",https://github.com/jwt/ruby-jwt,MIT
 "json:",http://json-jruby.rubyforge.org/,Ruby
+"logger:",https://github.com/ruby/logger,BSD-2-Clause
 "lru_redux:","https://github.com/SamSaffron/lru_redux/",MIT
 "mail:","https://github.com/mikel/mail/",MIT
 "manticore:","https://github.com/cheald/manticore/",MIT

--- a/tools/dependencies-report/src/main/resources/notices/logger-NOTICE.txt
+++ b/tools/dependencies-report/src/main/resources/notices/logger-NOTICE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

A new transative dependency on the `logger` gem has been added. Update the license checker to ensure this is accounted for.

## Why is it important/What is the impact to the user?

This should have no direct impact to the user other than ensuring all licenses are transparent for vendored code. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

WIthout this patch the command (show successfull after this patch) will fail:
```
➜  logstash git:(update-license-for-logger) ✗ ./bin/dependencies-report --csv report.csv
Using system java: /Users/cas/.jenv/versions/21/bin/java
Finding gem dependencies
Finding gem embedded java/jar dependencies
Adding non-gem non-jar dependencies (such as jruby distribution)
Wrote temporary ruby deps CSV to /var/folders/cw/q_xjr4md1wj_w_c1xwfrnxdw0000gn/T/c6349f9a-c616-4457-8921-c7954862250a
Find gradle jar dependencies /Users/cas/elastic-repos/logstash
Executing ["./gradlew", "generateLicenseReport", "-PlicenseReportInputCSV=/var/folders/cw/q_xjr4md1wj_w_c1xwfrnxdw0000gn/T/c6349f9a-c616-4457-8921-c7954862250a", "-PlicenseReportOutputCSV=report.csv"]
WARNING: Unknown module: org.jruby.dist specified to --add-opens
WARNING: Unknown module: org.jruby.dist specified to --add-opens
WARNING: Unknown module: org.jruby.dist specified to --add-opens
WARNING: Unknown module: org.jruby.dist specified to --add-opens
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.7/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build

> Task :generateLicenseReport
Generated report with 160 dependencies (0 unknown or unacceptable licenses, 0 unknown or missing notices).

The following 49 license mappings were specified but unused:
awesome_print
builder
cgi
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
com.google.code.findbugs:jsr305
com.google.errorprone:error_prone_annotations
com.google.j2objc:j2objc-annotations
csv
diff-lcs
elastic-app-search
elastic-workplace-search
ffi-binary-libfixposix
gradle.plugin.com.github.jk1:gradle-license-report
io-console
io.netty:netty-all
mime-types
net-http
org.codehaus.janino:commons-compiler
org.codehaus.mojo:animal-sniffer-annotations
org.eclipse.core:org.eclipse.core.commands
org.eclipse.core:org.eclipse.core.contenttype
org.eclipse.core:org.eclipse.core.expressions
org.eclipse.core:org.eclipse.core.filesystem
org.eclipse.core:org.eclipse.core.jobs
org.eclipse.core:org.eclipse.core.resources
org.eclipse.core:org.eclipse.core.runtime
org.eclipse.equinox:org.eclipse.equinox.app
org.eclipse.equinox:org.eclipse.equinox.common
org.eclipse.equinox:org.eclipse.equinox.preferences
org.eclipse.equinox:org.eclipse.equinox.registry
org.eclipse.jdt:org.eclipse.jdt.core
org.eclipse.osgi:org.eclipse.osgi
org.eclipse.text:org.eclipse.text
reline
rspec
rspec-collection_matchers
rspec-core
rspec-expectations
rspec-mocks
rspec-support
rspec-wait
snappy
snappy-jars
snmp
strscan
time
unf
uri
webrick

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 2s
15 actionable tasks: 2 executed, 13 up-to-date
➜  logstash git:(update-license-fo
```

## Logs

Example failing CI run https://buildkite.com/elastic/logstash-pull-request-pipeline/builds/1861#01934058-c2ca-4c87-a4c4-e05a4df19531
```
Add complying licenses (using the SPDX license ID from https://spdx.org/licenses) with URLs for the libraries listed below to tools/dependencies-report/src/main/resources/licenseMapping.csv:
"logger:1.6.1"
The following NOTICE.txt entries are missing, please add them:
LS_HOME/tools/dependencies-report/src/main/resources/notices/logger-NOTICE.txt
```
<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
