### PR TITLE
[Doc] use UBI8 as base image

### DIFF
--- a/docs/static/docker.asciidoc
+++ b/docs/static/docker.asciidoc
@@ -1,7 +1,7 @@
 [[docker]]
 === Running Logstash on Docker
 Docker images for Logstash are available from the Elastic Docker
-registry. The base image is https://hub.docker.com/_/ubuntu/[ubuntu:20.04].
+registry. The base image is https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8[Red Hat Universal Base Image 8 Minimal].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in


### PR DESCRIPTION
relates: https://github.com/elastic/ingest-dev/issues/3648

Since v9, the Docker base image has been changed from Ubuntu to UBI.