### PR TITLE
plugin manager: add `--level=[major|minor|patch]` (default: `minor`)

### DIFF
--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -112,6 +112,21 @@ bin/logstash-plugin update logstash-input-github <2>
 <1> updates all installed plugins
 <2> updates only the plugin you specify
 
+[NOTE]
+.Major-version plugin updates
+==============================
+By default, the plugin manager will consume _minor_ updates containing non-breaking features and fixes.
+If you wish to also include breaking changes, specify `--level=major`.
+
+[source,shell]
+----------------------------------
+bin/logstash-plugin update --level=major <1>
+bin/logstash-plugin update --level=major logstash-input-github <2>
+----------------------------------
+<1> updates all installed plugins to latest, including major-version breaking changes
+<2> updates only the plugin you specify to latest, including major-version breaking changes
+==============================
+
 [discrete]
 [[removing-plugins]]
 === Removing plugins

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -115,7 +115,7 @@ bin/logstash-plugin update logstash-input-github <2>
 [NOTE]
 .Major-version plugin updates
 ==============================
-By default, the plugin manager will consume _minor_ updates containing non-breaking features and fixes.
+By default, the plugin manager will only update plugins for which newer _minor_ or _patch_ versions exist, to avoid the introduction of breaking changes.
 If you wish to also include breaking changes, specify `--level=major`.
 
 [source,shell]

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -113,10 +113,10 @@ bin/logstash-plugin update logstash-input-github <2>
 <2> updates only the plugin you specify
 
 [discrete]
-[[updating-plugins-major-versions]]
-==== Major-version plugin updates
+[[updating-major]]
+==== Major version plugin updates
 
-To avoid introducing breaking changes, the plugin manager updates plugins for which newer minor or patch versions exist by default. 
+To avoid introducing breaking changes, the plugin manager updates only plugins for which newer _minor_ or _patch_ versions exist by default.
 If you wish to also include breaking changes, specify `--level=major`.
 
 [source,shell]
@@ -124,8 +124,8 @@ If you wish to also include breaking changes, specify `--level=major`.
 bin/logstash-plugin update --level=major <1>
 bin/logstash-plugin update --level=major logstash-input-github <2>
 ----------------------------------
-<1> updates all installed plugins to latest, including major-version breaking changes
-<2> updates only the plugin you specify to latest, including major-version breaking changes
+<1> updates all installed plugins to latest, including major versions with breaking changes
+<2> updates only the plugin you specify to latest, including major versions with breaking changes
 
 
 [discrete]

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -112,9 +112,10 @@ bin/logstash-plugin update logstash-input-github <2>
 <1> updates all installed plugins
 <2> updates only the plugin you specify
 
-[NOTE]
-.Major-version plugin updates
-==============================
+[discrete]
+[[updating-plugins-major-versions]]
+==== Major-version plugin updates
+
 By default, the plugin manager will only update plugins for which newer _minor_ or _patch_ versions exist, to avoid the introduction of breaking changes.
 If you wish to also include breaking changes, specify `--level=major`.
 
@@ -125,7 +126,7 @@ bin/logstash-plugin update --level=major logstash-input-github <2>
 ----------------------------------
 <1> updates all installed plugins to latest, including major-version breaking changes
 <2> updates only the plugin you specify to latest, including major-version breaking changes
-==============================
+
 
 [discrete]
 [[removing-plugins]]

--- a/docs/static/plugin-manager.asciidoc
+++ b/docs/static/plugin-manager.asciidoc
@@ -116,7 +116,7 @@ bin/logstash-plugin update logstash-input-github <2>
 [[updating-plugins-major-versions]]
 ==== Major-version plugin updates
 
-By default, the plugin manager will only update plugins for which newer _minor_ or _patch_ versions exist, to avoid the introduction of breaking changes.
+To avoid introducing breaking changes, the plugin manager updates plugins for which newer minor or patch versions exist by default. 
 If you wish to also include breaking changes, specify `--level=major`.
 
 [source,shell]

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -264,6 +264,7 @@ module LogStash
       elsif options[:update]
         arguments << "update"
         arguments << expand_logstash_mixin_dependencies(options[:update])
+        arguments << "--#{options[:level] || 'minor'}"
         arguments << "--local" if options[:local]
         arguments << "--conservative" if options[:conservative]
       elsif options[:clean]

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -140,6 +140,33 @@ describe LogStash::Bundler do
         end
       end
 
+      context "level: major" do
+        let(:options) { super().merge(:level => "major") }
+        it "invokes bundler with --minor" do
+          expect(bundler_arguments).to include("--major")
+        end
+      end
+
+      context "level: minor" do
+        let(:options) { super().merge(:level => "minor") }
+        it "invokes bundler with --minor" do
+          expect(bundler_arguments).to include("--minor")
+        end
+      end
+
+      context "level: patch" do
+        let(:options) { super().merge(:level => "patch") }
+        it "invokes bundler with --minor" do
+          expect(bundler_arguments).to include("--patch")
+        end
+      end
+
+      context "level: unspecified" do
+        it "invokes bundler with --minor" do
+          expect(bundler_arguments).to include("--minor")
+        end
+      end
+
       context 'with ecs_compatibility' do
         let(:plugin_name) { 'logstash-output-elasticsearch' }
         let(:options) { { :update => plugin_name } }
