### PR TITLE
move fips-mode gradle hooks to x-pack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ plugins {
     id "com.dorongold.task-tree" version "2.1.0"
 }
 
+apply from: "${projectDir}/x-pack/distributions/internal/observabilitySRE/build-ext.gradle"
+
 apply plugin: 'de.undercouch.download'
 apply from: "rubyUtils.gradle"
 
@@ -50,16 +52,6 @@ import org.logstash.gradle.tooling.ExtractBundledJdkVersion
 import org.logstash.gradle.tooling.SignAliasDefinitions
 import org.logstash.gradle.tooling.ToolingUtils
 import org.logstash.gradle.tooling.SnapshotArtifactURLs
-
-ext {
-    runTestsInFIPSMode = project.hasProperty('runTestsInFIPSMode') ? project.property('runTestsInFIPSMode').toBoolean() : false
-}
-
-subprojects {
-    ext {
-        runTestsInFIPSMode = rootProject.runTestsInFIPSMode
-    }
-}
 
 allprojects {
   group = 'org.logstash'

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -124,20 +124,6 @@ tasks.register("javaTests", Test) {
     exclude '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     exclude '/org/logstash/execution/ObservedExecutionTest.class'
 
-    if (runTestsInFIPSMode) {
-        systemProperty "java.security.properties", System.getenv("JAVA_SECURITY_PROPERTIES")
-        systemProperty "javax.net.ssl.keyStore", "/etc/java/security/keystore.bcfks"
-        systemProperty "javax.net.ssl.keyStoreType", "BCFKS"
-        systemProperty "javax.net.ssl.keyStoreProvider", "BCFIPS"
-        systemProperty "javax.net.ssl.keyStorePassword", "changeit"
-        systemProperty "javax.net.ssl.trustStore", "/etc/java/security/cacerts.bcfks"
-        systemProperty "javax.net.ssl.trustStoreType", "BCFKS"
-        systemProperty "javax.net.ssl.trustStoreProvider", "BCFIPS"
-        systemProperty "javax.net.ssl.trustStorePassword", "changeit"
-        systemProperty "ssl.KeyManagerFactory.algorithm", "PKIX"
-        systemProperty "ssl.TrustManagerFactory.algorithm", "PKIX"
-        systemProperty "org.bouncycastle.fips.approved_only", "true"
-    }
     jacoco {
         enabled = true
         destinationFile = layout.buildDirectory.file('jacoco/test.exec').get().asFile
@@ -170,21 +156,6 @@ tasks.register("rubyTests", Test) {
     include '/org/logstash/plugins/CounterMetricImplTest.class'
     include '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     include '/org/logstash/execution/ObservedExecutionTest.class'
-
-    if (runTestsInFIPSMode) {
-        systemProperty "java.security.properties", System.getenv("JAVA_SECURITY_PROPERTIES")
-        systemProperty "javax.net.ssl.keyStore", "/etc/java/security/keystore.bcfks"
-        systemProperty "javax.net.ssl.keyStoreType", "BCFKS"
-        systemProperty "javax.net.ssl.keyStoreProvider", "BCFIPS"
-        systemProperty "javax.net.ssl.keyStorePassword", "changeit"
-        systemProperty "javax.net.ssl.trustStore", "/etc/java/security/cacerts.bcfks"
-        systemProperty "javax.net.ssl.trustStoreType", "BCFKS"
-        systemProperty "javax.net.ssl.trustStoreProvider", "BCFIPS"
-        systemProperty "javax.net.ssl.trustStorePassword", "changeit"
-        systemProperty "ssl.KeyManagerFactory.algorithm", "PKIX"
-        systemProperty "ssl.TrustManagerFactory.algorithm", "PKIX"
-        systemProperty "org.bouncycastle.fips.approved_only", "true"
-    }
 }
 
 test {

--- a/qa/integration/build.gradle
+++ b/qa/integration/build.gradle
@@ -72,20 +72,6 @@ tasks.register("integrationTests", Test) {
   inputs.files fileTree("${projectDir}/specs")
 
   systemProperty 'logstash.root.dir', projectDir.toPath().getParent().getParent().toString()
-  if (runTestsInFIPSMode) {
-      systemProperty "java.security.properties", System.getenv("JAVA_SECURITY_PROPERTIES")
-      systemProperty "javax.net.ssl.keyStore", "/etc/java/security/keystore.bcfks"
-      systemProperty "javax.net.ssl.keyStoreType", "BCFKS"
-      systemProperty "javax.net.ssl.keyStoreProvider", "BCFIPS"
-      systemProperty "javax.net.ssl.keyStorePassword", "changeit"
-      systemProperty "javax.net.ssl.trustStore", "/etc/java/security/cacerts.bcfks"
-      systemProperty "javax.net.ssl.trustStoreType", "BCFKS"
-      systemProperty "javax.net.ssl.trustStoreProvider", "BCFIPS"
-      systemProperty "javax.net.ssl.trustStorePassword", "changeit"
-      systemProperty "ssl.KeyManagerFactory.algorithm", "PKIX"
-      systemProperty "ssl.TrustManagerFactory.algorithm", "PKIX"
-      systemProperty "org.bouncycastle.fips.approved_only", "true"
-  }
   include '/org/logstash/integration/RSpecTests.class'
 
   outputs.upToDateWhen {

--- a/x-pack/distributions/internal/observabilitySRE/build-ext.gradle
+++ b/x-pack/distributions/internal/observabilitySRE/build-ext.gradle
@@ -1,0 +1,31 @@
+ext {
+    runTestsInFIPSMode = project.hasProperty('runTestsInFIPSMode') ? project.property('runTestsInFIPSMode').toBoolean() : false
+}
+
+subprojects {
+    ext {
+        runTestsInFIPSMode = rootProject.runTestsInFIPSMode
+    }
+}
+
+allprojects {
+    afterEvaluate {
+        tasks.withType(Test) {
+            if (runTestsInFIPSMode) {
+                logger.debug("configuring ${it} to run in FIPSMode ")
+                systemProperty "java.security.properties", System.getenv("JAVA_SECURITY_PROPERTIES")
+                systemProperty "javax.net.ssl.keyStore", "/etc/java/security/keystore.bcfks"
+                systemProperty "javax.net.ssl.keyStoreType", "BCFKS"
+                systemProperty "javax.net.ssl.keyStoreProvider", "BCFIPS"
+                systemProperty "javax.net.ssl.keyStorePassword", "changeit"
+                systemProperty "javax.net.ssl.trustStore", "/etc/java/security/cacerts.bcfks"
+                systemProperty "javax.net.ssl.trustStoreType", "BCFKS"
+                systemProperty "javax.net.ssl.trustStoreProvider", "BCFIPS"
+                systemProperty "javax.net.ssl.trustStorePassword", "changeit"
+                systemProperty "ssl.KeyManagerFactory.algorithm", "PKIX"
+                systemProperty "ssl.TrustManagerFactory.algorithm", "PKIX"
+                systemProperty "org.bouncycastle.fips.approved_only", "true"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Suggestion for https://github.com/elastic/logstash/pull/17029 to move all the gradle bits for the `internal/observabilitySRE` into x-pack.