### PR TITLE
plugin manager: add --no-expand flag for list command

### DIFF
--- a/lib/pluginmanager/util.rb
+++ b/lib/pluginmanager/util.rb
@@ -47,6 +47,16 @@ module LogStash::PluginManager
   # Defines the plugin alias, must be kept in synch with Java class org.logstash.plugins.AliasRegistry
   ALIASES = load_aliases_definitions()
 
+  def self.resolve_alias(alias_name)
+    ALIASES[alias_name]
+  end
+
+  def self.find_aliases(plugin_name)
+    ALIASES.each_with_object([]) do |(alias_name, candidate_plugin_name), aliases|
+      aliases << alias_name if candidate_plugin_name == plugin_name
+    end.compact.uniq
+  end
+
   class ValidationError < StandardError; end
 
   # check for valid logstash plugin gem name & version or .gem file, logs errors to $stdout

--- a/qa/integration/fixtures/list_spec.yml
+++ b/qa/integration/fixtures/list_spec.yml
@@ -1,0 +1,3 @@
+---
+services:
+  - logstash

--- a/qa/integration/specs/cli/list_spec.rb
+++ b/qa/integration/specs/cli/list_spec.rb
@@ -62,8 +62,8 @@ describe "CLI > logstash-plugin remove" do
       plugins = list_command.stderr_and_stdout.split(/\n(?! )/)
 
       integration_plugin = plugins.find { |plugin_output| plugin_output.match(/^logstash-integration-jdbc\b/) }
-      expect(integration_plugin).to match(/^#{sub_heading_pattern} logstash-input-jdbc$/)
-      expect(integration_plugin).to match(/^#{sub_heading_pattern} logstash-filter-jdbc_static$/)
+      expect(integration_plugin).to match(/^#{sub_heading_pattern} #{Regexp.escape("logstash-input-jdbc")}$/)
+      expect(integration_plugin).to match(/^#{sub_heading_pattern} #{Regexp.escape("logstash-filter-jdbc_static")}$/)
     end
 
     it "expands plugin aliases" do
@@ -72,7 +72,7 @@ describe "CLI > logstash-plugin remove" do
       plugins = list_command.stderr_and_stdout.split(/\n(?! )/)
 
       alias_plugin = plugins.find { |plugin_output| plugin_output.match(/^logstash-input-beats\b/) }
-      expect(alias_plugin).to match(/^#{sub_heading_pattern} logstash-input-elastic_agent (alias)$/)
+      expect(alias_plugin).to match(/^#{sub_heading_pattern} #{Regexp.escape("logstash-input-elastic_agent (alias)")}$/)
     end
 
     context "--no-expand" do

--- a/qa/integration/specs/cli/list_spec.rb
+++ b/qa/integration/specs/cli/list_spec.rb
@@ -1,0 +1,94 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../../framework/fixture'
+require_relative '../../framework/settings'
+require_relative '../../services/logstash_service'
+require_relative '../../framework/helpers'
+require "logstash/devutils/rspec/spec_helper"
+
+describe "CLI > logstash-plugin remove" do
+  before(:all) do
+    @fixture = Fixture.new(__FILE__)
+    @logstash_plugin = @fixture.get_service("logstash").plugin_cli
+  end
+
+  context "listing plugins" do
+
+    let(:sub_heading_pattern) do
+      Regexp.union(" ├──"," └──")
+    end
+
+    let(:version_pattern) do
+      /[0-9]+[.][0-9][0-9a-z.]+/
+    end
+
+    def parse_output(output)
+      output.split(/\n(?! )/)
+    end
+
+    context "--verbose" do
+      it "successfully lists a single plugin" do
+        list_command = @logstash_plugin.run("list --verbose logstash-integration-jdbc")
+        expect(list_command.exit_code).to eq(0)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-integration-jdbc [(]#{version_pattern}[)]/)
+      end
+      it "successfully lists all plugins" do
+        list_command = @logstash_plugin.run("list --verbose")
+        expect(list_command.exit_code).to eq(0)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-integration-jdbc [(]#{version_pattern}[)]/)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-input-beats [(]#{version_pattern}[)]/)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-output-elasticsearch [(]#{version_pattern}[)]/)
+      end
+    end
+
+    it "expands integration plugins" do
+      list_command = @logstash_plugin.run("list logstash-integration-jdbc")
+      expect(list_command.exit_code).to eq(0)
+      plugins = list_command.stderr_and_stdout.split(/\n(?! )/)
+
+      integration_plugin = plugins.find { |plugin_output| plugin_output.match(/^logstash-integration-jdbc\b/) }
+      expect(integration_plugin).to match(/^#{sub_heading_pattern} logstash-input-jdbc$/)
+      expect(integration_plugin).to match(/^#{sub_heading_pattern} logstash-filter-jdbc_static$/)
+    end
+
+    it "expands plugin aliases" do
+      list_command = @logstash_plugin.run("list logstash-input-beats")
+      expect(list_command.exit_code).to eq(0)
+      plugins = list_command.stderr_and_stdout.split(/\n(?! )/)
+
+      alias_plugin = plugins.find { |plugin_output| plugin_output.match(/^logstash-input-beats\b/) }
+      expect(alias_plugin).to match(/^#{sub_heading_pattern} logstash-input-elastic_agent (alias)$/)
+    end
+
+    context "--no-expand" do
+      it "does not expand integration plugins" do
+        list_command = @logstash_plugin.run("list --no-expand")
+        expect(list_command.exit_code).to eq(0)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-integration-jdbc\b/)
+        expect(list_command.stderr_and_stdout).to_not include("logstash-input-jdbc") # known integrated plugin
+        expect(list_command.stderr_and_stdout).to_not include("logstash-filter-jdbc") # known integrated plugin
+      end
+      it "does not expand plugin aliases" do
+        list_command = @logstash_plugin.run("list --no-expand")
+        expect(list_command.exit_code).to eq(0)
+        expect(list_command.stderr_and_stdout).to match(/^logstash-input-beats\b/)
+        expect(list_command.stderr_and_stdout).to_not include("logstash-input-elastic_agent") # known alias
+      end
+    end
+  end
+end


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes

* The plugin manager `bin/logstash-plugin`'s  `list` command now supports a `--no-expand` flag to avoid expanding plugin aliases and the individual plugins within integration plugins.

## What does this PR do?

Adds `--[no-]expand` flag (default: true) to the plugin manager's `list` command, so that a caller can avoid expanding the integration plugins and aliases to get only a list of the plugin _packages_ installed.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] file doc issue

## How to test this PR locally

~~~
bin/logstash-plugin list --no-expand
~~~
~~~
bin/logstash-plugin list --verbose --no-expand
~~~
~~~
bin/logstash-plugin list --no-expand logstash-integration-aws
~~~
~~~
bin/logstash-plugin list --no-expand --verbose logstash-integration-aws
~~~



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
