### PR TITLE
integration tests: switch log input to filestream in filebeat

### DIFF
--- a/qa/integration/specs/beats_input_spec.rb
+++ b/qa/integration/specs/beats_input_spec.rb
@@ -84,7 +84,7 @@ describe "Beat Input" do
     let(:filebeat_config) do
       {
         "filebeat" => {
-          "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
+          "inputs" => [{ "paths" => [log_path], "type" => "filestream" }],
           "registry.path" => registry_file,
           "scan_frequency" => "1s"
         },
@@ -109,7 +109,7 @@ describe "Beat Input" do
       let(:filebeat_config) do
         {
           "filebeat" => {
-            "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
+            "inputs" => [{ "paths" => [log_path], "type" => "filestream" }],
             "registry.path" => registry_file,
             "scan_frequency" => "1s"
           },
@@ -136,7 +136,7 @@ describe "Beat Input" do
       let(:filebeat_config) do
         {
           "filebeat" => {
-            "inputs" => [{ "paths" => [log_path], "input_type" => "log" }],
+            "inputs" => [{ "paths" => [log_path], "type" => "filestream" }],
             "registry.path" => registry_file,
             "scan_frequency" => "1s"
           },


### PR DESCRIPTION
log input has been deprecated in filebeat 9.0.0 and throws an error if it's present in the configuration.
This commit switches the configuration to the "filestream" input.

exhaustive test suite run: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1205