### PR TITLE
fix jars installer for new maven and pin psych to 5.2.2

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,3 +43,4 @@ gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
+gem "psych", "5.2.2"

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require_relative './patches/jar_dependencies'
+
 module LogStash
   module Bundler
     extend self
@@ -134,28 +136,6 @@ module LogStash
       ::Bundler.settings.set_local(:without, options[:without])
       ::Bundler.settings.set_local(:force, options[:force])
 
-      require 'jars/installer'
-      ::Jars::Installer.singleton_class.class_eval do
-        alias_method :original_load_from_maven, :load_from_maven
-
-        define_method(:load_from_maven) do |file|
-          $stderr.puts "DEBUG: load_from_maven called with arguments: #{file.inspect}"
-          result = []
-          ::File.read(file).each_line do |line|
-            if line.match?(/ --/)
-              fixed_line = line.strip.gsub(/ --.+?$/, "")[0...-5]
-              $stderr.puts "changed from \"#{line.inspect}\" to \"#{fixed_line.inspect}\""
-              dep = ::Jars::Installer::Dependency.new(fixed_line)
-            else
-              dep = ::Jars::Installer::Dependency.new(line)
-            end
-            puts dep.inspect
-            result << dep if dep && dep.scope == :runtime
-          end
-          $stderr.puts "DEBUG: load_from_maven returned: #{result.inspect}"
-          result
-        end
-      end
       # This env setting avoids the warning given when bundler is run as root, as is required
       # to update plugins when logstash is run as a service
       # Note: Using `ENV`s here because ::Bundler.settings.set_local or `bundle config`

--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# work around https://github.com/jruby/jruby/issues/8579
 require_relative './patches/jar_dependencies'
 
 module LogStash

--- a/lib/bootstrap/patches/jar_dependencies.rb
+++ b/lib/bootstrap/patches/jar_dependencies.rb
@@ -21,11 +21,33 @@ def require_jar(*args)
   return nil unless Jars.require?
   result = Jars.require_jar(*args)
   if result.is_a? String
-    # JAR_DEBUG=1 will now show theses
+    # JARS_VERBOSE=true will show these
     Jars.debug { "--- jar coordinate #{args[0..-2].join(':')} already loaded with version #{result} - omit version #{args[-1]}" }
     Jars.debug { "    try to load from #{caller.join("\n\t")}" }
     return false
   end
   Jars.debug { "    register #{args.inspect} - #{result == true}" }
   result
+end
+
+require 'jars/installer'
+
+class ::Jars::Installer
+  def self.load_from_maven(file)
+    Jars.debug { "[load_from_maven] called with arguments: #{file.inspect}" }
+    result = []
+    ::File.read(file).each_line do |line|
+      if line.match?(/ --/)
+        Jars.debug { "[load_from_maven] line: #{line.inspect}" }
+        fixed_line = line.strip.gsub(/ --.+?$/, "")[0...-5]
+        Jars.debug { "[load_from_maven] fixed_line: #{fixed_line.inspect}" }
+        dep = ::Jars::Installer::Dependency.new(fixed_line)
+      else
+        dep = ::Jars::Installer::Dependency.new(line)
+      end
+      result << dep if dep && dep.scope == :runtime
+    end
+    Jars.debug { "[load_from_maven] returned: #{result.inspect}" }
+    result
+  end
 end

--- a/lib/bootstrap/patches/jar_dependencies.rb
+++ b/lib/bootstrap/patches/jar_dependencies.rb
@@ -30,6 +30,10 @@ def require_jar(*args)
   result
 end
 
+# work around https://github.com/jruby/jruby/issues/8579
+# the ruby maven 3.9.3 + maven-libs 3.9.9 gems will output unnecessary text we need to trim down during `load_from_maven`
+# remove everything from "--" until the end of the line
+# the `[...-5]` is just to remove the color changing characters from the end of the string that exist before "--"
 require 'jars/installer'
 
 class ::Jars::Installer


### PR DESCRIPTION
handle maven output that can carry "garbage" information after the jar's name. this patch deletes that extra information, also pins psych to 5.2.2 until jruby ships with snakeyaml-engine 2.9 (upcoming in 9.4.10.0)

exhaustive test run: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1155 🟢 

backport to 8.x: https://github.com/elastic/logstash/pull/16920

closes https://github.com/elastic/logstash/issues/16921