### PR TITLE
Release note placeholder might be empty, make parsing lines nil tolerant.

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -48,8 +48,8 @@ coming_tag_index = release_notes.find_index {|line| line.match(/^coming\[#{curre
 coming_tag_index += 1 if coming_tag_index
 release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/^\[\[logstash/) }
 
-report << "[[logstash-#{current_release_dashes}]]" unless release_notes.any? { |line| line.match(/^\[\[logstash-#{current_release_dashes}/) }
-report << "=== Logstash #{current_release} Release Notes\n" unless release_notes.any? { |line| line.match(/^=== Logstash #{current_release}/)}
+report << "[[logstash-#{current_release_dashes}]]" unless release_notes.any? { |line| line&.match(/^\[\[logstash-#{current_release_dashes}/) }
+report << "=== Logstash #{current_release} Release Notes\n" unless release_notes.any? { |line| line&.match(/^=== Logstash #{current_release}/)}
 
 plugin_changes = {}
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Modifies release note generator in a way that notes might be empty, parsing should be nil tolerant.
Before, generator was failing with following error:
```
Switched to a new branch '9.0'
./tools/release/generate_release_notes.rb:[5](https://github.com/elastic/logstash/actions/runs/13162596537/job/36734882969#step:6:6)1:in `block in <main>': undefined method `match' for nil:NilClass (NoMethodError)
	from ./tools/release/generate_release_notes.rb:51:in `any?'
	from ./tools/release/generate_release_notes.rb:51:in `<main>'
Error: Process completed with exit code 1.
```

## Why is it important/What is the impact to the user?
No user impact.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally
Checkout 9.0 branch and run `ruby tools/release/generate_release_notes.rb`

## Related issues

## Use cases

## Screenshots

## Logs
