### PR TITLE
Potential fix Badly anchored regular expression

### DIFF
--- a/logstash-core/lib/logstash/util/thread_safe_attributes.rb
+++ b/logstash-core/lib/logstash/util/thread_safe_attributes.rb
@@ -21,7 +21,7 @@ module LogStash
     module ThreadSafeAttributes
       # Thread-safe lazy initialized attribute with a given (variable) name.
       def lazy_init_attr(attribute, variable: "@#{attribute}".to_sym, &block)
-        raise ArgumentError.new("invalid attribute name: #{attribute}") unless attribute.match? /^[_A-Za-z]\w*$/
+        raise ArgumentError.new("invalid attribute name: #{attribute}") unless attribute.match? /\A[_A-Za-z]\w*\z/
         raise ArgumentError.new('no block given') unless block_given?
         send(:define_method, attribute.to_sym) do
           if instance_variable_defined?(variable)


### PR DESCRIPTION
Regular expressions in Ruby can use anchors to match the beginning and end of a string. However, if the ^ and $ anchors are used, the regular expression can match a single line of a multi-line string. This allows bad actors to bypass your regular expression checks and inject malicious input.

https://ruby-doc.org/3.2.0/Regexp.html#class-Regexp-label-Anchors
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works



## Related issues
#17163
