### PR TITLE
[docs] Document JDK 21 since Logstash 8.15.0

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -4,8 +4,8 @@
 
 {ls} requires one of these versions:
 
-* Java 17 (default). Check out <<jdk17-upgrade>> for settings info.
-* Java 21
+* Java 17. Check out <<jdk17-upgrade>> for settings info.
+* Java 21 (default since 8.15.0)
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official
@@ -20,7 +20,7 @@ for the official word on supported versions across releases.
 =====
 {ls} offers architecture-specific
 https://www.elastic.co/downloads/logstash[downloads] that include
-Adoptium Eclipse Temurin 17, a long term support (LTS) release of the JDK.
+Adoptium Eclipse Temurin 21, a long term support (LTS) release of the JDK.
 
 Use the LS_JAVA_HOME environment variable if you want to use a JDK other than the
 version that is bundled.
@@ -40,9 +40,9 @@ On systems with Java installed, this command produces output similar to the foll
 
 [source,shell]
 -----
-openjdk version "17.0.12" 2024-07-16
-OpenJDK Runtime Environment Temurin-17.0.12+7 (build 17.0.12+7)
-OpenJDK 64-Bit Server VM Temurin-17.0.12+7 (build 17.0.12+7, mixed mode)
+openjdk version "21.0.5" 2024-10-15
+OpenJDK Runtime Environment Temurin-21.0.5+11 (build 21.0.5+11)
+OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11, mixed mode)
 -----
 
 [float]
@@ -67,7 +67,7 @@ installation, you may get an error message, and {ls} will not start properly.
 [[jdk17-upgrade]]
 ==== Using JDK 17
 
-{ls} uses JDK 17 by default, but you need to update settings in `jvm.options` and
+{ls} uses JDK 21 by default, but you need to update settings in `jvm.options` and
 `log4j2.properties` if you are upgrading from  {ls} 7.11.x (or earlier) to 7.12 or later.
 
 


### PR DESCRIPTION
Since Logstash 8.15.0, we are shipping JDK 21 as per https://www.elastic.co/guide/en/logstash/current/logstash-8-15-0.html:

```
IMPLEMENTOR="Eclipse Adoptium"
IMPLEMENTOR_VERSION="Temurin-21.0.5+11"
JAVA_RUNTIME_VERSION="21.0.5+11-LTS"
JAVA_VERSION="21.0.5"
JAVA_VERSION_DATE="2024-10-15"
LIBC="gnu"
MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.jvmstat jdk.attach jdk.charsets jdk.internal.opt jdk.zipfs jdk.compiler jdk.crypto.ec jdk.crypto.cryptoki jdk.dynalink jdk.internal.ed jdk.editpad jdk.hotspot.agent jdk.httpserver jdk.incubator.vector jdk.internal.le jdk.internal.vm.ci jdk.internal.vm.compiler jdk.internal.vm.compiler.management jdk.jartool jdk.javadoc jdk.jcmd jdk.management jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jlink jdk.jpackage jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.nio.mapmode jdk.random jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported jdk.unsupported.desktop jdk.xml.dom"
OS_ARCH="x86_64"
OS_NAME="Linux"
SOURCE=".:git:9f7db4edca1b"
BUILD_SOURCE="git:08621c72262ba260e4bb6451a9c75bf1c0ab365d"
BUILD_SOURCE_REPO="https://github.com/adoptium/temurin-build.git"
SOURCE_REPO="https://github.com/adoptium/jdk21u.git"
FULL_VERSION="21.0.5+11-LTS"
SEMANTIC_VERSION="21.0.5+11"
BUILD_INFO="OS: Linux Version: 6.5.0-1025-azure"
JVM_VARIANT="Hotspot"
JVM_VERSION="21.0.5+11-LTS"
IMAGE_TYPE="JDK"
```

This needs to be reflected in the documentation and backported to 8.15.0 and newer. Ideally, it would be reviewed by the dev team to ensure all other information is still accurate too.