### PR TITLE
Bump versions for 7.17.28

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -17,7 +17,7 @@ PATH
       gems (~> 1)
       i18n (~> 1)
       jar-dependencies (= 0.4.1)
-      jrjackson (= 0.4.14)
+      jrjackson (= 0.4.17)
       jruby-openssl (~> 0.11)
       manticore (~> 0.6)
       minitar (~> 0.8)
@@ -169,7 +169,7 @@ GEM
     jls-lumberjack (0.0.26)
       concurrent-ruby
     jmespath (1.6.2)
-    jrjackson (0.4.14-java)
+    jrjackson (0.4.17-java)
     jruby-jms (1.3.0-java)
       gene_pool
       semantic_logger
@@ -371,12 +371,12 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       nokogiri
       xml-simple
-    logstash-input-azure_event_hubs (1.4.9)
+    logstash-input-azure_event_hubs (1.5.1)
       logstash-codec-json
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
       stud (>= 0.0.22)
-    logstash-input-beats (6.2.6-java)
+    logstash-input-beats (6.4.3-java)
       concurrent-ruby (~> 1.0)
       jar-dependencies (~> 0.3, >= 0.3.4)
       logstash-codec-multiline (>= 2.0.5)
@@ -667,7 +667,7 @@ GEM
       mime-types (>= 1.16, < 4)
     manticore (0.8.0-java)
       openssl_pkcs8_pure
-    march_hare (4.4.0-java)
+    march_hare (4.6.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)

--- a/build.gradle
+++ b/build.gradle
@@ -86,11 +86,18 @@ allprojects {
   tasks.withType(Test) {
     // Add Exports to enable tests to run in JDK17
     jvmArgs = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
         "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
     ]
-
+    maxHeapSize = "2g"
     testLogging {
       // set options for log level LIFECYCLE
       events "passed", "skipped", "failed", "standardOut"

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -85,3 +85,8 @@
 
 17-:--add-opens java.base/sun.nio.ch=ALL-UNNAMED
 17-:--add-opens java.base/java.io=ALL-UNNAMED
+17-:--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+17-:--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+17-:--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+17-:--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+17-:--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -184,10 +184,7 @@ dependencies {
     }
     // pin version of jackson-dataformat-yaml's transitive dependency "snakeyaml"
     implementation "org.yaml:snakeyaml:1.33"
-    implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
-    // WARNING: DO NOT UPGRADE "google-java-format"
-    // later versions require GPL licensed code in javac-shaded that is
-    // Apache2 incompatible
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation('com.google.googlejavaformat:google-java-format:1.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -29,12 +29,14 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -70,10 +72,20 @@ public final class ObjectMappers {
     public static final ObjectMapper JSON_MAPPER =
         new ObjectMapper().registerModule(RUBY_SERIALIZERS);
 
+    public static final PolymorphicTypeValidator TYPE_VALIDATOR = BasicPolymorphicTypeValidator.builder()
+            .allowIfBaseType(java.util.HashMap.class)
+            .allowIfSubType(org.jruby.RubyNil.class)
+            .allowIfSubType(org.jruby.RubyString.class)
+            .allowIfSubType(org.logstash.ConvertedMap.class)
+            .allowIfSubType(org.logstash.ConvertedList.class)
+            .allowIfSubType(org.logstash.Timestamp.class)
+            .build();
+
     public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(
         new CBORFactory().configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false)
     ).registerModules(RUBY_SERIALIZERS, CBOR_DESERIALIZERS)
-        .enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+            .activateDefaultTyping(TYPE_VALIDATOR, ObjectMapper.DefaultTyping.NON_FINAL);
+
 
     /**
      * {@link JavaType} for the {@link HashMap} that {@link Event} is serialized as.

--- a/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/discovery/PluginRegistry.java
@@ -23,7 +23,6 @@ package org.logstash.plugins.discovery;
 import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.logstash.plugins.AliasRegistry;
 import co.elastic.logstash.api.Codec;
 import co.elastic.logstash.api.Configuration;

--- a/tools/ingest-converter/build.gradle
+++ b/tools/ingest-converter/build.gradle
@@ -24,6 +24,7 @@ def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.ym
 
 description = """Ingest JSON to Logstash Grok Config Converter"""
 version = versionMap['logstash-core']
+String jacksonDatabindVersion = versionMap['jackson-databind']
 
 repositories {
   mavenCentral()
@@ -35,14 +36,14 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'org.yaml:snakeyaml:1.33'
+    classpath 'org.yaml:snakeyaml:2.2'
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }
 
 dependencies {
   implementation 'net.sf.jopt-simple:jopt-simple:4.6'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
+  implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
   testImplementation "junit:junit:4.12"
   testImplementation 'commons-io:commons-io:2.5'
 }

--- a/versions.yml
+++ b/versions.yml
@@ -27,6 +27,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.14
-jackson: 2.9.10
-jackson-databind: 2.9.10.8
+jrjackson: 0.4.17
+jackson: 2.14.1
+jackson-databind: 2.14.1


### PR DESCRIPTION
Plugins

* logstash-input-azure_event_hubs: 1.5.1
* logstash-input-beats: 6.4.3-java

 Jars

* jackson: 2.14.1
* jackson-databind: 2.14.1
* guava: 32.1.3
* org.yaml:snakeyaml: 2.2 (ingest converter)

 Gems

* march_hare: 4.6.0-java
* jrjackson: 0.4.17

 Other changes:

* tweak add-exports/add-opens to accomodate newer dependencies
* serialization changes to ObjectMappers.java to accommodate jackson 2.13

exhaustive test suite run: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1297