### PR TITLE
Add beats and es-agent SSL breaking changes to 9.0 breaking change doc.

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -23,7 +23,47 @@ If your plugin configuration contains any of these obsolete options, the plugin 
 Click the arrow beside a plugin name to see the list of settings that have been
 removed and their replacements. 
 
-**Plugins with changes to SSL settings** 
+**Plugins with changes to SSL settings**
+
+[discrete]
+[[input-beats-ssl-9.0]]
+.`logstash-input-beats`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cipher_suites |<<plugins-inputs-beats-ssl_cipher_suites>>
+| ssl |<<plugins-inputs-beats-ssl_enabled>>
+| ssl_peer_metadata |`ssl_peer_metadata` option of <<plugins-inputs-beats-enrich>>
+| ssl_verify_mode |<<plugins-inputs-beats-ssl_client_authentication>>
+| tls_min_version |<<plugins-inputs-beats-ssl_supported_protocols>>
+| tls_max_version |<<plugins-inputs-beats-ssl_supported_protocols>>
+|=======================================================================
+
+====
+
+[discrete]
+[[input-elastic_agent-ssl-9.0]]
+.`logstash-input-elastic_agent`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cipher_suites |<<plugins-inputs-elastic_agent-ssl_cipher_suites>>
+| ssl |<<plugins-inputs-elastic_agent-ssl_enabled>>
+| ssl_peer_metadata | `ssl_peer_metadata` option of <<plugins-inputs-elastic_agent-enrich>>
+| ssl_verify_mode |<<plugins-inputs-elastic_agent-ssl_client_authentication>>
+| tls_min_version |<<plugins-inputs-elastic_agent-ssl_supported_protocols>>
+| tls_max_version |<<plugins-inputs-elastic_agent-ssl_supported_protocols>>
+|=======================================================================
+
+====
 
 [discrete]
 [[output-http-ssl-9.0]]


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Adds SSL params obsoletion to the LS core 9.0 breaking change doc.

## Why is it important/What is the impact to the user?
Improves visibility and guides to successful upgrade when users upgrade from 8.x stack to 9.0

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes https://github.com/logstash-plugins/logstash-input-beats/pull/508

## Use cases


## Screenshots

## Logs
