### PR TITLE
Open modules to test also with jdk17 under Windows OS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,13 @@ allprojects {
 
   //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
   tasks.withType(Test) {
+    // Add Exports to enable tests to run in JDK17
+    jvmArgs = [
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
+        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+    ]
+
     testLogging {
       // set options for log level LIFECYCLE
       events "passed", "skipped", "failed", "standardOut"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Opens the IO modules in Gradle test task to let the `7.17` tested without IO access errors on Windows OS.

## Why is it important/What is the impact to the user?

Permit to keep the `7.17` tested with JDK 17.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Spawn a WinOS image used by BK after checkout of `7.17` run
```
C:\Users\buildkite\logstash\.buildkite\scripts\jdk-matrix-tests\launch-command.ps1  -JDK adoptiumjdk_17  -CIScript "ci\unit_tests.ps1 ruby"
```

Because the failure seems not to be always consistent you can loop with this script
```
for ($i = 0; $i -lt 10; $i++) {
    Write-Host "Running script for iteration $i"
    
    try {
	Write-Host "Cleaning Gradle"
	& "C:\Users\buildkite\logstash\gradlew.bat" clean

        $param1 = '-JDK adoptiumjdk_17'
	$param2 = '-CIScript "ci\unit_tests.ps1 ruby"'

	# Build the command string
	$command = "& 'C:\Users\buildkite\logstash\.buildkite\scripts\jdk-matrix-tests\launch-command.ps1' $param1 $param2"
        # $command = "C:\Users\buildkite\logstash\random-fail-script.ps1"

	# Execute the command using Invoke-Expression
	Invoke-Expression $command
        Write-Host "After invoke expression of $command"
        
        # If the script fails, throw an error and break
        if ($? -eq $false) {
            throw "Error occurred during script execution."
        }
    } catch {
        Write-Host "Caught error: $_. Exiting loop."
        exit 1 # Exit the loop
    }
}
```

Or try sometime with direct test run
```
$env:SPEC_OPTS="-fd -P spec/filters/geoip/database_metadata_spec.rb" .\gradlew.bat --rerun-tasks :logstash-xpack:rubyTests
```
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

During test we can see the warning message on `installBundler` test. While this didn't  create any problem under Linux or MacOS, with BK images used in CI it failed with:
```
Failures:

      1) LogStash::Filters::Geoip DatabaseMetadata database path return the default city database path
         Failure/Error: FileUtils.cp_r(cc_database_paths, dir_path)

         Errno::EACCES:
           Permission denied - A:/data/plugins/filters/geoip/CC/GeoLite2-City.mmdb
         # ./spec/filters/geoip/test_helper.rb:121:in `copy_cc'
         # ./spec/filters/geoip/database_metadata_spec.rb:75:in `block in <main>'
         # A:/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block in A:/vendor/bundle/jruby/2.5.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb'
         # A:\lib\bootstrap\rspec.rb:31:in `<main>'
```

Was able to reproduce in a fresh WinOS VM with:
```
 $env:SPEC_OPTS="-fd -P spec/filters/geoip/database_metadata_spec.rb" .\gradlew.bat --rerun-tasks :logstash-xpack:rubyTests
```

Here is the failure on `7.17`: https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/338#0194e0b5-5402-412c-9b8a-f5c38b179faf/56-7406

This run on matrix test instead prove this PR works: https://buildkite.com/elastic/logstash-windows-jdk-matrix-pipeline/builds/339