### PR TITLE
Add Windows 2025 to CI

### DIFF
--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -15,6 +15,8 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_OS}"
         options:
+          - label: "Windows 2025"
+            value: "windows-2025"
           - label: "Windows 2022"
             value: "windows-2022"
           - label: "Windows 2019"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

This commit adds Windows 2025 to the Windows JDK matrix pipeline.

## Why is it important/What is the impact to the user?

Is required to satisfy support matrix requirements and ensure the product works on Windows 2025.

## How to test this PR locally

Can be tested only in Buildkite. Link TBD:

