### PR TITLE
Skip offline pack manager tests when running in fips mode

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |c|
   Flores::RSpec.configure(c)
   c.include LogStashHelper
   c.extend LogStashHelper
-
+  c.filter_run_excluding skip_fips: true if java.lang.System.getProperty("org.bouncycastle.fips.approved_only") == "true"
   if ENV['COVERAGE']
     c.after(:suite) do
       SimpleCov.result.format!

--- a/spec/unit/plugin_manager/offline_plugin_packager_spec.rb
+++ b/spec/unit/plugin_manager/offline_plugin_packager_spec.rb
@@ -79,7 +79,7 @@ describe LogStash::PluginManager::OfflinePluginPackager do
     end
   end
 
-  context "when the plugins exist" do
+  context "when the plugins exist", :skip_fips do
     before :all do
       Paquet.ui = Paquet::SilentUI
     end


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

This commit introduces a pattern for skipping tests we do not want to run in fips mode. In this case the plugin manager tests rely on using bundler/net-http/openssl which is not configured to be run with bouncycastle fips providers.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/5070
