### PR TITLE
[CI] update serverless test index

### DIFF
--- a/ci/serverless/README.md
+++ b/ci/serverless/README.md
@@ -7,7 +7,7 @@ The test cases against serverless Elasticsearch cover the following scenarios
 - DLQ
 - central pipeline management
 - Kibana API for pipeline management (CPM)
-- Metricbeat monitoring
+- ~~Metricbeat monitoring~~
 - ~~Logstash legacy monitoring~~
 
 ### Setup testing endpoint

--- a/ci/serverless/metricbeat_monitoring_tests.sh
+++ b/ci/serverless/metricbeat_monitoring_tests.sh
@@ -13,7 +13,7 @@ get_cpu_arch() {
   fi
 }
 
-export INDEX_NAME=".monitoring-logstash-8-mb"
+export INDEX_NAME=".monitoring-logstash-9-mb"
 export OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 export ARCH=$(get_cpu_arch)
 export BEATS_VERSION=$(curl -s "https://api.github.com/repos/elastic/beats/tags" | jq -r '.[0].name' | cut -c 2-)

--- a/ci/serverless/metricbeat_monitoring_tests.sh
+++ b/ci/serverless/metricbeat_monitoring_tests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+# metricbeat monitoring is disabled. Serverless does not support stack monitoring.
 set -ex
 
 source ./$(dirname "$0")/common.sh


### PR DESCRIPTION
update metricbeat `.monitoring-logstash-8-mb` to `.monitoring-logstash-9-mb`

wait until [[1]](https://github.com/elastic/beats/pull/42823), [[2]](https://github.com/elastic/elasticsearch/pull/123106) get merged