### PR TITLE
Add `x-elastic-product-origin` header to Kibana requests

### DIFF
--- a/logstash-core/lib/logstash/modules/kibana_client.rb
+++ b/logstash-core/lib/logstash/modules/kibana_client.rb
@@ -91,7 +91,12 @@ module LogStash module Modules class KibanaClient
     @endpoint = "#{@scheme}://#{@host}"
 
     @client = client || Manticore::Client.new(client_options)
-    @http_options = {:headers => {'Content-Type' => 'application/json'}}
+    @http_options = {
+      :headers => {
+        'Content-Type' => 'application/json',
+        "x-elastic-product-origin" => "logstash"
+      }
+    }
     username = @settings["var.kibana.username"]
     if username
       password = @settings["var.kibana.password"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Include a special product origin header for requests to Kibana so that Upgrade Assistant can avoid calling out deprecations that are not user-actionable.

## What does this PR do?

Update the Kibana client with an additional HTTP header, so that Upgrade Assistant can reduce noise from non-user-actionable deprecation warnings potentially generated by the requests in Kibana.

## Why is it important/What is the impact to the user?

Often Stack-internal communication may include usage of deprecated API's in one major, with upstream fixes already present in the next major's branch. This can result in non-user-actionable deprecations flooding the Upgrade Assistant. By adding the `x-elastic-product-origin` header with value Logstash, we empower the Upgrade Assistant to isolate Stack-internal communication from the user-facing messaging (https://github.com/elastic/kibana/pull/121174)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works


## Related issues

Closes https://github.com/elastic/logstash/issues/16735
Release note and PR description inspired by https://github.com/elastic/logstash/pull/13563 