### PR TITLE
plugins: add `clean` command to remove inactive plugins/dependencies

### DIFF
--- a/lib/pluginmanager/clean.rb
+++ b/lib/pluginmanager/clean.rb
@@ -1,0 +1,34 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "pluginmanager/command"
+
+class LogStash::PluginManager::Clean < LogStash::PluginManager::Command
+
+  def execute
+    output = Bundler.settings.temporary(:frozen => false) { LogStash::Bundler.invoke! clean: true }
+
+    removed_gems = output.scan(/(?<=^Removing ).+$/)
+
+    plugins, deps = removed_gems.partition { |gem| gem[/^logstash-(?:input|output|filter|codec|integration)-/] }
+
+    plugins.each { |plugin| puts("cleaned inactive plugin #{plugin}") }
+    deps.each { |dep| puts("cleaned inactive dependency #{dep}") }
+  ensure
+    display_bundler_output(output)
+  end
+end

--- a/lib/pluginmanager/main.rb
+++ b/lib/pluginmanager/main.rb
@@ -34,6 +34,7 @@ require "pluginmanager/install"
 require "pluginmanager/remove"
 require "pluginmanager/list"
 require "pluginmanager/update"
+require "pluginmanager/clean"
 require "pluginmanager/pack"
 require "pluginmanager/unpack"
 require "pluginmanager/generate"
@@ -50,6 +51,7 @@ module LogStash
       subcommand "install", "Install a Logstash plugin", LogStash::PluginManager::Install
       subcommand "remove", "Remove a Logstash plugin", LogStash::PluginManager::Remove
       subcommand "update", "Update a plugin", LogStash::PluginManager::Update
+      subcommand "clean", "Remove all inactive plugins", LogStash::PluginManager::Clean
       subcommand "pack", "Package currently installed plugins, Deprecated: Please use prepare-offline-pack instead", LogStash::PluginManager::Pack
       subcommand "unpack", "Unpack packaged plugins, Deprecated: Please use prepare-offline-pack instead", LogStash::PluginManager::Unpack
       subcommand "generate", "Create the foundation for a new plugin", LogStash::PluginManager::Generate


### PR DESCRIPTION
## Release notes

 - adds `bin/logstash-plugin clean` command to allow the plugin manager to prune orphaned dependencies

## What does this PR do?

adds `bin/logstash-plugin clean` command to allow the plugin manager to prune orphaned dependencies

## Why is it important/What is the impact to the user?

 - For users who update plugins, providing a way to clean out deactivated dependencies can reduce the disk footprint of the logstash installation
 - For building Logstash artifacts, a `clean` option allows us to build a true subset of the dependency graph after removing plugins that are not needed in a minimalized artifact

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ There are existing tests around `LogStash::Bunder#invoke!(clean: true)`

## Author's Checklist

- [ ] File follow-up to document after the asciidoc-freeze on `main` is lifted.

## How to test this PR locally

1. remove a plugin that has dependencies (like `logstash-integration-aws`)
   `bin/logstash-plugin remove logstash-integration-aws`
2. run the plugin manger's `clean` command
   `bin/logstash-plugin clean`
3. Observe that the orphaned plugin and dependencies are cleaned up and removed from `vendor`

## Logs

> ~~~
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (pluginmanager-clean-command ✘) }
> ╰─● bin/logstash-plugin remove logstash-integration-aws
> Using system java: /Users/rye/.jenv/shims/java
> Resolving dependencies......
> Resolving dependencies......
> Successfully removed logstash-integration-aws
> [success (00:00:06)]
>
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (pluginmanager-clean-command ✘) }
> ╰─● bin/logstash-plugin clean
> Using system java: /Users/rye/.jenv/shims/java
> cleaned inactive plugin logstash-integration-aws-7.1.8 (java)
> cleaned inactive dependency aws-eventstream (1.3.0)
> cleaned inactive dependency aws-partitions (1.1043.0)
> cleaned inactive dependency aws-sdk-cloudfront (1.109.0)
> cleaned inactive dependency aws-sdk-cloudwatch (1.109.0)
> cleaned inactive dependency aws-sdk-core (3.217.0)
> cleaned inactive dependency aws-sdk-kms (1.97.0)
> cleaned inactive dependency aws-sdk-resourcegroups (1.77.0)
> cleaned inactive dependency aws-sdk-s3 (1.179.0)
> cleaned inactive dependency aws-sdk-sns (1.94.0)
> cleaned inactive dependency aws-sdk-sqs (1.91.0)
> cleaned inactive dependency aws-sigv4 (1.11.0)
> cleaned inactive dependency jar-dependencies (0.4.1)
> cleaned inactive dependency jmespath (1.6.2)
> [success]
> ~~~
