### PR TITLE
Doc: Remove extra symbol to fix formatting error

### DIFF
--- a/docs/static/ls-to-cloud.asciidoc
+++ b/docs/static/ls-to-cloud.asciidoc
@@ -7,7 +7,7 @@ When you configure the Elasticsearch output plugin to use <<plugins-outputs-elas
 Examples:
 
 * `output {elasticsearch { cloud_id => "<cloud id>" cloud_auth => "<cloud auth>" } }`
-* `output {elasticsearch { cloud_id => "<cloud id>" api_key => "<api key>" } }``
+* `output {elasticsearch { cloud_id => "<cloud id>" api_key => "<api key>" } }`
 
 {ess-leadin-short}
 


### PR DESCRIPTION
Extra symbol doesn't cause problems in classic docs, but will for V3 docs. 

### Nextdocs

<img width="777" alt="Screenshot 2025-01-22 at 3 55 53 PM" src="https://github.com/user-attachments/assets/d5f23db6-94aa-4ef1-b924-00cd35d941b0" />
