### PR TITLE
Add logstash-filter-http obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,29 @@ removed and their replacements.
 ====
 
 [discrete]
+[[filter-http-ssl-9.0]]
+.`logstash-filter-http`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cacert |<<plugins-filters-http-ssl_certificate_authorities>>
+| client_cert |<<plugins-filters-http-ssl_certificate>>
+| client_key |<<plugins-filters-http-ssl_key>>
+| keystore |<<plugins-filters-http-ssl_keystore_path>>
+| keystore_password |<<plugins-filters-http-ssl_keystore_password>>
+| keystore_type |<<plugins-filters-http-ssl_keystore_type>>
+| truststore |<<plugins-filters-http-ssl_truststore_path>>
+| truststore_password |<<plugins-filters-http-ssl_truststore_password>>
+| truststore_type |<<plugins-filters-http-ssl_truststore_type>>
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the HTTP filter to the `9.0` breaking changes doc