### PR TITLE
[Health API E2E] Align on agent python version and avoid pip install.

### DIFF
--- a/.buildkite/scripts/health-report-tests/main.sh
+++ b/.buildkite/scripts/health-report-tests/main.sh
@@ -10,7 +10,7 @@ eval "$(rbenv init -)"
 eval "$(pyenv init -)"
 
 echo "--- Installing dependencies"
-python3 -mpip install -r .buildkite/scripts/health-report-tests/requirements.txt
+python3 -m pip install -r .buildkite/scripts/health-report-tests/requirements.txt
 
 echo "--- Running tests"
 python3 .buildkite/scripts/health-report-tests/main.py

--- a/.buildkite/scripts/health-report-tests/main.sh
+++ b/.buildkite/scripts/health-report-tests/main.sh
@@ -4,11 +4,10 @@ set -euo pipefail
 
 export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
 export JAVA_HOME="/opt/buildkite-agent/.java"
+export PYENV_VERSION="3.11.5"
+
 eval "$(rbenv init -)"
 eval "$(pyenv init -)"
-
-echo "--- Installing pip"
-sudo apt-get install python3-pip -y
 
 echo "--- Installing dependencies"
 python3 -mpip install -r .buildkite/scripts/health-report-tests/requirements.txt

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -721,7 +721,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/health_report_tests_pipeline.yml"
-      maximum_timeout_in_minutes: 60
+      maximum_timeout_in_minutes: 30 # usually tests last max ~17mins
       provider_settings:
         trigger_mode: none # don't trigger jobs from github activity
       env:


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Fixes the CI hang caused by installing pip. This change aligns on python installed on BK agent.
Health API E2E run: https://buildkite.com/elastic/logstash-health-report-tests-pipeline/builds/99

## Why is it important/What is the impact to the user?
No impact.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally
- It cannot be tested locally since it is an agent specific.

## Related issues
- 

## Use cases

## Screenshots

