### PR TITLE
qa: use clean expansion of LS tarball per fixture instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -414,7 +414,7 @@ def qaBuildPath = "${buildDir}/qa/integration"
 def qaVendorPath = "${qaBuildPath}/vendor"
 
 tasks.register("installIntegrationTestGems") {
-  dependsOn unpackTarDistribution
+  dependsOn assembleTarDistribution
   def gemfilePath = file("${projectDir}/qa/integration/Gemfile")
   inputs.files gemfilePath
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")

--- a/qa/integration/framework/settings.rb
+++ b/qa/integration/framework/settings.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require 'yaml'
+require 'delegate'
 
 # All settings for a test, global and per test
 class TestSettings
@@ -75,5 +76,24 @@ class TestSettings
   def feature_config_dir
     feature = feature_flag
     feature.empty? ? nil : File.join(FIXTURES_DIR, feature)
+  end
+
+  def override(kv_map)
+    Override.new(self, kv_map)
+  end
+
+  class Override < SimpleDelegator# quacks like TestSettings
+    def initialize(test_settings, overrides)
+      super(test_settings)
+      @overrides = overrides
+    end
+
+    def is_set?(key)
+      @overrides.include?(key) || super
+    end
+
+    def get(key)
+      @overrides.fetch(key) { super }
+    end
   end
 end


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?

Ensures that Logstash integration tests are run against a _clean_ expansion of the built tarball.

## Why is it important/What is the impact to the user?

Because QA tests can _modify_ the Logstash installation (e.g. those that invoke the plugin manager), it is important that the service wrapper begins with a clean expansion of the logstash tarball.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

Run integration tests that invoke the Logstash service (or any of its sub-command features like the plugin manager):

~~~ sh
ci/integration_tests.sh specs/cli/remove_spec.rb
~~~

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs

see `expunging`, indicating that the old was removed
see `expanding`, indicating a fresh expansion
see `Using`...`as LS_HOME`, indicating that the fresh expansion is being used

> ~~~
>     CLI > logstash-plugin remove
>     expunging(/Users/rye/src/elastic/logstash@main/build/qa-fixture/logstash-9.1.0-SNAPSHOT)
>     expanding(/Users/rye/src/elastic/logstash@main/build/logstash-9.1.0-SNAPSHOT.tar.gz)
>     Using /Users/rye/src/elastic/logstash@main/build/qa-fixture/logstash-9.1.0-SNAPSHOT as LS_HOME
>     Setting up services
>     Setting up logstash service
>     Setup script not found for logstash
>     logstash service setup complete
>       when other plugins depends on this plugin
>         refuses to remove the plugin and display the plugin that depends on it.
>       when no other plugins depends on this plugin
>         successfully remove the plugin
> 
>     Finished in 2 minutes 0.2 seconds (files took 0.98941 seconds to load)
>     2 examples, 0 failures
> ~~~
