### PR TITLE
[Backport 8.x] add openssl command to wolfi image

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -106,7 +106,7 @@ FROM <%= base_image %>
 
 RUN for iter in {1..10}; do \
 <% if image_flavor == 'wolfi' %>
-  <%= package_manager %> add --no-cache curl bash && \
+  <%= package_manager %> add --no-cache curl bash openssl && \
 <% else -%>
   <% if image_flavor == 'full' || image_flavor == 'oss' -%>
     export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
Backport of https://github.com/elastic/logstash/pull/16966
This commit added openssl command to logstash-wolfi image
