### PR TITLE
ensure inputSize state value is reset during buftok.flush

### DIFF
--- a/logstash-core/spec/logstash/util/buftok_spec.rb
+++ b/logstash-core/spec/logstash/util/buftok_spec.rb
@@ -43,6 +43,35 @@ describe  FileWatch::BufferedTokenizer  do
     expect(subject.extract("\n\n\n")).to eq(["", "", ""])
   end
 
+  describe 'flush' do
+    let(:data) { "content without a delimiter" }
+    before(:each) do
+      subject.extract(data)
+    end
+
+    it "emits the contents of the buffer" do
+      expect(subject.flush).to eq(data)
+    end
+
+    it "resets the state of the buffer" do
+      subject.flush
+      expect(subject).to be_empty
+    end
+
+    context 'with decode_size_limit_bytes' do
+      subject { FileWatch::BufferedTokenizer.new("\n", 100) }
+
+      it "emits the contents of the buffer" do
+        expect(subject.flush).to eq(data)
+      end
+
+      it "resets the state of the buffer" do
+        subject.flush
+        expect(subject).to be_empty
+      end
+    end
+  end
+
   context 'with delimiter' do
     subject { FileWatch::BufferedTokenizer.new(delimiter) }
 

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
@@ -106,12 +106,13 @@ public class BufferedTokenizerExt extends RubyObject {
     public IRubyObject flush(final ThreadContext context) {
         final IRubyObject buffer = input.join(context);
         input.clear();
+        inputSize = 0;
         return buffer;
     }
 
     @JRubyMethod(name = "empty?")
     public IRubyObject isEmpty(final ThreadContext context) {
-        return input.empty_p();
+        return RubyUtil.RUBY.newBoolean(input.isEmpty() && (inputSize == 0));
     }
 
 }


### PR DESCRIPTION
The BufferedTokenizer.flush must reset the inputSize value back to zero on flush, otherwise it will grow until a buffer full exception is thrown if the buffer has a size limit.

We can see the test fails if the `inputSize = 0` is not present:

```
❯ bin/rspec logstash-core/spec/logstash/util/buftok_spec.rb -fd -e flush
[...]
FileWatch::BufferedTokenizer
  flush
    emits the contents of the buffer
    resets the state of the buffer
    with decode_size_limit_bytes
      resets the state of the buffer (FAILED - 1)
      emits the contents of the buffer

Failures:

  1) FileWatch::BufferedTokenizer flush with decode_size_limit_bytes resets the state of the buffer
     Failure/Error: expect(subject).to be_empty
       expected `#<FileWatch::BufferedTokenizer:0x35977ba7>.empty?` to be truthy, got false
     # ./logstash-core/spec/logstash/util/buftok_spec.rb:65:in `block in <main>'
     # ./spec/spec_helper.rb:84:in `block in <main>'
```

But with it tests pass:

```
❯ bin/rspec logstash-core/spec/logstash/util/buftok_spec.rb -fd -e flush

FileWatch::BufferedTokenizer
  flush
    resets the state of the buffer
    emits the contents of the buffer
    with decode_size_limit_bytes
      emits the contents of the buffer
      resets the state of the buffer

Finished in 0.0246 seconds (files took 1.34 seconds to load)
4 examples, 0 failures
```