### PR TITLE
Update container acceptance tests with stdout/stderr changes

### DIFF
--- a/qa/docker/shared_examples/container.rb
+++ b/qa/docker/shared_examples/container.rb
@@ -15,16 +15,13 @@ shared_examples_for 'the container is configured correctly' do |flavor|
 
     it 'should run with the correct version' do
       console_out = exec_in_container(@container, 'logstash --version')
-      console_filtered = console_out.split("\n")
-            .delete_if do |line|
-              line =~ /Using LS_JAVA_HOME defined java|Using system java: /
-            end.join
-      expect(console_filtered).to match /#{version}/
+      expect(console_out).to match /#{version}/
     end
 
     it 'should run with the bundled JDK' do
-      first_console_line = exec_in_container(@container, 'logstash --version').split("\n")[0]
-      expect(first_console_line).to match /Using bundled JDK: \/usr\/share\/logstash\/jdk/
+      full_command = exec_in_container_full(@container, 'logstash --version')
+      std_err = full_command[:stderr].join.chomp.strip
+      expect(std_err).to match /Using bundled JDK: \/usr\/share\/logstash\/jdk/
     end
 
     it 'should be running an API server on port 9600' do


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

In https://github.com/elastic/logstash/pull/17125 jvm setup was redirected to stderr to avoid polluting stdout. This test was actually having to do some additional processing to parse that information. Now that we have split the destinations the tests can be simplified to look for the data they are trying to validate on the appropriate stream.


## Why is it important/What is the impact to the user?

No user impact, just a test fix. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/elastic/logstash/pull/17125


## Failing tests
```console

Failures:
--
  |  
  | 1) A container running the wolfi image behaves like the container is configured correctly logstash should run with the bundled JDK
  | Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { \|failure, _opts\| raise failure }
  |  
  | expected "logstash 9.1.0" to match /Using bundled JDK: \/usr\/share\/logstash\/jdk/
  | Diff:
  | @@ -1 +1 @@
  | -/Using bundled JDK: \/usr\/share\/logstash\/jdk/
  | +"logstash 9.1.0"
  |  
  | Shared Example Group: "the container is configured correctly" called from ./docker/spec/wolfi/container_spec.rb:8
  | # ./docker/shared_examples/container.rb:27:in `block in <main>'
  |  
  | Finished in 9 minutes 26 seconds (files took 2.6 seconds to load)
```