### PR TITLE
Pin `jar-dependencies` to `0.4.1`

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "sinatra", '~> 4'
   gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.4.2'
   gem.add_runtime_dependency 'ruby-maven-libs', '~> 3', '>= 3.8.9'
-
+  gem.add_runtime_dependency "jar-dependencies",'= 0.4.1' # Pin to `0.4.1` until https://github.com/jruby/jruby/issues/7262 is resolved
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
Pin jar-dependencies to `0.4.1`, until https://github.com/jruby/jruby/issues/7262 is resolved.
