### PR TITLE
Add logstash-input-http_poller obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,29 @@ removed and their replacements.
 ====
 
 [discrete]
+[[input-http_poller-ssl-9.0]]
+.`logstash-input-http_poller`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cacert |<<plugins-inputs-http_poller-ssl_certificate_authorities>>
+| client_cert |<<plugins-inputs-http_poller-ssl_certificate>>
+| client_key |<<plugins-inputs-http_poller-ssl_key>>
+| keystore |<<plugins-inputs-http_poller-ssl_keystore_path>>
+| keystore_password |<<plugins-inputs-http_poller-ssl_keystore_password>>
+| keystore_type |<<plugins-inputs-http_poller-ssl_keystore_password>>
+| truststore |<<plugins-inputs-http_poller-ssl_truststore_path>>
+| truststore_password |<<plugins-inputs-http_poller-ssl_truststore_password>>
+| truststore_type |<<plugins-inputs-http_poller-ssl_truststore_type>>
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the HTTP poller input to the `9.0` breaking changes doc