### PR TITLE
Doc: Roll 6.3 breaking changes under 6.0 series

### DIFF
--- a/docs/static/breaking-changes-60.asciidoc
+++ b/docs/static/breaking-changes-60.asciidoc
@@ -1,7 +1,20 @@
 [[breaking-6.0]]
-=== Breaking changes in 6.0
+=== Breaking changes in 6.0 series
 
 Here are the breaking changes for 6.0. 
+
+[discrete]
+[[breaking-pq]]
+=== Breaking change across PQ versions prior to Logstash 6.3.0
+
+If you are upgrading from Logstash 6.2.x or any earlier version (including 5.x)
+and have the persistent queue enabled, we strongly recommend that you drain or
+delete the persistent queue before you upgrade. See <<draining-pqs>>
+for information and instructions.
+
+[discrete]
+[[breaking-6.0-rel]]
+=== Breaking changes in 6.0
 
 [discrete]
 ==== Changes in Logstash Core

--- a/docs/static/breaking-changes-pre63.asciidoc
+++ b/docs/static/breaking-changes-pre63.asciidoc
@@ -1,8 +1,0 @@
-[[breaking-pq]]
-=== Breaking change across PQ versions prior to Logstash 6.3.0
-
-If you are upgrading from Logstash 6.2.x or any earlier version (including 5.x)
-and have the persistent queue enabled, we strongly recommend that you drain or
-delete the persistent queue before you upgrade. See <<draining-pqs>>
-for information and instructions.
-

--- a/docs/static/breaking-changes.asciidoc
+++ b/docs/static/breaking-changes.asciidoc
@@ -30,12 +30,10 @@ See these topics for breaking changes in earlier releases:
 
 * <<breaking-8.0>>
 * <<breaking-7.0>>
-* <<breaking-pq>>
 * <<breaking-6.0>>
 
 include::breaking-changes-80.asciidoc[]
 include::breaking-changes-70.asciidoc[]
-include::breaking-changes-pre63.asciidoc[]
 include::breaking-changes-60.asciidoc[]
 
 


### PR DESCRIPTION
Related: #16613
Move the pre-6.3 PQ issue under 6.0-series breaking changes for consistency and ease of use. 

**PREVIEW:** https://logstash_bk_16706.docs-preview.app.elstc.co/guide/en/logstash/master/breaking-6.0.html

## Before:
<img width="640" alt="Screenshot 2024-11-20 at 4 38 24 PM" src="https://github.com/user-attachments/assets/d75ec8e2-70cd-4e8d-85f0-8d9177018b3e">

## After: 
<img width="731" alt="Screenshot 2024-11-20 at 4 38 34 PM" src="https://github.com/user-attachments/assets/be129ff4-36a8-493d-9703-bf4b32190110">
