### PR TITLE
CPM handle 404 response gracefully with user-friendly log

### DIFF
--- a/logstash-core/lib/logstash/config/source_loader.rb
+++ b/logstash-core/lib/logstash/config/source_loader.rb
@@ -93,6 +93,12 @@ module LogStash module Config
 
           SuccessfulFetch.new(pipeline_configs)
         rescue => e
+          # es-output 12.0.2 throws 404 as error
+          if e.is_a?(LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError) && e.response_code == 404
+            logger.error("No configuration found in the configured sources.")
+            return SuccessfulFetch.new({})
+          end
+
           logger.error("Could not fetch all the sources", :exception => e.class, :message => e.message, :backtrace => e.backtrace)
           FailedFetch.new(e.message)
         end


### PR DESCRIPTION
Starting from es-output 12.0.2, a 404 response is treated as an error. Previously, central pipeline management considered 404 as an empty pipeline, not an error.

This commit restores the expected behavior by handling 404 gracefully  and logs a user-friendly message. 

Fixes: https://github.com/elastic/logstash/issues/17035