### PR TITLE
Add %{{TIME_NOW}} pattern for sprintf

### DIFF
--- a/docs/static/event-data.asciidoc
+++ b/docs/static/event-data.asciidoc
@@ -94,6 +94,23 @@ These formats are not directly interchangeable, and we advise you to begin using
 
 NOTE: A Logstash timestamp represents an instant on the UTC-timeline, so using sprintf formatters will produce results that may not align with your machine-local timezone.
 
+You can generate a fresh timestamp by using `%{{TIME_NOW}}` syntax instead of relying on the value in `@timestamp`.
+This is particularly useful when you need to estimate the time span of each plugin.
+
+[source,js]
+----------------------------------
+input {
+  heartbeat {
+    add_field => { "heartbeat_time" => "%{{TIME_NOW}}" }
+  }
+}
+filter {
+  mutate {
+    add_field => { "mutate_time" => "%{{TIME_NOW}}" }
+  }
+}
+----------------------------------
+
 [discrete]
 [[conditionals]]
 ==== Conditionals

--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -83,13 +83,20 @@ public final class StringInterpolation {
                 // JAVA-style @timestamp formatter:
                 // - `%{{yyyy-MM-dd}}` -> `2021-08-11`
                 // - `%{{YYYY-'W'ww}}` -> `2021-W32`
+                // A special pattern to generate a fresh current time
+                // - `%{{TIME_NOW}}` -> `2025-01-16T16:57:12.488955Z`
                 close = close + 1; // consume extra closing squiggle
-                final Timestamp t =  event.getTimestamp();
-                if (t != null) {
-                    final String javaTimeFormatPattern = template.substring(open+3, close-1);
-                    final java.time.format.DateTimeFormatter javaDateTimeFormatter = DateTimeFormatter.ofPattern(javaTimeFormatPattern).withZone(ZoneOffset.UTC);
-                    final String formattedTimestamp = javaDateTimeFormatter.format(t.toInstant());
-                    builder.append(formattedTimestamp);
+                final String pattern = template.substring(open+3, close-1);
+                if (pattern.equals("TIME_NOW")) {
+                    final Timestamp now = new Timestamp();
+                    builder.append(now);
+                } else {
+                    final Timestamp t = event.getTimestamp();
+                    if (t != null) {
+                        final DateTimeFormatter javaDateTimeFormatter = DateTimeFormatter.ofPattern(pattern).withZone(ZoneOffset.UTC);
+                        final String formattedTimestamp = javaDateTimeFormatter.format(t.toInstant());
+                        builder.append(formattedTimestamp);
+                    }
                 }
             } else if (template.charAt(open + 2) == '+') {
                 // JODA-style @timestamp formatter:

--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 public final class StringInterpolation {
 
+    private static final String TIME_NOW = "TIME_NOW";
     private static final ThreadLocal<StringBuilder> STRING_BUILDER =
         new ThreadLocal<StringBuilder>() {
             @Override
@@ -87,7 +88,7 @@ public final class StringInterpolation {
                 // - `%{{TIME_NOW}}` -> `2025-01-16T16:57:12.488955Z`
                 close = close + 1; // consume extra closing squiggle
                 final String pattern = template.substring(open+3, close-1);
-                if (pattern.equals("TIME_NOW")) {
+                if (pattern.equals(TIME_NOW)) {
                     final Timestamp now = new Timestamp();
                     builder.append(now);
                 } else {

--- a/logstash-core/src/main/java/org/logstash/StringInterpolation.java
+++ b/logstash-core/src/main/java/org/logstash/StringInterpolation.java
@@ -29,6 +29,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class StringInterpolation {
 
@@ -89,15 +90,14 @@ public final class StringInterpolation {
                 close = close + 1; // consume extra closing squiggle
                 final String pattern = template.substring(open+3, close-1);
                 if (pattern.equals(TIME_NOW)) {
-                    final Timestamp now = new Timestamp();
-                    builder.append(now);
+                    builder.append(new Timestamp());
                 } else {
-                    final Timestamp t = event.getTimestamp();
-                    if (t != null) {
-                        final DateTimeFormatter javaDateTimeFormatter = DateTimeFormatter.ofPattern(pattern).withZone(ZoneOffset.UTC);
-                        final String formattedTimestamp = javaDateTimeFormatter.format(t.toInstant());
-                        builder.append(formattedTimestamp);
-                    }
+                    Optional.ofNullable(event.getTimestamp())
+                            .map(Timestamp::toInstant)
+                            .map(instant -> DateTimeFormatter.ofPattern(pattern)
+                                    .withZone(ZoneOffset.UTC)
+                                    .format(instant))
+                            .ifPresent(builder::append);
                 }
             } else if (template.charAt(open + 2) == '+') {
                 // JODA-style @timestamp formatter:

--- a/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
+++ b/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
@@ -21,15 +21,17 @@
 package org.logstash;
 
 
+import org.awaitility.Awaitility;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -156,11 +158,11 @@ public class StringInterpolationTest extends RubyTestBase {
     public void testPatternTimeNowGenerateFreshTimestamp() throws IOException, InterruptedException {
         Event event = getTestEvent();
         Timestamp before = new Timestamp();
-        TimeUnit.NANOSECONDS.sleep(1);
+        Awaitility.await("Make sure we sleep enough get another current timestamp")
+                .atMost(Duration.ofSeconds(1))
+                .until(() -> Instant.now().isAfter(before.toInstant()));
         Timestamp result = new Timestamp(StringInterpolation.evaluate(event, "%{{TIME_NOW}}"));
-        Timestamp after = new Timestamp();
         assertTrue(before.compareTo(result) < 0);
-        assertTrue(after.compareTo(result) >= 0);
     }
 
     @Test

--- a/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
+++ b/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -73,14 +74,14 @@ public class StringInterpolationTest extends RubyTestBase {
     }
 
     @Test
-    public void TestMixDateAndFields() throws IOException {
+    public void testMixDateAndFields() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{+YYYY}/weeee/%{bar}";
         assertEquals("/full/2015/weeee/foo", StringInterpolation.evaluate(event, path));
     }
 
     @Test
-    public void TestMixDateAndFieldsJavaSyntax() throws IOException {
+    public void testMixDateAndFieldsJavaSyntax() throws IOException {
         Event event = getTestEvent();
         String path = "/full/%{{YYYY-DDD}}/weeee/%{bar}";
         assertEquals("/full/2015-274/weeee/foo", StringInterpolation.evaluate(event, path));
@@ -94,28 +95,28 @@ public class StringInterpolationTest extends RubyTestBase {
     }
 
     @Test
-    public void TestStringIsOneDateTag() throws IOException {
+    public void testStringIsOneDateTag() throws IOException {
         Event event = getTestEvent();
         String path = "%{+YYYY}";
         assertEquals("2015", StringInterpolation.evaluate(event, path));
     }
 
     @Test
-    public void TestStringIsJavaDateTag() throws IOException {
+    public void testStringIsJavaDateTag() throws IOException {
         Event event = getTestEvent();
         String path = "%{{YYYY-'W'ww}}";
         assertEquals("2015-W40", StringInterpolation.evaluate(event, path));
     }
 
     @Test
-    public void TestFieldRef() throws IOException {
+    public void testFieldRef() throws IOException {
         Event event = getTestEvent();
         String path = "%{[j][k1]}";
         assertEquals("v", StringInterpolation.evaluate(event, path));
     }
 
     @Test
-    public void TestEpochSeconds() throws IOException {
+    public void testEpochSeconds() throws IOException {
         Event event = getTestEvent();
         String path = "%{+%ss}";
         // `+%ss` bypasses the EPOCH syntax and instead matches the JODA syntax.
@@ -124,14 +125,14 @@ public class StringInterpolationTest extends RubyTestBase {
     }
 
     @Test
-    public void TestEpoch() throws IOException {
+    public void testEpoch() throws IOException {
         Event event = getTestEvent();
         String path = "%{+%s}";
         assertEquals("1443657600", StringInterpolation.evaluate(event, path));
     }
 
     @Test
-    public void TestValueIsArray() throws IOException {
+    public void testValueIsArray() throws IOException {
         ArrayList<String> l = new ArrayList<>();
         l.add("Hello");
         l.add("world");
@@ -144,7 +145,7 @@ public class StringInterpolationTest extends RubyTestBase {
     }
 
     @Test
-    public void TestValueIsHash() throws IOException {
+    public void testValueIsHash() throws IOException {
         Event event = getTestEvent();
 
         String path = "%{j}";
@@ -152,21 +153,20 @@ public class StringInterpolationTest extends RubyTestBase {
     }
 
     @Test
-    public void TestTimeNow() throws IOException {
+    public void testPatternTimeNowGenerateFreshTimestamp() throws IOException, InterruptedException {
         Event event = getTestEvent();
-        String pattern = "%{{TIME_NOW}}";
         Timestamp before = new Timestamp();
-        Timestamp result = new Timestamp(StringInterpolation.evaluate(event, pattern));
+        TimeUnit.NANOSECONDS.sleep(1);
+        Timestamp result = new Timestamp(StringInterpolation.evaluate(event, "%{{TIME_NOW}}"));
         Timestamp after = new Timestamp();
         assertTrue(before.compareTo(result) < 0);
-        assertTrue(after.compareTo(result) > 0);
+        assertTrue(after.compareTo(result) >= 0);
     }
 
     @Test
-    public void TestBadTimeNow() throws IOException {
+    public void testBadPatternTimeNowShouldThrowException() throws IOException {
         Event event = getTestEvent();
-        String pattern = "%{{BAD_TIME_NOW}}";
-        assertThrows(IllegalArgumentException.class, () -> StringInterpolation.evaluate(event, pattern));
+        assertThrows(IllegalArgumentException.class, () -> StringInterpolation.evaluate(event, "%{{BAD_TIME_NOW}}"));
     }
 
     public Event getTestEvent() {

--- a/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
+++ b/logstash-core/src/test/java/org/logstash/StringInterpolationTest.java
@@ -30,7 +30,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 
 public class StringInterpolationTest extends RubyTestBase {
@@ -147,6 +149,24 @@ public class StringInterpolationTest extends RubyTestBase {
 
         String path = "%{j}";
         assertEquals("{\"k1\":\"v\"}", StringInterpolation.evaluate(event, path));
+    }
+
+    @Test
+    public void TestTimeNow() throws IOException {
+        Event event = getTestEvent();
+        String pattern = "%{{TIME_NOW}}";
+        Timestamp before = new Timestamp();
+        Timestamp result = new Timestamp(StringInterpolation.evaluate(event, pattern));
+        Timestamp after = new Timestamp();
+        assertTrue(before.compareTo(result) < 0);
+        assertTrue(after.compareTo(result) > 0);
+    }
+
+    @Test
+    public void TestBadTimeNow() throws IOException {
+        Event event = getTestEvent();
+        String pattern = "%{{BAD_TIME_NOW}}";
+        assertThrows(IllegalArgumentException.class, () -> StringInterpolation.evaluate(event, pattern));
     }
 
     public Event getTestEvent() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Add support of `%{{TIME_NOW}}` syntax to sprinf format to generate a new current timestamp

## What does this PR do?

This commit added `%{{TIME_NOW}}` syntax to `event.sprintf()` to generate a fresh timestamp as string

Example
```
input {
    heartbeat {
      add_field => { "heartbeat_time" => "%{{TIME_NOW}}" }
    }
}
filter {
    mutate {
      add_field => { "mutate_time" => "%{{TIME_NOW}}" }
    }
}
```
It gives two different timestamps.

## Why is it important/What is the impact to the user?

When the incoming event has value in `@timestamp`, eg. event from agent, Logstash use the provided value instead of generating a new timestamp. Prior to the change, there is no way to force a new timestamp to generate during the execution of input plugins. 

Previously, users often generate timestamp with ruby-filter `code => "event.set('ruby_time', Time.now());"`, but this approach requires events to pass through PQ before the timestamp was assigned. It is not a good indicator of when the event actually arrived in Logstash.

With this change, all input and filter plugins can generate new timestamps

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes https://github.com/elastic/logstash/issues/15701

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
