### PR TITLE
Apply Jackson stream read constraints defaults at runtime

### DIFF
--- a/logstash-core/src/main/java/org/logstash/jackson/StreamReadConstraintsUtil.java
+++ b/logstash-core/src/main/java/org/logstash/jackson/StreamReadConstraintsUtil.java
@@ -18,6 +18,14 @@ public class StreamReadConstraintsUtil {
 
     private StreamReadConstraints configuredStreamReadConstraints;
 
+    // Provide default values for Jackson constraints in the case they are
+    // not specified in configuration file.
+    private static final Map<Override, Integer> JACKSON_DEFAULTS = Map.of(
+        Override.MAX_STRING_LENGTH, 200_000_000,
+        Override.MAX_NUMBER_LENGTH, 10_000,
+        Override.MAX_NESTING_DEPTH, 1_000
+    );
+
     enum Override {
         MAX_STRING_LENGTH(StreamReadConstraints.Builder::maxStringLength, StreamReadConstraints::getMaxStringLength),
         MAX_NUMBER_LENGTH(StreamReadConstraints.Builder::maxNumberLength, StreamReadConstraints::getMaxNumberLength),
@@ -78,6 +86,8 @@ public class StreamReadConstraintsUtil {
         if (configuredStreamReadConstraints == null) {
             final StreamReadConstraints.Builder builder = StreamReadConstraints.defaults().rebuild();
 
+            // Apply the Jackson defaults first, then the overrides from config
+            JACKSON_DEFAULTS.forEach((override, value) -> override.applicator.apply(builder, value));
             eachOverride((override, value) -> override.applicator.apply(builder, value));
 
             this.configuredStreamReadConstraints = builder.build();


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

Ensure that the Jackson read constraints defaults (Maximum Number value length, Maximum String value length, and Maximum Nesting depth) are applied at runtime if they are absent from `jvm.options`. 


## What does this PR do?

When Logstash 8.12.0 added increased Jackson stream read constraints to jvm.options, assumptions about the existence of that file's contents were invalidated. This led to issues like #16683.

This change ensures Logstash applies defaults from config at runtime:
- MAX_STRING_LENGTH: 200_000_000
- MAX_NUMBER_LENGTH: 10_000
- MAX_NESTING_DEPTH: 1_000

These match the jvm.options defaults and are applied even when config is missing. Config values still override these defaults when present.

## Why is it important/What is the impact to the user?

Users who have custom `jvm.options` files or have files that are not being updated with defaults in latest Logstash releases will still get the defaults we intend configure for the Jackson parsing lib.  

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works


## Related issues
Closes https://github.com/elastic/logstash/issues/16773
