### PR TITLE
Increase timeout for docs PR link action

### DIFF
--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -20,7 +20,7 @@ jobs:
           # when running with on: pull_request_target we get the PR base ref by default
           ref: ${{ github.event.pull_request.head.sha }}
           statusName: "buildkite/docs-build-pr"
-          # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
+          # https://buildkite.com/elastic/docs-build-pr/builds?meta_data[repo_pr]=${REPO}_${PR}
           # usually finishes in ~ 20 minutes
           timeoutSeconds: 1800
           intervalSeconds: 30

--- a/.github/workflows/add-docs-preview-link.yml
+++ b/.github/workflows/add-docs-preview-link.yml
@@ -22,7 +22,7 @@ jobs:
           statusName: "buildkite/docs-build-pr"
           # https://elasticsearch-ci.elastic.co/job/elastic+logstash+pull-request+build-docs
           # usually finishes in ~ 20 minutes
-          timeoutSeconds: 900
+          timeoutSeconds: 1800
           intervalSeconds: 30
       - name: Add Docs Preview link in PR Comment
         if: steps.wait-for-status.outputs.state == 'success'


### PR DESCRIPTION
Update the timeout from 15 minutes to 30 minutes to try and fix the inline docs previews feature

