### PR TITLE
Fix acceptance test assertions for updated plugin `remove`

### DIFF
--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb
@@ -75,7 +75,7 @@ shared_examples "integration plugins compatible" do |logstash|
       context "trying to uninstall an inner plugin" do
         it "fails to uninstall it" do
           result = logstash.run_sudo_command_in_path("bin/logstash-plugin uninstall logstash-input-rabbitmq")
-          expect(result.stderr).to match(/is already provided by/)
+          expect(result.stderr).to include("The plugin `logstash-input-rabbitmq` is provided by 'logstash-integration-rabbitmq' so it can't be removed individually")
         end
       end
     end

--- a/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
+++ b/qa/acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb
@@ -33,7 +33,7 @@ shared_examples "logstash uninstall" do |logstash|
     context "when the plugin isn't installed" do
       it "fails to uninstall it" do
         result = logstash.run_sudo_command_in_path("bin/logstash-plugin uninstall logstash-filter-qatest")
-        expect(result.stderr).to match(/This plugin has not been previously installed/)
+        expect(result.stderr).to include("The plugin `logstash-filter-qatest` has not been previously installed")
       end
     end
 


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
This commit updates the acceptance tests to expect messages in the updated format for removing plugins. See https://github.com/elastic/logstash/pull/17030 for change.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
No user impact, this is fixing acceptance test assertions
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates to https://github.com/elastic/logstash/pull/17030

## Logs
Example failures:
https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1359#01951fe3-2f12-46d5-872e-0af111c463ba
```console
1) CLI operation behaves like logstash uninstall logstash-plugin uninstall on [Ubuntu 22.04] when the plugin isn't installed fails to uninstall it
--
  | Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { \|failure, _opts\| raise failure }
  |  
  | expected "ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-filter-qatest` has not been previously installed" to match /This plugin has not been previously installed/
  | Diff:
  | @@ -1 +1 @@
  | -/This plugin has not been previously installed/
  | +"ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-filter-qatest` has not been previously installed"
  |  
  | Shared Example Group: "logstash uninstall" called from ./acceptance/spec/lib/cli_operation_spec.rb:37
  | # ./acceptance/spec/shared_examples/cli/logstash-plugin/uninstall.rb:36:in `block in <main>'
  | # ./Rakefile:30:in `block in <main>'
  |  
  | 2) CLI operation behaves like logstash remove logstash-plugin remove on [Ubuntu 22.04] when the plugin isn't installed fails to remove it
  | Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { \|failure, _opts\| raise failure }
  |  
  | expected "ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-filter-qatest` has not been previously installed" to match /This plugin has not been previously installed/
  | Diff:
  | @@ -1 +1 @@
  | -/This plugin has not been previously installed/
  | +"ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-filter-qatest` has not been previously installed"
  |  
  | Shared Example Group: "logstash remove" called from ./acceptance/spec/lib/cli_operation_spec.rb:38
  | # ./acceptance/spec/shared_examples/cli/logstash-plugin/remove.rb:36:in `block in <main>'
  | # ./Rakefile:30:in `block in <main>'
  |  
  | 3) CLI operation behaves like integration plugins compatible logstash-plugin uninstall on [Ubuntu 22.04] when the integration is installed trying to uninstall an inner plugin fails to uninstall it
  | Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { \|failure, _opts\| raise failure }
  |  
  | expected "ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-input-rabbitmq` is provided by 'logstash-integration-rabbitmq' so it can't be removed individually" to match /is already provided by/
  | Diff:
  | @@ -1 +1 @@
  | -/is already provided by/
  | +"ERROR: Operation aborted, cannot remove plugin, message: The plugin `logstash-input-rabbitmq` is provided by 'logstash-integration-rabbitmq' so it can't be removed individually"
  |  
  | Shared Example Group: "integration plugins compatible" called from ./acceptance/spec/lib/cli_operation_spec.rb:40
  | # ./acceptance/spec/shared_examples/cli/logstash-plugin/integration_plugin.rb:78:in `block in <main>'
  | # ./Rakefile:30:in `block in <main>'
  |  
  | Finished in 21 minutes 10 seconds (files took 1.68 seconds to load)
  | 30 examples, 3 failures, 1 pending

```