### PR TITLE
spec: improve ls2ls spec (#17114)

### DIFF
--- a/qa/integration/fixtures/logstash_to_logstash_spec.yml
+++ b/qa/integration/fixtures/logstash_to_logstash_spec.yml
@@ -14,7 +14,7 @@ config:
       file {
         path => '<%=options[:output_file_path]%>'
         flush_interval => 0
-        codec => line { format => "%{message}" }
+        codec => line { format => "%{[event][sequence]}:%{message}" }
       }
     }
   basic_ls_output: |-

--- a/qa/integration/specs/logstash_to_logstash_spec.rb
+++ b/qa/integration/specs/logstash_to_logstash_spec.rb
@@ -36,13 +36,6 @@ describe "Logstash to Logstash communication Integration test" do
     @fixture.teardown
   }
 
-  def change_logstash_setting(logstash_service, name, value)
-    settings = {}.tap do |settings|
-      settings[name] = value
-    end
-    IO.write(logstash_service.application_settings_file, settings.to_yaml)
-  end
-
   def get_temp_path_dir
     tmp_path = Stud::Temporary.pathname
     tmp_data_path = File.join(tmp_path, "data")
@@ -50,13 +43,26 @@ describe "Logstash to Logstash communication Integration test" do
     tmp_data_path
   end
 
-  def run_logstash_instance(config_name, options = {})
-    api_port = 9600 + rand(1000)
-    logstash_service = LogstashService.new(@fixture.settings, api_port)
-    change_logstash_setting(logstash_service, "api.http.port", api_port)
-    logstash_service.spawn_logstash("-f", config_to_temp_file(@fixture.config(config_name, options)), "--path.data", get_temp_path_dir)
+  def run_logstash_instance(config_name, options = {}, &block)
+    @next_api_port_offset = (@next_api_port_offset||100).next.modulo(1000) # cycle through 1000 possibles
+    api_port = 9600 + @next_api_port_offset
+
+    # to avoid LogstashService's clean-from-tarball default behaviour, we need
+    # to tell it where our LOGSTASH_HOME is in the existing service
+    existing_fixture_logstash_home = @fixture.get_service("logstash").logstash_home
+    logstash_service = LogstashService.new(@fixture.settings.override("ls_home_abs_path" => existing_fixture_logstash_home), api_port)
+
+    logstash_service.spawn_logstash("--node.name", config_name,
+                                    "--pipeline.id", config_name,
+                                    "--path.config", config_to_temp_file(@fixture.config(config_name, options)),
+                                    "--path.data", get_temp_path_dir,
+                                    "--api.http.port", api_port.to_s)
     wait_for_logstash(logstash_service)
-    logstash_service
+
+    yield logstash_service
+
+  ensure
+    logstash_service&.teardown
   end
 
   def wait_for_logstash(service)
@@ -86,26 +92,25 @@ describe "Logstash to Logstash communication Integration test" do
     }
 
     it "successfully send events" do
-      upstream_logstash_service = run_logstash_instance(input_config_name, all_config_options)
-      downstream_logstash_service = run_logstash_instance(output_config_name, all_config_options)
+      run_logstash_instance(input_config_name, all_config_options) do |downstream_logstash_service|
+        run_logstash_instance(output_config_name, all_config_options) do |upstream_logstash_service|
 
-      try(num_retries) do
-        event_stats = upstream_logstash_service.monitoring_api.event_stats
-        if event_stats
-          expect(event_stats["in"]).to eq(num_events)
+          try(num_retries) do
+            downstream_event_stats = downstream_logstash_service.monitoring_api.event_stats
+
+            expect(downstream_event_stats).to include({"in" => num_events}), lambda { "expected #{num_events} events to have been received by downstream"}
+          end
+
+          # make sure received events are in the file
+          file_output_path = File.join(downstream_logstash_service.logstash_home, output_file_path_with_datetime)
+          expect(File).to exist(file_output_path), "Logstash to Logstash output file: #{file_output_path} does not exist"
+          actual_lines = File.read(file_output_path).lines.to_a
+          expected_lines = (0...num_events).map { |sequence| "#{sequence}:Hello world!\n" }
+          expect(actual_lines).to match_array(expected_lines)
+
+          File.delete(file_output_path)
         end
       end
-
-      upstream_logstash_service.teardown
-      downstream_logstash_service.teardown
-
-      # make sure received events are in the file
-      file_output_path = File.join(upstream_logstash_service.logstash_home, output_file_path_with_datetime)
-      expect(File).to exist(file_output_path), "Logstash to Logstash output file: #{file_output_path} does not exist"
-      count = File.foreach(file_output_path).inject(0) { |c, _| c + 1 }
-      expect(count).to eq(num_events)
-
-      File.delete(file_output_path)
     end
   end
 


### PR DESCRIPTION
* spec: improve ls2ls spec

 - fixes upstream/downstream convention
   - upstream: the sending logstash (has an LS output)
   - downstream: the receiving logstash (has an LS input)
 - helper `run_logstash_instance` yields the `LogstashService` instance and handles the teardown.
 - pass the pipeline id and node name to the LS instances via command line flags to make logging easier to differentiate
 - use the generator input's sequence id to ensure that the _actual_ events generated are received by the downstream pipeline

* start with port-offset 100

Co-authored-by: Mashhur <99575341+mashhurs@users.noreply.github.com>

---------

Co-authored-by: Mashhur <99575341+mashhurs@users.noreply.github.com>
(cherry picked from commit 9abad6609c21c4e796cb9a97ba782a7a9837f589)

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
