### PR TITLE
Doc: Add appropriate alternate for deprecated module in 8.x

### DIFF
--- a/docs/static/azure-module.asciidoc
+++ b/docs/static/azure-module.asciidoc
@@ -7,7 +7,7 @@ experimental[]
 <titleabbrev>Azure Module (deprecated)</titleabbrev>
 ++++
 
-deprecated[7.8.0, "We recommend using the Azure modules in {filebeat-ref}/filebeat-module-azure.html[{Filebeat}] and {metricbeat-ref}/metricbeat-module-azure.html[{metricbeat}], which are compliant with the {ecs-ref}/index.html[Elastic Common Schema (ECS)]"]
+deprecated[7.8.0, "Replaced by the https://www.elastic.co/guide/en/integrations/current/azure-events.html[Azure Logs integration]."]
 
 The https://azure.microsoft.com/en-us/overview/what-is-azure/[Microsoft Azure]
 module in Logstash helps you easily integrate your Azure activity logs and SQL


### PR DESCRIPTION
Related: #16590 

We have better alternatives for the Logstash Azure module than we did when we first marked it for deprecation. 
This PR updates 8.x and 7.17 branches with a better alternative: https://www.elastic.co/guide/en/integrations/current/azure-events.html.

Backport targets:
* 8.17
* 8.16
* 7.17

**PREVIEW:** https://logstash_bk_16856.docs-preview.app.elstc.co/guide/en/logstash/8.x/azure-module.html
