### PR TITLE
fix user and password detection from environment's uri

### DIFF
--- a/lib/pluginmanager/proxy_support.rb
+++ b/lib/pluginmanager/proxy_support.rb
@@ -55,8 +55,8 @@ def apply_env_proxy_settings(settings)
   scheme = settings[:protocol].downcase
   java.lang.System.setProperty("#{scheme}.proxyHost", settings[:host])
   java.lang.System.setProperty("#{scheme}.proxyPort", settings[:port].to_s)
-  java.lang.System.setProperty("#{scheme}.proxyUsername", settings[:username].to_s)
-  java.lang.System.setProperty("#{scheme}.proxyPassword", settings[:password].to_s)
+  java.lang.System.setProperty("#{scheme}.proxyUser", settings[:username].to_s)
+  java.lang.System.setProperty("#{scheme}.proxyPass", settings[:password].to_s)
 end
 
 def extract_proxy_values_from_uri(proxy_uri)

--- a/spec/unit/plugin_manager/proxy_support_spec.rb
+++ b/spec/unit/plugin_manager/proxy_support_spec.rb
@@ -71,8 +71,22 @@ describe "Proxy support" do
       schemes.each do |scheme|
         expect(java.lang.System.getProperty("#{scheme}.proxyHost")).to eq(send("#{scheme}_proxy_uri").host)
         expect(java.lang.System.getProperty("#{scheme}.proxyPort")).to eq(send("#{scheme}_proxy_uri").port.to_s)
-        expect(java.lang.System.getProperty("#{scheme}.proxyUsername")).to eq(send("#{scheme}_proxy_uri").user)
-        expect(java.lang.System.getProperty("#{scheme}.proxyPassword")).to eq(send("#{scheme}_proxy_uri").password)
+        expect(java.lang.System.getProperty("#{scheme}.proxyUser")).to eq(send("#{scheme}_proxy_uri").user)
+        expect(java.lang.System.getProperty("#{scheme}.proxyPass")).to eq(send("#{scheme}_proxy_uri").password)
+      end
+    end
+
+    context "URI's use of proxy" do
+      it "applies the settings from environment" do
+        schemes.each do |scheme|
+          configure_proxy
+          uri = URI.parse("#{scheme}://rubygems.org")
+          proxy = uri.find_proxy
+          expect(proxy.host).to eq(send("#{scheme}_proxy_uri").host)
+          expect(proxy.port).to eq(send("#{scheme}_proxy_uri").port)
+          expect(proxy.user).to eq(send("#{scheme}_proxy_uri").user)
+          expect(proxy.password).to eq(send("#{scheme}_proxy_uri").password)
+        end
       end
     end
 


### PR DESCRIPTION
URI::Generic expects that JRuby will use http.proxyUser and http.proxyPass instead of http.proxyUsername and http.proxyPassword.

This misalignment breaks plugin manager's ability to use an authenticated proxy.

This commit fixes the alignment and confirms that the proxy configuration fetched from a URI object has the user and password set correctly.