### PR TITLE
Backport PR #16747 to 7.17: Pin jar-dependencies to 0.4.1

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -59,7 +59,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'puma', '~> 5', '>= 5.6.8'
   gem.add_runtime_dependency "jruby-openssl", "~> 0.11"
   gem.add_runtime_dependency "chronic_duration", "~> 0.10"
-
+  gem.add_runtime_dependency "jar-dependencies",'= 0.4.1' # Pin to `0.4.1` until https://github.com/jruby/jruby/issues/7262 is resolved
+  
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 
   gem.add_runtime_dependency "i18n", "~> 1" #(MIT license)


### PR DESCRIPTION
Backport PR #16747 to 7.17 branch, original message:

Pin jar-dependencies to 0.4.1, until jruby/jruby#7262 is resolved.

This was not a clean backport. `jar-dependencies` version verified against version of jruby shipped with `7.17`

https://github.com/jruby/jruby/blob/9.2.20.1/pom.rb#L82