### PR TITLE
Docs: Mark Java 21 default.

### DIFF
--- a/docs/static/jvm.asciidoc
+++ b/docs/static/jvm.asciidoc
@@ -4,8 +4,8 @@
 
 {ls} requires one of these versions:
 
-* Java 17 (default). Check out <<jdk17-upgrade>> for settings info.
-* Java 21
+* Java 17. Check out <<jdk17-upgrade>> for settings info.
+* Java 21 (default)
 
 Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Updates the JVM doc saying Java 17 is default. Unfortunately we changed it to Java 21 a way back.

## Why is it important/What is the impact to the user?
Deliver accurate message about JDK

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ] Needs to forwardport to `main`

## How to test this PR locally

## Related issues


## Use cases


## Screenshots


## Logs
