### PR TITLE
Validate the size limit in BufferedTokenizer.

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerExtBenchmark.java
@@ -12,7 +12,6 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;

--- a/logstash-core/spec/logstash/util/buftok_spec.rb
+++ b/logstash-core/spec/logstash/util/buftok_spec.rb
@@ -61,6 +61,11 @@ describe  FileWatch::BufferedTokenizer  do
     context 'with decode_size_limit_bytes' do
       subject { FileWatch::BufferedTokenizer.new("\n", 100) }
 
+      it "validates size limit" do
+        expect { FileWatch::BufferedTokenizer.new("\n", -101) }.to raise_error(java.lang.IllegalArgumentException, "Size limit must be positive")
+        expect { FileWatch::BufferedTokenizer.new("\n", 0) }.to raise_error(java.lang.IllegalArgumentException, "Size limit must be positive")
+      end
+
       it "emits the contents of the buffer" do
         expect(subject.flush).to eq(data)
       end

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizerExt.java
@@ -55,7 +55,11 @@ public class BufferedTokenizerExt extends RubyObject {
             this.delimiter = args[0].convertToString();
         }
         if (args.length == 2) {
-            this.sizeLimit = args[1].convertToInteger().getIntValue();
+            final int sizeLimit = args[1].convertToInteger().getIntValue();
+            if (sizeLimit <= 0) {
+                throw new IllegalArgumentException("Size limit must be positive");
+            }
+            this.sizeLimit = sizeLimit;
             this.hasSizeLimit = true;
         }
         this.inputSize = 0;


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Currently, `BufferedTokenizer` doesn't validate size limit. That means any negative or zero value can lead `input buffer full` exception. This PR adds a safeguard validation on size limit to allow only positive number. 

## Why is it important/What is the impact to the user?
As it is a public interface, this enhancement improves interface experience.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes #16824

## Use cases

## Screenshots

## Logs
