### PR TITLE
Add logstash-filter-elasticsearch obsolete ssl section to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,24 @@ removed and their replacements.
 ====
 
 [discrete]
+[[filter-elasticsearch-ssl-9.0]]
+.`logstash-filter-elasticsearch`
+
+[%collapsible]
+====
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| ca_file |<<plugins-filters-elasticsearch-ssl_certificate_authorities>>
+| keystore |<<plugins-filters-elasticsearch-ssl_keystore_path>>
+| keystore_password |<<plugins-filters-elasticsearch-ssl_keystore_password>>
+| ssl |<<plugins-filters-elasticsearch-ssl_enabled>>
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 

--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -50,7 +50,7 @@ removed and their replacements.
 [%collapsible]
 ====
 
-[cols="<,<,<",options="header",]
+[cols="<,<",options="header",]
 |=======================================================================
 |Setting|Replaced by
 | ca_file |<<plugins-filters-elasticsearch-ssl_certificate_authorities>>


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the Elasticsearch filter to the `9.0` breaking changes doc