### PR TITLE
Add logstash-output-tcp obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -86,3 +86,21 @@ removed and their replacements.
 |=======================================================================
 
 ====
+
+[discrete]
+[[output-tcp-ssl-9.0]]
+.`logstash-output-tcp`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| ssl_cacert |<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| ssl_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
+| ssl_enable |<<plugins-{type}s-{plugin}-ssl_enabled>>
+| ssl_verify |<<plugins-{type}s-{plugin}-ssl_client_authentication>> in `server` mode and <<plugins-{type}s-{plugin}-ssl_verification_mode>> in `client` mode
+|=======================================================================
+
+====

--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -97,10 +97,10 @@ removed and their replacements.
 [cols="<,<",options="header",]
 |=======================================================================
 |Setting|Replaced by
-| ssl_cacert |<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
-| ssl_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
-| ssl_enable |<<plugins-{type}s-{plugin}-ssl_enabled>>
-| ssl_verify |<<plugins-{type}s-{plugin}-ssl_client_authentication>> in `server` mode and <<plugins-{type}s-{plugin}-ssl_verification_mode>> in `client` mode
+| ssl_cacert |<<plugins-outputs-tcp-ssl_certificate_authorities>>
+| ssl_cert |<<plugins-outputs-tcp-ssl_certificate>>
+| ssl_enable |<<plugins-outputs-tcp-ssl_enabled>>
+| ssl_verify |<<plugins-outputs-tcp-ssl_client_authentication>> in `server` mode and <<plugins-outputs-tcp-ssl_verification_mode>> in `client` mode
 |=======================================================================
 
 ====


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the TCP output to the `9.0` breaking changes doc