### PR TITLE
Allow capturing heap dumps in DRA BK jobs

### DIFF
--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -25,7 +25,7 @@ function save_docker_tarballs {
 # Since we are using the system jruby, we need to make sure our jvm process
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
-export JRUBY_OPTS="-J-Xmx1g"
+export JRUBY_OPTS="-J-Xmx4g"
 
 # Extract the version number from the version.yml file
 # e.g.: 8.6.0

--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -25,7 +25,7 @@ function save_docker_tarballs {
 # Since we are using the system jruby, we need to make sure our jvm process
 # uses at least 1g of memory, If we don't do this we can get OOM issues when
 # installing gems. See https://github.com/elastic/logstash/issues/5179
-export JRUBY_OPTS="-J-Xmx4g"
+export JRUBY_OPTS="-J-Xmx1g"
 
 # Extract the version number from the version.yml file
 # e.g.: 8.6.0

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -30,6 +30,8 @@ def package_x86_step(branch, workflow_type):
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
     eval "$(rbenv init -)"
     .buildkite/scripts/dra/build_packages.sh
+  artifact_paths:
+    - "**/*.hprof"
 '''
 
     return step
@@ -44,6 +46,8 @@ def package_x86_docker_step(branch, workflow_type):
     image: family/platform-ingest-logstash-ubuntu-2204
     machineType: "n2-standard-16"
     diskSizeGb: 200
+  artifact_paths:
+    - "**/*.hprof"
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
@@ -63,6 +67,8 @@ def package_aarch64_docker_step(branch, workflow_type):
     imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
     instanceType: "m6g.4xlarge"
     diskSizeGb: 200
+  artifact_paths:
+    - "**/*.hprof"
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit allows Buildkite to capture any heap dumps produced during DRA builds.

## Why is it important/What is the impact to the user?

Eases investigating failing builds like https://buildkite.com/elastic/logstash-dra-snapshot-pipeline/builds/2231#0194fd28-acc5-4f24-9f06-66e52b3f0567
