### PR TITLE
Add logstash-input-http obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,29 @@ removed and their replacements.
 ====
 
 [discrete]
+[[input-http-ssl-9.0]]
+.`logstash-input-http`
+
+[%collapsible]
+====
+
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cipher_suites |<<plugins-inputs-http-ssl_cipher_suites>>
+| keystore |<<plugins-inputs-http-ssl_keystore_path>>
+| keystore_password |<<plugins-inputs-http-ssl_keystore_password>>
+| ssl |<<plugins-inputs-http-ssl_enabled>>
+| ssl_verify_mode |<<plugins-inputs-http-ssl_client_authentication>>
+| tls_max_version |<<plugins-inputs-http-ssl_supported_protocols>>
+| tls_min_version |<<plugins-inputs-http-ssl_supported_protocols>>
+| verify_mode |<<plugins-inputs-http-ssl_client_authentication>>
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the HTTP input to the `9.0` breaking changes doc