### PR TITLE
Add logstash-input-elastic_serverless_forwarder ssl conf to breaking changes doc

### DIFF
--- a/docs/static/breaking-changes-90.asciidoc
+++ b/docs/static/breaking-changes-90.asciidoc
@@ -44,6 +44,21 @@ removed and their replacements.
 ====
 
 [discrete]
+[[input-elastic_serverless_forwarder-ssl-9.0]]
+.`logstash-input-elastic_serverless_forwarder`
+
+[%collapsible]
+====
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| ssl |<<plugins-inputs-elastic_serverless_forwarder-ssl_enabled>>
+|=======================================================================
+
+====
+
+[discrete]
 [[output-elasticsearch-ssl-9.0]]
 .`logstash-output-elasticsearch`
 


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Adds information about the SSL setting obsolescence for the `elastic_serverless_forwarder` input to the `9.0` breaking changes doc