### PR TITLE
Add logstash-input-tcp obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -53,9 +53,9 @@ removed and their replacements.
 [cols="<,<",options="header",]
 |=======================================================================
 |Setting|Replaced by
-| ssl_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
-| ssl_enable |<<plugins-{type}s-{plugin}-ssl_enabled>>
-| ssl_verify |<<plugins-{type}s-{plugin}-ssl_client_authentication>> in `server` mode and <<plugins-{type}s-{plugin}-ssl_verification_mode>> in `client` mode
+| ssl_cert |<<plugins-inputs-tcp-ssl_certificate>>
+| ssl_enable |<<plugins-inputs-tcp-ssl_enabled>>
+| ssl_verify |<<plugins-inputs-tcp-ssl_client_authentication>> in `server` mode and <<plugins-inputs-tcp-ssl_verification_mode>> in `client` mode
 |=======================================================================
 
 ====

--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,23 @@ removed and their replacements.
 ====
 
 [discrete]
+[[input-tcp-ssl-9.0]]
+.`logstash-input-tcp`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| ssl_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
+| ssl_enable |<<plugins-{type}s-{plugin}-ssl_enabled>>
+| ssl_verify |<<plugins-{type}s-{plugin}-ssl_client_authentication>> in `server` mode and <<plugins-{type}s-{plugin}-ssl_verification_mode>> in `client` mode
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the TCP input to the `9.0` breaking changes doc