### PR TITLE
Replace removed yaml module

### DIFF
--- a/docker/data/logstash/env2yaml/env2yaml.go
+++ b/docker/data/logstash/env2yaml/env2yaml.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
In https://github.com/elastic/logstash/pull/16586 the module include was removed. This causes failures in the script when the module is referenced. This commit re-enables the include for the yaml module.

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

Example failed test: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/949#01934968-b66c-4455-ad70-1778cc13def3
