### PR TITLE
Backport PR #17063 to 8.x: Use centralized source of truth for active branches

### DIFF
--- a/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
+++ b/.buildkite/scripts/common/trigger-pipeline-generate-steps.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # https://github.com/elastic/ingest-dev/issues/2664
 # *******************************************************
 
-ACTIVE_BRANCHES_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/branches.json"
+ACTIVE_BRANCHES_URL="https://storage.googleapis.com/artifacts-api/snapshots/branches.json"
 EXCLUDE_BRANCHES_ARRAY=()
 BRANCHES=()
 
@@ -63,7 +63,7 @@ exclude_branches_to_array
 set -u
 set +e
 # pull releaseable branches from $ACTIVE_BRANCHES_URL
-readarray -t ELIGIBLE_BRANCHES < <(curl --retry-all-errors --retry 5 --retry-delay 5 -fsSL $ACTIVE_BRANCHES_URL | jq -r '.branches[].branch')
+readarray -t ELIGIBLE_BRANCHES < <(curl --retry-all-errors --retry 5 --retry-delay 5 -fsSL $ACTIVE_BRANCHES_URL | jq -r '.branches[]')
 if [[ $? -ne 0 ]]; then
   echo "There was an error downloading or parsing the json output from [$ACTIVE_BRANCHES_URL]. Exiting."
   exit 1


### PR DESCRIPTION
**Backport PR #17063 to 8.x branch, original message:**

---


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip]

## What does this PR do?

This commit simplifies the DRA process in Logstash by removing the need to maintain a separate file for the active branches, and instead rely on a centrally maintained file containing source of truth.
While at it, we refactor/simplify the creation of an array with the versions in `.buildkite/scripts/snyk/resolve_stack_version.sh`.

## Why is it important/What is the impact to the user?

Removes a manual step required when new branches get cut.

## How to test this PR locally

```yaml
$ PIPELINES_TO_TRIGGER="test-pipeline" .buildkite/scripts/common/trigger-pipeline-generate-steps.sh 
--- Printing generated steps
steps:
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 7.17"
    build:
      branch: "7.17"
      message: ":testexecute: Scheduled build for 7.17"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 8.x"
    build:
      branch: "8.x"
      message: ":testexecute: Scheduled build for 8.x"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 8.16"
    build:
      branch: "8.16"
      message: ":testexecute: Scheduled build for 8.16"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 8.17"
    build:
      branch: "8.17"
      message: ":testexecute: Scheduled build for 8.17"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 8.18"
    build:
      branch: "8.18"
      message: ":testexecute: Scheduled build for 8.18"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / 9.0"
    build:
      branch: "9.0"
      message: ":testexecute: Scheduled build for 9.0"
  - trigger: test-pipeline
    label: ":testexecute: Triggering test-pipeline / main"
    build:
      branch: "main"
      message: ":testexecute: Scheduled build for main"
```

```
$ .buildkite/scripts/snyk/resolve_stack_version.sh 
Fetching versions from https://storage.googleapis.com/artifacts-api/snapshots/branches.json
7.17 8.x 8.16 8.17 8.18 9.0 main
```

Test in buildkite by triggering the scheduled pipeline: https://buildkite.com/elastic/logstash-pipeline-scheduler/builds/568#0194fa84-0a66-42d7-8806-d4610ce2abce/64-100