### PR TITLE
Avoid lock when ecs_compatibility is explicitly specified

### DIFF
--- a/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
+++ b/logstash-core/lib/logstash/plugins/ecs_compatibility_support.rb
@@ -9,10 +9,11 @@ module LogStash
 
       def ecs_compatibility
         @_ecs_compatibility || LogStash::Util.synchronize(self) do
-          @_ecs_compatibility ||= begin
-            # use config_init-set value if present
-            break @ecs_compatibility unless @ecs_compatibility.nil?
+          # use config_init-set value if present
+          @_ecs_compatibility ||= @ecs_compatibility
 
+          # load default from settings
+          @_ecs_compatibility ||= begin
             pipeline = execution_context.pipeline
             pipeline_settings = pipeline && pipeline.settings
             pipeline_settings ||= LogStash::SETTINGS


### PR DESCRIPTION
## Release notes

 - Improves concurrent performance of some plugins when they are instantiated with an explicit `ecs_compatibility` directive.

## What does this PR do?

Properly memoizes an explicitly-given `ecs_compatibility` directive on first access so that it can be retrieved _without_ lock contention.

Because a `break` escapes a `begin`...`end` block, we must not use a `break` in order to ensure that the explicitly set value gets memoized to avoid lock contention.

> ~~~ ruby
> def fake_sync(&block)
>   puts "FAKE_SYNC:enter"
>   val = yield
>   puts "FAKE_SYNC:return(#{val})"
>   return val
> ensure
>   puts "FAKE_SYNC:ensure"
> end
> 
> returned = fake_sync do
>   @ivar = begin
>     puts("BE:begin")
>     break :break # expectation: break the current `begin`...`end` block
>   	
>     val = :returned
>     puts("BE:return(#{val})")
>     val
>   ensure
>     puts("BE:ensure")
>   end
> end
> puts({:returned => returned, :@ivar => @ivar})
> ~~~

Note: no `FAKE_SYNC:return`:

> ~~~
> ╭─{ rye@perhaps:~/src/elastic/logstash (main ✔) }
> ╰─● ruby break-esc.rb
> FAKE_SYNC:enter
> BE:begin
> BE:ensure
> FAKE_SYNC:ensure
> {:returned=>:break, :@ivar=>nil}
> [success]
> ~~~

## Why is it important/What is the impact to the user?

Eliminates unnecessary lock contention, which can prevent some plugins from running as concurrently as they would otherwise be able.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
