### PR TITLE
Ensure plugin config marked :deprecated logs to deprecation logger

### DIFF
--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -123,13 +123,13 @@ module LogStash::Config::Mixin
       if opts && opts[:deprecated]
         extra = opts[:deprecated].is_a?(String) ? opts[:deprecated] : ""
         extra.gsub!("%PLUGIN%", self.class.config_name)
-        self.logger.warn("You are using a deprecated config setting " +
-                     "#{name.inspect} set in #{self.class.config_name}. " +
-                     "Deprecated settings will continue to work, " +
-                     "but are scheduled for removal from logstash " +
-                     "in the future. #{extra} If you have any questions " +
-                     "about this, please visit the #logstash channel " +
-                     "on freenode irc.", :name => name, :plugin => self)
+        self.deprecation_logger.deprecated("You are using a deprecated config setting " +
+                                           "#{name.inspect} set in #{self.class.config_name}. " +
+                                           "Deprecated settings will continue to work, " +
+                                           "but are scheduled for removal from logstash " +
+                                           "in the future. #{extra} If you have any questions " +
+                                           "about this, please visit the #logstash channel " +
+                                           "on freenode irc.", {})
 
       end
 

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -123,6 +123,15 @@ module LogStash::Config::Mixin
       if opts && opts[:deprecated]
         extra = opts[:deprecated].is_a?(String) ? opts[:deprecated] : ""
         extra.gsub!("%PLUGIN%", self.class.config_name)
+        # Log to main logger in addition to deprecation logger, in the 9.x series
+        # we will remove the main logger and only use the deprecation logger
+        self.logger.warn("You are using a deprecated config setting " +
+                         "#{name.inspect} set in #{self.class.config_name}. " +
+                         "Deprecated settings will continue to work, " +
+                         "but are scheduled for removal from logstash " +
+                         "in the future. #{extra} If you have any questions " +
+                         "about this, please visit the #logstash channel " +
+                         "on freenode irc.", :name => name, :plugin => self)
         self.deprecation_logger.deprecated("You are using a deprecated config setting " +
                                            "#{name.inspect} set in #{self.class.config_name}. " +
                                            "Deprecated settings will continue to work, " +


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Log messages for configuration options marked as `:deprecated` in plugin config are now routed to the deprecation logger in addition to the main logger. In the next major version (9.0.0) these messages will *only* go to the deprecation logger. 

## What does this PR do?

Ensure plugin config marked :deprecated logs to deprecation logger
Previously when the `:deprecated` modifier was used in the plugin config DSL a
log message was sent at `:warn` level ONLY to the main logger. This commit updates
that message to be routed *both* to the deprecation logger as well as the main
logger. In 9.x this will *only* go to the deprecation logger.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

Instead of needing to check the main logger for deprecation messages logged at `WARN` level, users can now expect to find the messages at the expected deprecation logger location. This allows them to find the complete set in the designated/expected destination. Note that the WARN message destined for the main logger is preserved in 8.x but in 9.x the message will *only* go to the deprecation logger. 

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes https://github.com/elastic/logstash/issues/14988
