### PR TITLE
Doc: Update security docs to replace obsolete cacert setting

### DIFF
--- a/docs/static/security/es-security.asciidoc
+++ b/docs/static/security/es-security.asciidoc
@@ -78,7 +78,7 @@ As always, there's a definite argument for consistency across deployments.
 [[es-sec-plugin]]
 ==== Configure the elasticsearch output
 
-Use the <<plugins-outputs-elasticsearch,`elasticsearch output`'s>> <<plugins-outputs-elasticsearch-cacert,`cacert` option>> to point to the certificate's location. 
+Use the <<plugins-outputs-elasticsearch,`elasticsearch output`'s>> <<plugins-outputs-elasticsearch-ssl_certificate_authorities,`ssl_certificate_authorities` option>> to point to the certificate's location. 
 
 **Example**
 
@@ -87,7 +87,7 @@ Use the <<plugins-outputs-elasticsearch,`elasticsearch output`'s>> <<plugins-out
 output {
   elasticsearch {
     hosts => ["https://...] <1>
-    cacert => '/etc/logstash/config/certs/ca.crt' <2>
+    ssl_certificate_authorities => '/etc/logstash/config/certs/ca.crt' <2>
   }
 }
 -------

--- a/docs/static/security/es-security.asciidoc
+++ b/docs/static/security/es-security.asciidoc
@@ -87,7 +87,7 @@ Use the <<plugins-outputs-elasticsearch,`elasticsearch output`'s>> <<plugins-out
 output {
   elasticsearch {
     hosts => ["https://...] <1>
-    ssl_certificate_authorities => '/etc/logstash/config/certs/ca.crt' <2>
+    ssl_certificate_authorities => ['/etc/logstash/config/certs/ca.crt'] <2>
   }
 }
 -------


### PR DESCRIPTION
Related: 
* Issue:  https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1190
* PR: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1197

The "**Secure your connection to Elasticsearch > [Configure the elasticsearch output](https://www.elastic.co/guide/en/logstash/current/ls-security.html#es-sec-plugin)**" topic contains inaccurate info (and link) in light of obsolete SSL setttings.  

This PR updates the content to point to replacement setting and fixes the example.  

**PREVIEW:** https://logstash_bk_16798.docs-preview.app.elstc.co/guide/en/logstash/master/ls-security.html#es-sec-plugin