### PR TITLE
Pin plugins that incorporate breaking changes in 9.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,3 +43,7 @@ gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
+
+# Pin plugins to avoid including those with breaking changes in development builds without a defined lockfile
+gem "logstash-input-beats", "~> 6"
+gem "logstash-output-http", "~> 5"


### PR DESCRIPTION
A number of plugins include breaking changes in 9.x, which, without restriction, will be included in development `8.x` branches that do not include a lockfile.

This commit adds these to the Gemfile.template to avoid being introduced in 8.x development branches
