### PR TITLE
[doc] fix the necessary privileges of central pipeline management

### DIFF
--- a/docs/static/security/api-keys.asciidoc
+++ b/docs/static/security/api-keys.asciidoc
@@ -249,8 +249,7 @@ POST /_security/api_key
   "name": "logstash_host001", <1>
   "role_descriptors": {
     "logstash_monitoring": { <2>
-      "cluster": ["monitor"],
-      "index": ["read"]
+      "cluster": ["monitor", "manage_logstash_pipelines"]
     }
   }
 }

--- a/docs/static/security/grant-access.asciidoc
+++ b/docs/static/security/grant-access.asciidoc
@@ -1,6 +1,6 @@
 [discrete]
 [[ls-user-access]]
-=== Granting access to the Logstash indices
+=== Granting access to the indices Logstash creates
 
 To access the indices Logstash creates, users need the `read` and
 `view_index_metadata` privileges:
@@ -13,14 +13,20 @@ privileges  for the Logstash indices. You can create roles from the
 ---------------------------------------------------------------
 POST _security/role/logstash_reader
 {
-  "cluster": ["manage_logstash_pipelines"]
+  "cluster": ["manage_logstash_pipelines"],
+  "indices": [
+    {
+      "names": [ "logstash-*" ],
+      "privileges": ["read","view_index_metadata"]
+    }
+  ]
 }
 ---------------------------------------------------------------
 
 . Assign your Logstash users the `logstash_reader` role. If the Logstash user
 will be using
 {logstash-ref}/logstash-centralized-pipeline-management.html[centralized pipeline management],
-also assign the `logstash_admin` role. You can create and manage users from the
+also assign the `logstash_system` role. You can create and manage users from the
 **Management > Users** UI in {kib} or through the `user` API:
 +
 [source, sh]
@@ -28,9 +34,9 @@ also assign the `logstash_admin` role. You can create and manage users from the
 POST _security/user/logstash_user
 {
   "password" : "x-pack-test-password",
-  "roles" : [ "logstash_reader", "logstash_admin"], <1>
+  "roles" : [ "logstash_reader", "logstash_system"], <1>
   "full_name" : "Kibana User for Logstash"
 }
 ---------------------------------------------------------------
-<1> `logstash_admin` is a built-in role that provides access to system
-indices for managing configurations.
+<1> `logstash_system` is a built-in role that provides the necessary permissions to
+check the availability of the supported features of {es} cluster.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -54,9 +54,10 @@ section in your Logstash configuration, or a different one. Defaults to
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
-should have the built-in `logstash_admin` role and the customized `logstash_writer` role, which provides access to system
-indices for managing configurations. Starting with Elasticsearch version 7.10.0, the
-`logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
+should have the built-in `logstash_admin` role and `logstash_system` role, which provides access to system
+indices for managing configurations.
+
+NOTE: Starting with Elasticsearch version 7.10.0, the `logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
 If a user has created their own roles and granted them access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8.0.
 
 `xpack.management.elasticsearch.proxy`::
@@ -143,8 +144,8 @@ If you're using {es} in {ecloud}, you can set your auth credentials here.
 This setting is an alternative to both `xpack.management.elasticsearch.username`
 and `xpack.management.elasticsearch.password`. If `cloud_auth` is configured,
 those settings should not be used.
-The credentials you specify here should be for a user with the `logstash_admin` role, which
-provides access to system indices for managing configurations.
+The credentials you specify here should be for a user with the `logstash_admin` and `logstash_system` roles, which
+provide access to system indices for managing configurations.
 
 `xpack.management.elasticsearch.api_key`::
 

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -54,8 +54,8 @@ section in your Logstash configuration, or a different one. Defaults to
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
-should have the built-in `logstash_admin` role and `logstash_system` role, which provides access to system
-indices for managing configurations.
+should have the built-in `logstash_admin` role and `logstash_system` role.
+These roles provide access to system indices for managing configurations.
 
 NOTE: Starting with Elasticsearch version 7.10.0, the `logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.
 If a user has created their own roles and granted them access to the .logstash index, those roles will continue to work in 7.x but will need to be updated for 8.0.

--- a/docs/static/settings/configuration-management-settings.asciidoc
+++ b/docs/static/settings/configuration-management-settings.asciidoc
@@ -54,7 +54,7 @@ section in your Logstash configuration, or a different one. Defaults to
 If your {es} cluster is protected with basic authentication, these settings
 provide the username and password that the Logstash instance uses to
 authenticate for accessing the configuration data. The username you specify here
-should have the built-in `logstash_admin` role and `logstash_system` role.
+should have the built-in `logstash_admin` and `logstash_system` roles.
 These roles provide access to system indices for managing configurations.
 
 NOTE: Starting with Elasticsearch version 7.10.0, the `logstash_admin` role inherits the `manage_logstash_pipelines` cluster privilege for centralized pipeline management.


### PR DESCRIPTION
This commit updated the instructions of using central pipeline management with the necessary privileges

fixes: https://github.com/elastic/logstash/issues/16905
relates: https://github.com/elastic/ingest-dev/issues/4812
