### PR TITLE
Update usage of beats-input obsoleted SSL params in the core.

### DIFF
--- a/docs/static/ls-ls-lumberjack.asciidoc
+++ b/docs/static/ls-ls-lumberjack.asciidoc
@@ -73,7 +73,7 @@ Start the downstream instance of Logstash:
 
 [source,shell]
 ----
-bin/logstash -e 'input { beats { codec => json port => 5000 ssl => true ssl_certificate => "lumberjack.cert" ssl_key => "lumberjack.key"} }'
+bin/logstash -e 'input { beats { codec => json port => 5000 ssl_enabled => true ssl_certificate => "lumberjack.cert" ssl_key => "lumberjack.key"} }'
 ----
 
 This sample command sets port 5000 to listen for incoming Beats input.

--- a/docsk8s/quick-start/sample-configuration-files.asciidoc
+++ b/docsk8s/quick-start/sample-configuration-files.asciidoc
@@ -41,11 +41,11 @@ data:
     input {
       beats {
         port => "5044"
-        ssl => true
+        ssl_enabled => true
         ssl_certificate_authorities => ["/usr/share/logstash/config/ca.crt"]
         ssl_certificate => "/usr/share/logstash/config/server.crt"
         ssl_key => "/usr/share/logstash/config/server.pkcs8.key"
-        ssl_verify_mode => "force_peer"
+        ssl_client_authentication => "required"
       }
     }
     output {

--- a/docsk8s/setting-up/ls-k8s-secure.asciidoc
+++ b/docsk8s/setting-up/ls-k8s-secure.asciidoc
@@ -28,11 +28,11 @@ On {ls}, configure the server certificates to the pipeline:
 input {
     beats {
         port => "5044"
-        ssl => true
+        ssl_enabled => true
         ssl_certificate_authorities => ["/usr/share/logstash/config/ca.crt"]
         ssl_certificate => "/usr/share/logstash/config/server.crt"
         ssl_key => "/usr/share/logstash/config/server.pkcs8.key"
-        ssl_verify_mode => "force_peer"
+        ssl_client_authentication => "required"
     }
 }
 --

--- a/qa/integration/fixtures/beats_input_spec.yml
+++ b/qa/integration/fixtures/beats_input_spec.yml
@@ -13,7 +13,7 @@ config:
   tls_server_auth: |-
     input {
       beats {
-        ssl => true
+        ssl_enabled => true
         port => 5044
         ssl_certificate => '<%=options[:ssl_certificate]%>'
         ssl_key => '<%=options[:ssl_key]%>'
@@ -23,11 +23,11 @@ config:
   tls_mutual_auth: |-
     input {
       beats {
-        ssl => true
+        ssl_enabled => true
         port => 5044
         ssl_certificate => '<%=options[:ssl_certificate]%>'
         ssl_key => '<%=options[:ssl_key]%>'
-        ssl_verify_mode => "force_peer"
+        ssl_client_authentication => "required"
         ssl_certificate_authorities => '<%=options[:ssl_certificate]%>'
       }
     }


### PR DESCRIPTION

## Release notes
[rn:skip]

## What does this PR do?
Recently, some of SSL params of beats-input obsoleted. We need update usage of those params which this PR does.

## Why is it important/What is the impact to the user?
N.A

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- 

## Use cases

## Screenshots

## Logs

