### PR TITLE
Replace/remove references to defunct freenode instance (#16873)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ supported platforms, from [downloads page](https://www.elastic.co/downloads/logs
 
 - [Logstash Forum](https://discuss.elastic.co/c/logstash)
 - [Logstash Documentation](https://www.elastic.co/guide/en/logstash/current/index.html)
-- [#logstash on freenode IRC](https://webchat.freenode.net/?channels=logstash)
 - [Logstash Product Information](https://www.elastic.co/products/logstash)
 - [Elastic Support](https://www.elastic.co/subscriptions)
 

--- a/lib/pluginmanager/templates/codec-plugin/README.md
+++ b/lib/pluginmanager/templates/codec-plugin/README.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+Need help? Try the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/lib/pluginmanager/templates/filter-plugin/README.md
+++ b/lib/pluginmanager/templates/filter-plugin/README.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+Need help? Try the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/lib/pluginmanager/templates/input-plugin/README.md
+++ b/lib/pluginmanager/templates/input-plugin/README.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+Need help? Try the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/lib/pluginmanager/templates/output-plugin/README.md
+++ b/lib/pluginmanager/templates/output-plugin/README.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+Need help? Try the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/logstash-core/lib/logstash/config/mixin.rb
+++ b/logstash-core/lib/logstash/config/mixin.rb
@@ -125,21 +125,20 @@ module LogStash::Config::Mixin
         extra.gsub!("%PLUGIN%", self.class.config_name)
         # Log to main logger in addition to deprecation logger, in the 9.x series
         # we will remove the main logger and only use the deprecation logger
-        self.logger.warn("You are using a deprecated config setting " +
-                         "#{name.inspect} set in #{self.class.config_name}. " +
-                         "Deprecated settings will continue to work, " +
-                         "but are scheduled for removal from logstash " +
-                         "in the future. #{extra} If you have any questions " +
-                         "about this, please visit the #logstash channel " +
-                         "on freenode irc.", :name => name, :plugin => self)
-        self.deprecation_logger.deprecated("You are using a deprecated config setting " +
-                                           "#{name.inspect} set in #{self.class.config_name}. " +
-                                           "Deprecated settings will continue to work, " +
-                                           "but are scheduled for removal from logstash " +
-                                           "in the future. #{extra} If you have any questions " +
-                                           "about this, please visit the #logstash channel " +
-                                           "on freenode irc.", {})
-
+        self.logger.warn("You are using a deprecated config setting " \
+                         "#{name.inspect} set in #{self.class.config_name}. " \
+                         "Deprecated settings will continue to work, " \
+                         "but are scheduled for removal from logstash " \
+                         "in the future. #{extra} If you have any questions " \
+                         "about this, please ask it on the " \
+                         "https://discuss.elastic.co/c/logstash discussion forum", :name => name, :plugin => self)
+        self.deprecation_logger.deprecated("You are using a deprecated config setting " \
+                                           "#{name.inspect} set in #{self.class.config_name}. " \
+                                           "Deprecated settings will continue to work, " \
+                                           "but are scheduled for removal from logstash " \
+                                           "in the future. #{extra} If you have any questions " \
+                                           "about this, please ask it on the " \
+                                           "https://discuss.elastic.co/c/logstash discussion forum", {})
       end
 
       if opts && opts[:obsolete]

--- a/logstash-core/spec/logstash/config/mixin_spec.rb
+++ b/logstash-core/spec/logstash/config/mixin_spec.rb
@@ -38,7 +38,7 @@ describe LogStash::Config::Mixin do
       expect(main_logger).to receive(:warn).at_least(:once)  do |arg1, arg2|
         message = 'You are using a deprecated config setting "old_opt" set in test_deprecated. ' \
         'Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. ' \
-        'this is old school If you have any questions about this, please visit the #logstash channel on freenode irc.'
+        'this is old school If you have any questions about this, please ask it on the https://discuss.elastic.co/c/logstash discussion forum'
         expect(arg1).to eq(message)
         expect(arg2[:plugin].to_s).to include('"password"=><password>')
       end


### PR DESCRIPTION
**Backport PR #16873 to 8.x branch, original message:**


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Remove references to defunct freenode IRC and replace with preferred discussion forum. 

## Why is it important/What is the impact to the user?

Point folks at the preferred public discussion forum. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [ ] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Related issues

Closes https://github.com/elastic/logstash/issues/16851