## Logs
```
buildkite-agent@mst-logstash-ubuntu-2204:~/logstash$ ./gradlew clean bootstrap assemble installDefaultGems
Downloading https://services.gradle.org/distributions/gradle-8.7-bin.zip
............10%.............20%.............30%.............40%............50%.............60%.............70%.............80%.............90%............100%

Welcome to Gradle 8.7!

Here are the highlights of this release:
 - Compiling and testing with Java 22
 - Cacheable Groovy script compilation
 - New methods in lazy collection properties

For more details see https://docs.gradle.org/8.7/release-notes.html

To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.7/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 

> Task :downloadJRuby
Download https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.9.0/jruby-dist-9.4.9.0-bin.tar.gz

> Task :logstash-core:compileJava
Note: Processing Log4j annotations
Note: Annotations processed
Note: Processing Log4j annotations
Note: No elements to process

> Task :installDefaultGems
Skipping bundler install...
Building logstash-core using gradle
./gradlew assemble
[plugin:install-default] Installing default plugins
Installing logstash-codec-avro, logstash-codec-cef, logstash-codec-collectd, logstash-codec-dots, logstash-codec-edn, logstash-codec-edn_lines, logstash-codec-es_bulk, logstash-codec-fluent, logstash-codec-graphite, logstash-codec-json, logstash-codec-json_lines, logstash-codec-line, logstash-codec-msgpack, logstash-codec-multiline, logstash-codec-netflow, logstash-codec-plain, logstash-codec-rubydebug, logstash-filter-aggregate, logstash-filter-anonymize, logstash-filter-cidr, logstash-filter-clone, logstash-filter-csv, logstash-filter-date, logstash-filter-de_dot, logstash-filter-dissect, logstash-filter-dns, logstash-filter-drop, logstash-filter-elastic_integration, logstash-filter-elasticsearch, logstash-filter-fingerprint, logstash-filter-geoip, logstash-filter-grok, logstash-filter-http, logstash-filter-json, logstash-filter-kv, logstash-filter-memcached, logstash-filter-metrics, logstash-filter-mutate, logstash-filter-prune, logstash-filter-ruby, logstash-filter-sleep, logstash-filter-split, logstash-filter-syslog_pri, logstash-filter-throttle, logstash-filter-translate, logstash-filter-truncate, logstash-filter-urldecode, logstash-filter-useragent, logstash-filter-uuid, logstash-filter-xml, logstash-input-azure_event_hubs, logstash-input-beats, logstash-input-couchdb_changes, logstash-input-dead_letter_queue, logstash-input-elasticsearch, logstash-input-exec, logstash-input-file, logstash-input-ganglia, logstash-input-gelf, logstash-input-generator, logstash-input-graphite, logstash-input-heartbeat, logstash-input-http, logstash-input-http_poller, logstash-input-jms, logstash-input-pipe, logstash-input-redis, logstash-input-stdin, logstash-input-syslog, logstash-input-tcp, logstash-input-twitter, logstash-input-udp, logstash-input-unix, logstash-integration-elastic_enterprise_search, logstash-input-elastic_serverless_forwarder, logstash-integration-jdbc, logstash-integration-kafka, logstash-integration-logstash, logstash-integration-rabbitmq, logstash-integration-snmp, logstash-integration-aws, logstash-output-csv, logstash-output-elasticsearch, logstash-output-email, logstash-output-file, logstash-output-graphite, logstash-output-http, logstash-output-lumberjack, logstash-output-nagios, logstash-output-null, logstash-output-pipe, logstash-output-redis, logstash-output-stdout, logstash-output-tcp, logstash-output-udp, logstash-output-webhdfs
Error Errno::ENOENT, retrying 1/10
No such file or directory - /opt/buildkite-agent/.m2/repository/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar -- module org.snakeyaml.engine.v2
Installation successful

BUILD SUCCESSFUL in 2m 57s
43 actionable tasks: 35 executed, 8 up-to-date
buildkite-agent@mst-logstash-ubuntu-2204:~/logstash$ python3 .buildkite/scripts/health-report-tests/main.py
Starting Logstash Health Report Integration test.
LS_BRANCH is not specified, using main branch.
Building Logstash...
Note: Processing Log4j annotations
Note: Annotations processed
Note: Processing Log4j annotations
Note: No elements to process
./gradlew assemble
Error Errno::ENOENT, retrying 1/10
No such file or directory - /opt/buildkite-agent/.m2/repository/org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar -- module org.snakeyaml.engine.v2
Logstash has successfully built.
logstash-integration-failure_injector successfully installed.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/abnormal-termination.yaml scenario file.
Validation succeeded.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/multipipeline.yaml scenario file.
Validation succeeded.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/normal-termination.yaml scenario file.
Validation succeeded.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/backpressure-5m.yaml scenario file.
Validation succeeded.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/slow-start.yaml scenario file.
Validation succeeded.
Validating /opt/buildkite-agent/logstash/.buildkite/scripts/health-report-tests/tests/backpressure-1m.yaml scenario file.
Validation succeeded.
Testing `Abnormally terminated pipeline` scenario.
Logstash is running with PID: 3533.
Test requires to wait for `5` seconds.
Scenario `Abnormally terminated pipeline` expectaion meets the health report stats.
Logstash stopped.
Testing `Multi pipeline` scenario.
Logstash is running with PID: 3628.
Test requires to wait for `10` seconds.
Scenario `Multi pipeline` expectaion meets the health report stats.
Logstash stopped.
Testing `Successfully terminated pipeline` scenario.
Logstash is running with PID: 3733.
Test requires to wait for `5` seconds.
Scenario `Successfully terminated pipeline` expectaion meets the health report stats.
Logstash stopped.
Testing `Backpressured in 5min pipeline` scenario.
Logstash is running with PID: 3819.
Test requires to wait for `310` seconds.
Differences found in 'expectation' section between YAML content and stats:
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`pipelines`)', 'got': '1 indicator is concerning (`pipelines`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`backpressure-5m-pp`)', 'got': '1 indicator is concerning (`backpressure-5m-pp`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': 'The pipeline is unhealthy; 1 area is impacted and 1 diagnosis is available', 'got': 'The pipeline is concerning; 1 area is impacted and 1 diagnosis is available'}}
Difference: {'diagnosis': {'expected': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-blocked', 'cause': 'pipeline workers have been completely blocked for at least five minutes', 'action': 'address bottleneck or add resources'}], 'got': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-nearly-blocked', 'cause': 'pipeline workers have been nearly blocked for at least five minutes', 'action': 'address bottleneck or add resources', 'help_url': 'https://www.elastic.co/guide/en/logstash/master/health-report-pipeline-flow-worker-utilization.html#nearly-blocked-5m'}]}}
Differences found in 'expectation' section between YAML content and stats:
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`pipelines`)', 'got': '1 indicator is concerning (`pipelines`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`backpressure-5m-pp`)', 'got': '1 indicator is concerning (`backpressure-5m-pp`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': 'The pipeline is unhealthy; 1 area is impacted and 1 diagnosis is available', 'got': 'The pipeline is concerning; 1 area is impacted and 1 diagnosis is available'}}
Difference: {'diagnosis': {'expected': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-blocked', 'cause': 'pipeline workers have been completely blocked for at least five minutes', 'action': 'address bottleneck or add resources'}], 'got': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-nearly-blocked', 'cause': 'pipeline workers have been nearly blocked for at least five minutes', 'action': 'address bottleneck or add resources', 'help_url': 'https://www.elastic.co/guide/en/logstash/master/health-report-pipeline-flow-worker-utilization.html#nearly-blocked-5m'}]}}
Differences found in 'expectation' section between YAML content and stats:
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`pipelines`)', 'got': '1 indicator is concerning (`pipelines`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`backpressure-5m-pp`)', 'got': '1 indicator is concerning (`backpressure-5m-pp`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': 'The pipeline is unhealthy; 1 area is impacted and 1 diagnosis is available', 'got': 'The pipeline is concerning; 1 area is impacted and 1 diagnosis is available'}}
Difference: {'diagnosis': {'expected': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-blocked', 'cause': 'pipeline workers have been completely blocked for at least five minutes', 'action': 'address bottleneck or add resources'}], 'got': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-nearly-blocked', 'cause': 'pipeline workers have been nearly blocked for at least five minutes', 'action': 'address bottleneck or add resources', 'help_url': 'https://www.elastic.co/guide/en/logstash/master/health-report-pipeline-flow-worker-utilization.html#nearly-blocked-5m'}]}}
Differences found in 'expectation' section between YAML content and stats:
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`pipelines`)', 'got': '1 indicator is concerning (`pipelines`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': '1 indicator is unhealthy (`backpressure-5m-pp`)', 'got': '1 indicator is concerning (`backpressure-5m-pp`)'}}
Difference: {'status': {'expected': 'red', 'got': 'yellow'}}
Difference: {'symptom': {'expected': 'The pipeline is unhealthy; 1 area is impacted and 1 diagnosis is available', 'got': 'The pipeline is concerning; 1 area is impacted and 1 diagnosis is available'}}
Difference: {'diagnosis': {'expected': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-blocked', 'cause': 'pipeline workers have been completely blocked for at least five minutes', 'action': 'address bottleneck or add resources'}], 'got': [{'id': 'logstash:health:pipeline:flow:worker_utilization:diagnosis:5m-nearly-blocked', 'cause': 'pipeline workers have been nearly blocked for at least five minutes', 'action': 'address bottleneck or add resources', 'help_url': 'https://www.elastic.co/guide/en/logstash/master/health-report-pipeline-flow-worker-utilization.html#nearly-blocked-5m'}]}}
Scenario `Backpressured in 5min pipeline` expectaion meets the health report stats.
Logstash didn't stop in 1min, sending SIGTERM signal.
Testing `Slow start pipeline` scenario.
Logstash is running with PID: 3958.
Test requires to wait for `0` seconds.
Scenario `Slow start pipeline` expectaion meets the health report stats.
Logstash stopped.
Testing `Backpressured in 1min pipeline` scenario.
Logstash is running with PID: 4049.
Test requires to wait for `70` seconds.
Scenario `Backpressured in 1min pipeline` expectaion meets the health report stats.
Logstash stopped.
buildkite-agent@mst-logstash-ubuntu-2204:~/logstash$ 
```