### PR TITLE
remove log for monitoring via internal collection

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -634,7 +634,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
     case settings.get("pipeline.ordered")
     when "auto"
       if settings.set?("pipeline.workers") && settings.get("pipeline.workers") == 1
-        @logger.warn("'pipeline.ordered' is enabled and is likely less efficient, consider disabling if preserving event order is not necessary")
+        @logger.warn("'pipeline.ordered' is enabled and is likely less efficient, consider disabling if preserving event order is not necessary") unless pipeline_id == LogStash::MonitoringExtension::PipelineRegisterHook::PIPELINE_ID
         return true
       end
     when "true"


### PR DESCRIPTION
This commit removed unactionable warning for monitoring via internal collection
monitoring pipeline is expected to be one worker.  The warning is not useful

Fixes: https://github.com/elastic/logstash/issues/13298