### PR TITLE
Split fips integration tests into two steps

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -125,8 +125,8 @@ steps:
       manual:
         allowed: true
 
-  - label: ":lab_coat: Integration Tests - FIPS mode"
-    key: "integration-tests-fips"
+  - label: ":lab_coat: Integration Tests - FIPS mode / part 1"
+    key: "integration-tests-fips-part-1"
     agents:
       provider: gcp
       imageProject: elastic-images-prod
@@ -141,7 +141,33 @@ steps:
       set -euo pipefail
 
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
-      docker run test-runner-image ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests
+      docker run test-runner-image /bin/bash -c '
+        source ci/test_split_utils.sh
+        specs=$(get_test_half 0)
+        ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
+      '
+
+  - label: ":lab_coat: Integration Tests - FIPS mode / part 2"
+    key: "integration-tests-fips-part-2"
+    agents:
+      provider: gcp
+      imageProject: elastic-images-prod
+      image: family/platform-ingest-logstash-ubuntu-2204
+      machineType: "n2-standard-4"
+      diskSizeGb: 64
+    retry:
+      automatic:
+      # dont retry on failure while they are expected
+        - limit: 0
+    command: |
+      set -euo pipefail
+
+      docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
+      docker run test-runner-image /bin/bash -c '
+        source ci/test_split_utils.sh
+        specs=$(get_test_half 1)
+        ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
+      '
 
   - label: ":lab_coat: Integration Tests / part 1"
     key: "integration-tests-part-1"

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -140,12 +140,7 @@ steps:
     command: |
       set -euo pipefail
 
-      docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
-      docker run test-runner-image /bin/bash -c '
-        source ci/get-test-half.sh
-        specs=\$(get_test_half 0)
-        ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
-      '
+      ci/run-integration-tests-fips.sh 0
 
   - label: ":lab_coat: Integration Tests - FIPS mode / part 2"
     key: "integration-tests-fips-part-2"
@@ -162,12 +157,7 @@ steps:
     command: |
       set -euo pipefail
 
-      docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
-      docker run test-runner-image /bin/bash -c '
-        source ci/get-test-half.sh
-        specs=\$(get_test_half 1)
-        ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
-      '
+      ci/run-integration-tests-fips.sh 1
 
   - label: ":lab_coat: Integration Tests / part 1"
     key: "integration-tests-part-1"

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -140,7 +140,8 @@ steps:
     command: |
       set -euo pipefail
 
-      ci/run-integration-tests-fips.sh 0
+      docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
+      docker run test-runner-image ci/run-fips-integration-tests.sh 0
 
   - label: ":lab_coat: Integration Tests - FIPS mode / part 2"
     key: "integration-tests-fips-part-2"
@@ -157,7 +158,8 @@ steps:
     command: |
       set -euo pipefail
 
-      ci/run-integration-tests-fips.sh 1
+      docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
+      docker run test-runner-image ci/run-fips-integration-tests.sh 1
 
   - label: ":lab_coat: Integration Tests / part 1"
     key: "integration-tests-part-1"

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -142,7 +142,7 @@ steps:
 
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
       docker run test-runner-image /bin/bash -c '
-        source ci/test_split_utils.sh
+        source ci/get-test-half.sh
         specs=$(get_test_half 0)
         ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
       '
@@ -164,7 +164,7 @@ steps:
 
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
       docker run test-runner-image /bin/bash -c '
-        source ci/test_split_utils.sh
+        source ci/get-test-half.sh
         specs=$(get_test_half 1)
         ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
       '

--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -143,7 +143,7 @@ steps:
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
       docker run test-runner-image /bin/bash -c '
         source ci/get-test-half.sh
-        specs=$(get_test_half 0)
+        specs=\$(get_test_half 0)
         ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
       '
 
@@ -165,7 +165,7 @@ steps:
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
       docker run test-runner-image /bin/bash -c '
         source ci/get-test-half.sh
-        specs=$(get_test_half 1)
+        specs=\$(get_test_half 1)
         ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"
       '
 

--- a/ci/get-test-half.sh
+++ b/ci/get-test-half.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# get_test_half returns either the first or second half of integration tests
+# Usage: get_test_half <half_number>
+# half_number: 0 for first half, 1 for second half
+get_test_half() {
+    local half_number=$1
+    # Ensure only spec files go to stdout
+    pushd qa/integration >/dev/null 2>&1
+    
+    # Collect all spec files
+    local glob1=(specs/*spec.rb)
+    local glob2=(specs/**/*spec.rb)
+    local all_specs=("${glob1[@]}" "${glob2[@]}")
+    
+    # Calculate the split point
+    local split_point=$((${#all_specs[@]} / 2))
+    
+    # Get the requested half (:: is "up to", : is "from")
+    if [[ $half_number -eq 0 ]]; then
+        local specs="${all_specs[@]::$split_point}"
+    else
+        local specs="${all_specs[@]:$split_point}"
+    fi
+    popd >/dev/null 2>&1
+    echo "$specs"
+}

--- a/ci/run-fips-integration-tests.sh
+++ b/ci/run-fips-integration-tests.sh
@@ -4,9 +4,6 @@
 # half_number: 0 for first half, 1 for second half
 
 half_number=$1
-docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
-docker run test-runner-image /bin/bash -c "
-    source ci/get-test-half.sh
-    specs=$(get_test_half $half_number)
-    ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs=\"\$specs\"
-"
+source ci/get-test-half.sh
+specs=$(get_test_half "$half_number")
+./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs="$specs"

--- a/ci/run-fips-integration-tests.sh
+++ b/ci/run-fips-integration-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# get_test_half returns either the first or second half of integration tests
+# Usage: get_test_half <half_number>
+# half_number: 0 for first half, 1 for second half
+
+half_number=$1
+docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
+docker run test-runner-image /bin/bash -c "
+    source ci/get-test-half.sh
+    specs=$(get_test_half $half_number)
+    ./gradlew --info --stacktrace -PrunTestsInFIPSMode=true runIntegrationTests -PrubyIntegrationSpecs=\"\$specs\"
+"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The integration tests suite takes about 40 minutes. This is far too slow for reasonable feedback on a PR. This commit follows the pattern for the non-fips integration tests whereby the tests are split into two sections that can run in parallel across two steps. This should halve the feedback time.

## Why is it important/What is the impact to the user?

This reduces feedback time on PR tests by a factor of 2. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

```
docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
docker run test-runner-image ci/run-fips-integration-tests.sh 1
```
## Related issues

https://github.com/elastic/ingest-dev/issues/4953
