### PR TITLE
jackson stream read constraints: code-based defaults

### DIFF
--- a/config/jvm.options
+++ b/config/jvm.options
@@ -71,11 +71,11 @@
 # text values with sizes less than or equal to this limit will be treated as invalid.
 # This value should be higher than `logstash.jackson.stream-read-constraints.max-number-length`.
 # The jackson library defaults to 20000000 or 20MB, whereas Logstash defaults to 200MB or 200000000 characters.
--Dlogstash.jackson.stream-read-constraints.max-string-length=200000000
+#-Dlogstash.jackson.stream-read-constraints.max-string-length=200000000
 #
 # Sets the maximum number length (in chars or bytes, depending on input context).
 # The jackson library defaults to 1000, whereas Logstash defaults to 10000.
--Dlogstash.jackson.stream-read-constraints.max-number-length=10000
+#-Dlogstash.jackson.stream-read-constraints.max-number-length=10000
 #
 # Sets the maximum nesting depth. The depth is a count of objects and arrays that have not
 # been closed, `{` and `[` respectively.

--- a/logstash-core/src/main/java/org/logstash/jackson/StreamReadConstraintsUtil.java
+++ b/logstash-core/src/main/java/org/logstash/jackson/StreamReadConstraintsUtil.java
@@ -5,10 +5,16 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class StreamReadConstraintsUtil {
@@ -19,29 +25,56 @@ public class StreamReadConstraintsUtil {
     private StreamReadConstraints configuredStreamReadConstraints;
 
     enum Override {
-        MAX_STRING_LENGTH(StreamReadConstraints.Builder::maxStringLength, StreamReadConstraints::getMaxStringLength),
-        MAX_NUMBER_LENGTH(StreamReadConstraints.Builder::maxNumberLength, StreamReadConstraints::getMaxNumberLength),
-        MAX_NESTING_DEPTH(StreamReadConstraints.Builder::maxNestingDepth, StreamReadConstraints::getMaxNestingDepth),
+        MAX_STRING_LENGTH(200_000_000, StreamReadConstraints.Builder::maxStringLength, StreamReadConstraints::getMaxStringLength),
+        MAX_NUMBER_LENGTH(10_000, StreamReadConstraints.Builder::maxNumberLength, StreamReadConstraints::getMaxNumberLength),
+        MAX_NESTING_DEPTH(null, StreamReadConstraints.Builder::maxNestingDepth, StreamReadConstraints::getMaxNestingDepth),
         ;
 
         static final String PROP_PREFIX = "logstash.jackson.stream-read-constraints.";
 
         final String propertyName;
+        final Integer defaultValue;
         private final IntValueApplicator applicator;
         private final IntValueObserver observer;
 
-        Override(final IntValueApplicator applicator,
+        Override(final Integer defaultValue,
+                 final IntValueApplicator applicator,
                  final IntValueObserver observer) {
             this.propertyName = PROP_PREFIX + this.name().toLowerCase().replace('_', '-');
+            this.defaultValue = defaultValue;
             this.applicator = applicator;
             this.observer = observer;
         }
 
-        @FunctionalInterface
-        interface IntValueObserver extends Function<StreamReadConstraints, Integer> {}
+        Integer resolve(final Integer specifiedValue) {
+            if (specifiedValue == null) {
+                return defaultValue;
+            }
+            return specifiedValue;
+        }
+
+        void apply(final StreamReadConstraints.Builder constraintsBuilder,
+                   @Nullable final Integer specifiedValue) {
+            final Integer resolvedValue = resolve(specifiedValue);
+            if (Objects.nonNull(resolvedValue)) {
+                this.applicator.applyIntValue(constraintsBuilder, resolvedValue);
+            }
+        }
+
+        int observe(final StreamReadConstraints constraints) {
+            return this.observer.observeIntValue(constraints);
+        }
 
         @FunctionalInterface
-        interface IntValueApplicator extends BiFunction<StreamReadConstraints.Builder, Integer, StreamReadConstraints.Builder> {}
+        interface IntValueObserver {
+            int observeIntValue(final StreamReadConstraints constraints);
+        }
+
+        @FunctionalInterface
+        interface IntValueApplicator {
+            @SuppressWarnings("UnusedReturnValue")
+            StreamReadConstraints.Builder applyIntValue(final StreamReadConstraints.Builder constraintsBuilder, final int value);
+        }
     }
 
     /**
@@ -78,7 +111,7 @@ public class StreamReadConstraintsUtil {
         if (configuredStreamReadConstraints == null) {
             final StreamReadConstraints.Builder builder = StreamReadConstraints.defaults().rebuild();
 
-            eachOverride((override, value) -> override.applicator.apply(builder, value));
+            eachOverride((override, specifiedValue) -> override.apply(builder, specifiedValue));
 
             this.configuredStreamReadConstraints = builder.build();
         }
@@ -96,11 +129,14 @@ public class StreamReadConstraintsUtil {
     private void validate(final StreamReadConstraints streamReadConstraints) {
         final List<String> fatalIssues = new ArrayList<>();
         eachOverride((override, specifiedValue) -> {
-            final Integer effectiveValue = override.observer.apply(streamReadConstraints);
-            if (Objects.equals(specifiedValue, effectiveValue)) {
-                logger.info("Jackson default value override `{}` configured to `{}`", override.propertyName, specifiedValue);
+            final Integer effectiveValue = override.observe(streamReadConstraints);
+            final Integer expectedValue = override.resolve(specifiedValue);
+
+            if (Objects.nonNull(expectedValue) && !Objects.equals(effectiveValue, expectedValue)) {
+                fatalIssues.add(String.format("`%s` (expected: `%s`, actual: `%s`)", override.propertyName, expectedValue, effectiveValue));
             } else {
-                fatalIssues.add(String.format("`%s` (expected: `%s`, actual: `%s`)", override.propertyName, specifiedValue, effectiveValue));
+                final String reason = (Objects.nonNull(specifiedValue) ? "system properties" : (Objects.nonNull(expectedValue) ? "logstash default" : "jackson default"));
+                logger.info("Jackson default value override `{}` configured to `{}` ({})", override.propertyName, effectiveValue, reason);
             }
         });
         for (String unsupportedProperty : getUnsupportedProperties()) {
@@ -114,13 +150,14 @@ public class StreamReadConstraintsUtil {
     void eachOverride(BiConsumer<Override,Integer> overrideIntegerBiConsumer) {
         for (Override override : Override.values()) {
             final String propValue = this.propertyOverrides.get(override.propertyName);
-            if (propValue != null) {
-                try {
-                    int intValue = Integer.parseInt(propValue);
-                    overrideIntegerBiConsumer.accept(override, intValue);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException(String.format("System property `%s` must be positive integer value. Received: `%s`", override.propertyName, propValue), e);
-                }
+
+            try {
+                final Integer explicitValue = Optional.ofNullable(propValue)
+                        .map(Integer::parseInt)
+                        .orElse(null);
+                overrideIntegerBiConsumer.accept(override, explicitValue);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(String.format("System property `%s` must be positive integer value. Received: `%s`", override.propertyName, propValue), e);
             }
         }
     }

--- a/logstash-core/src/test/java/org/logstash/ObjectMappersTest.java
+++ b/logstash-core/src/test/java/org/logstash/ObjectMappersTest.java
@@ -49,4 +49,9 @@ public class ObjectMappersTest {
         assertNotNull(found);
         assertTrue("RubyBasicObjectSerializer must be registered before others non-default serializers", found instanceof RubyBasicObjectSerializer);
     }
+
+    @Test
+    public void testStreamReadConstraintsApplication() {
+        ObjectMappers.CONFIGURED_STREAM_READ_CONSTRAINTS.validateIsGlobalDefault();
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/jackson/StreamReadConstraintsUtilTest.java
+++ b/logstash-core/src/test/java/org/logstash/jackson/StreamReadConstraintsUtilTest.java
@@ -7,13 +7,17 @@ import org.apache.logging.log4j.junit.LoggerContextRule;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.function.BiConsumer;
+
 import org.apache.logging.log4j.Level;
+import org.logstash.ObjectMappers;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.logstash.jackson.StreamReadConstraintsUtil.Override.*;
@@ -22,6 +26,9 @@ public class StreamReadConstraintsUtilTest {
 
     @ClassRule
     public static final LoggerContextRule LOGGER_CONTEXT_RULE = new LoggerContextRule("log4j2-log-stream-read-constraints.xml");
+
+    @Rule
+    public final DefaultsRestorer defaultsRestorer = new DefaultsRestorer();
 
     private ListAppender listAppender;
     private Logger observedLogger;
@@ -35,6 +42,7 @@ public class StreamReadConstraintsUtilTest {
 
     @Test
     public void configuresDefaultsByDefault() {
+        Objects.requireNonNull(ObjectMappers.CBOR_MAPPER); // force static init
         StreamReadConstraintsUtil.fromSystemProperties().validateIsGlobalDefault();
     }
 
@@ -52,7 +60,7 @@ public class StreamReadConstraintsUtilTest {
                     .returns(defaults.getMaxDocumentLength(), from(StreamReadConstraints::getMaxDocumentLength))
                     .returns(defaults.getMaxNameLength(), from(StreamReadConstraints::getMaxNameLength))
                     .returns(defaults.getMaxNestingDepth(), from(StreamReadConstraints::getMaxNestingDepth))
-                    .returns(defaults.getMaxNumberLength(), from(StreamReadConstraints::getMaxNumberLength));
+                    .returns(MAX_NUMBER_LENGTH.defaultValue, from(StreamReadConstraints::getMaxNumberLength));
 
             assertThatThrownBy(configuredUtil::validateIsGlobalDefault).isInstanceOf(IllegalStateException.class).hasMessageContaining(MAX_STRING_LENGTH.propertyName);
 
@@ -95,7 +103,7 @@ public class StreamReadConstraintsUtilTest {
                     .returns(defaults.getMaxDocumentLength(), from(StreamReadConstraints::getMaxDocumentLength))
                     .returns(defaults.getMaxNameLength(), from(StreamReadConstraints::getMaxNameLength))
                     .returns(defaults.getMaxNestingDepth(), from(StreamReadConstraints::getMaxNestingDepth))
-                    .returns(defaults.getMaxStringLength(), from(StreamReadConstraints::getMaxStringLength));
+                    .returns(MAX_STRING_LENGTH.defaultValue, from(StreamReadConstraints::getMaxStringLength));
 
             assertThatThrownBy(configuredUtil::validateIsGlobalDefault).isInstanceOf(IllegalStateException.class).hasMessageContaining(MAX_NUMBER_LENGTH.propertyName);
 
@@ -137,8 +145,8 @@ public class StreamReadConstraintsUtilTest {
             assertThat(configuredConstraints).as("inherited defaults")
                     .returns(defaults.getMaxDocumentLength(), from(StreamReadConstraints::getMaxDocumentLength))
                     .returns(defaults.getMaxNameLength(), from(StreamReadConstraints::getMaxNameLength))
-                    .returns(defaults.getMaxStringLength(), from(StreamReadConstraints::getMaxStringLength))
-                    .returns(defaults.getMaxNumberLength(), from(StreamReadConstraints::getMaxNumberLength));
+                    .returns(MAX_STRING_LENGTH.defaultValue, from(StreamReadConstraints::getMaxStringLength))
+                    .returns(MAX_NUMBER_LENGTH.defaultValue, from(StreamReadConstraints::getMaxNumberLength));
 
             assertThatThrownBy(configuredUtil::validateIsGlobalDefault).isInstanceOf(IllegalStateException.class).hasMessageContaining(MAX_NESTING_DEPTH.propertyName);
 
@@ -183,14 +191,26 @@ public class StreamReadConstraintsUtilTest {
             configuredUtil.validateIsGlobalDefault();
         });
 
-        System.out.format("OK%n");
-
         assertLogObserved(Level.INFO, "override `" + MAX_NESTING_DEPTH.propertyName + "` configured to `1010`");
         assertLogObserved(Level.INFO, "override `" + MAX_STRING_LENGTH.propertyName + "` configured to `1011`");
         assertLogObserved(Level.INFO, "override `" + MAX_NUMBER_LENGTH.propertyName + "` configured to `1110`");
 
         assertLogObserved(Level.WARN, "override `" + PROP_PREFIX + "unsupported-option1` is unknown and has been ignored");
         assertLogObserved(Level.WARN, "override `" + PROP_PREFIX + "unsupported-option1` is unknown and has been ignored");
+    }
+
+    @Test
+    public void validatesApplicationWithDefaults() {
+        final Properties properties = new Properties(); // empty -- no overrides
+
+        fromProperties(properties, (configuredUtil, defaults) -> {
+            configuredUtil.applyAsGlobalDefault();
+            configuredUtil.validateIsGlobalDefault();
+
+            assertLogObserved(Level.INFO, "override `" + MAX_NESTING_DEPTH.propertyName + "` configured to `" + defaults.getMaxNestingDepth() + "` (jackson default)");
+            assertLogObserved(Level.INFO, "override `" + MAX_STRING_LENGTH.propertyName + "` configured to `" + MAX_STRING_LENGTH.defaultValue + "` (logstash default)");
+            assertLogObserved(Level.INFO, "override `" + MAX_NUMBER_LENGTH.propertyName + "` configured to `" + MAX_NUMBER_LENGTH.defaultValue + "` (logstash default)");
+        });
     }
 
     private void assertLogObserved(final Level level, final String... messageFragments) {
@@ -201,13 +221,33 @@ public class StreamReadConstraintsUtilTest {
                 .anySatisfy(logEvent -> assertThat(logEvent.getMessage().getFormattedMessage()).contains(messageFragments));
     }
 
-    private synchronized void fromProperties(final Properties properties, BiConsumer<StreamReadConstraintsUtil, StreamReadConstraints> defaultsConsumer) {
+    private synchronized void fromProperties(final Properties properties,
+                                             final BiConsumer<StreamReadConstraintsUtil, StreamReadConstraints> defaultsConsumer) {
         final StreamReadConstraints defaults = StreamReadConstraints.defaults();
-        try {
-            final StreamReadConstraintsUtil util = new StreamReadConstraintsUtil(properties, this.observedLogger);
-            defaultsConsumer.accept(util, defaults);
-        } finally {
-            StreamReadConstraints.overrideDefaultStreamReadConstraints(defaults);
+        final StreamReadConstraintsUtil util = new StreamReadConstraintsUtil(properties, this.observedLogger);
+
+        defaultsConsumer.accept(util, defaults);
+    }
+
+    /**
+     * A TestRule to snapshot the current defaults from jackson prior to test execution, and to
+     * ensure that snapshot is restored after test execution has completed.
+     */
+    public static class DefaultsRestorer extends org.junit.rules.ExternalResource {
+        private StreamReadConstraints snapshot;
+
+        public StreamReadConstraints getSnapshot() {
+            return this.snapshot;
+        }
+
+        @Override
+        protected void before() throws Throwable {
+            this.snapshot = StreamReadConstraints.defaults();
+        }
+
+        @Override
+        protected void after() {
+            StreamReadConstraints.overrideDefaultStreamReadConstraints(this.snapshot);
         }
     }
 }


### PR DESCRIPTION
## Release notes

 - Ensures that logstash-provided defaults for jackson deserialization are applied unless explicitly overridden

## What does this PR do?

Brings the default values for `logstash.jackson.stream-read-constraints.*` properties into code, so that they are always applied (even when the provided `config/jvm.properties` does not include them, which is common on upgrades), and logs both the applied value and the _source_ of that value (whether a `jackson default`, a `logstash default`, or from `system properties`).

## Why is it important/What is the impact to the user?

Insulates users from shifting default values in Jackson, ensuring that the proper safeguards for deserializing are applied.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally



## Related issues

 - Relates #16832

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

When `config/jvm.options` has

~~~
-Dlogstash.jackson.stream-read-constraints.max-string-length=200000001
~~~

The logs include:

> ~~~
> [2025-01-03T22:58:29,560][INFO ][org.logstash.jackson.StreamReadConstraintsUtil] Jackson default value override `logstash.jackson.stream-read-constraints.max-string-length` configured to `200000001` (system properties)
> [2025-01-03T22:58:29,560][INFO ][org.logstash.jackson.StreamReadConstraintsUtil] Jackson default value override `logstash.jackson.stream-read-constraints.max-number-length` configured to `10000` (logstash default)
> [2025-01-03T22:58:29,560][INFO ][org.logstash.jackson.StreamReadConstraintsUtil] Jackson default value override `logstash.jackson.stream-read-constraints.max-nesting-depth` configured to `1000` (jackson default)
> ~~~