@@ -147,7 +174,7 @@ describe LogStash::Bundler do
         it "also update dependencies" do
           expect(bundler_arguments).to include('logstash-mixin-ecs_compatibility_support', plugin_name)
 
-          mixin_libs = bundler_arguments - ["update", plugin_name]
+          mixin_libs = bundler_arguments - ["update", "--minor", plugin_name]
           mixin_libs.each do |gem_name|
             dep = ::Gem::Dependency.new(gem_name)
             expect(dep.type).to eq(:runtime)

--- a/spec/unit/plugin_manager/update_spec.rb
+++ b/spec/unit/plugin_manager/update_spec.rb
@@ -21,18 +21,24 @@ require 'pluginmanager/main'
 describe LogStash::PluginManager::Update do
   let(:cmd)     { LogStash::PluginManager::Update.new("update") }
   let(:sources) { cmd.gemfile.gemset.sources }
+  let(:expect_preflight_error) { false } # hack to bypass before-hook expectations
 
   before(:each) do
-    expect(cmd).to receive(:find_latest_gem_specs).and_return({})
-    allow(cmd).to receive(:warn_local_gems).and_return(nil)
-    expect(cmd).to receive(:display_updated_plugins).and_return(nil)
+    unless expect_preflight_error
+      expect(cmd).to receive(:find_latest_gem_specs).and_return({})
+      allow(cmd).to receive(:warn_local_gems).and_return(nil)
+      expect(cmd).to receive(:display_updated_plugins).and_return(nil)
+    end
   end
 
   it "pass all gem sources to the bundle update command" do
     sources = cmd.gemfile.gemset.sources
     expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
-        :update => [], :rubygems_source => sources,
-        :conservative => true, :local => false
+        :update => [],
+        :rubygems_source => sources,
+        :conservative => true,
+        :local => false,
+        :level => "minor" # default
     )
     cmd.execute
   end
@@ -46,14 +52,52 @@ describe LogStash::PluginManager::Update do
       expect(cmd.gemfile).to receive(:save).and_return(nil)
       expect(cmd).to receive(:plugins_to_update).and_return([plugin])
       expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
-          hash_including(:update => [plugin], :rubygems_source => sources)
+        hash_including(:update => [plugin], :rubygems_source => sources, :level => "minor")
       ).and_return(nil)
     end
 
     it "skips version verification when ask for it" do
-      cmd.verify = false
       expect(cmd).to_not receive(:validates_version)
-      cmd.execute
+      cmd.run(["--no-verify"])
+    end
+  end
+
+  context "with explicit `--level` flag" do
+    LogStash::PluginManager::Update::SUPPORTED_LEVELS.each do |level|
+      context "with --level=#{level} (valid)" do
+        let(:requested_level) { level }
+
+        let(:cmd)    { LogStash::PluginManager::Update.new("update") }
+        let(:plugin) { OpenStruct.new(:name => "dummy", :options => {}) }
+
+        before(:each) do
+          cmd.verify = false
+        end
+
+        it "propagates the level flag as an option to Bundler#invoke!" do
+          expect(cmd.gemfile).to receive(:find).with(plugin).and_return(plugin)
+          expect(cmd.gemfile).to receive(:save).and_return(nil)
+          expect(cmd).to receive(:plugins_to_update).and_return([plugin])
+          expect_any_instance_of(LogStash::Bundler).to receive(:invoke!).with(
+            hash_including(:update => [plugin], :rubygems_source => sources, :level => requested_level)
+          ).and_return(nil)
+
+          cmd.run(["--level=#{requested_level}"])
+        end
+      end
+    end
+
+    context "with --level=eVeRyThInG (invalid)" do
+      let(:requested_level) { "eVeRyThInG" }
+      let(:expect_preflight_error) { true }
+
+      let(:cmd)    { LogStash::PluginManager::Update.new("update") }
+      let(:plugin) { OpenStruct.new(:name => "dummy", :options => {}) }
+
+      it "errors helpfully" do
+        expect { cmd.run(["--level=#{requested_level}"]) }
+          .to raise_error.with_message(including("unsupported level `#{requested_level}`"))
+      end
     end
   end
 end


### PR DESCRIPTION
## Release notes

 - By default, the plugin manager will no longer consume breaking changes in plugins, and will instead only consume minor revisions. If you wish to consume breaking changes, you must now explicitly add the `--level=major` flag.

## What does this PR do?

Adds `--level=[major|minor|patch]` to the `bin/logstash-plugin update` command, with default value `minor`, and propagates it to the underlying bundler's `--major`, `--minor`, or `--patch` flags, to ensure users can upgrade while avoiding breaking changes.

## Why is it important/What is the impact to the user?

Users are currently being surprised when their `bin/logstash-plugin update` consumes breaking changes in plugins, causing their currently-valid pipeline configurations to fail to load. This removes the element of surprise, while still allowing users to upgrade across the major version of the plugins if they expressly wish to do so.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

closes: #16894 