### PR TITLE
Update 8.17 Lockfile to include 4.21.x of the Elasticsearch input 

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -436,7 +436,7 @@ GEM
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       logstash-mixin-normalize_config_support (~> 1.0)
       logstash-mixin-plugin_factory_support
-    logstash-input-elasticsearch (4.20.5)
+    logstash-input-elasticsearch (4.21.1)
       elasticsearch (>= 7.17.9)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)


### PR DESCRIPTION
fixes: https://github.com/elastic/logstash/issues/16903

Rather than waiting for the 8.18.0 release, we should ship this functionality in the next release in the 8.17 series by updating the lockfile to include 4.21.x of the plugin, rather than be pinned to 4.20.x.