### PR TITLE
Fix empty node stats pipelines

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -185,9 +185,9 @@ module LogStash
               :reloads => stats[:reloads],
               :queue => stats[:queue],
               :pipeline => {
-                :workers => stats[:config][:workers],
-                :batch_size => stats[:config][:batch_size],
-                :batch_delay => stats[:config][:batch_delay],
+                :workers => stats.dig(:config, :workers),
+                :batch_size => stats.dig(:config, :batch_size),
+                :batch_delay => stats.dig(:config, :batch_delay),
               }
             }
             ret[:dead_letter_queue] = stats[:dlq] if stats.include?(:dlq)

--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -31,6 +31,12 @@ class MonitoringAPI
     stats_response.fetch("pipelines").fetch(pipeline_id)
   end
 
+  def pipelines_stats
+    resp = Manticore.get("http://localhost:#{@port}/_node/stats/pipelines").body
+    stats_response = JSON.parse(resp)
+    stats_response.fetch("pipelines")
+  end
+
   def event_stats
     resp = Manticore.get("http://localhost:#{@port}/_node/stats").body
     stats_response = JSON.parse(resp)

--- a/x-pack/qa/integration/monitoring/direct_shipping_spec.rb
+++ b/x-pack/qa/integration/monitoring/direct_shipping_spec.rb
@@ -31,6 +31,12 @@ describe "Direct shipping" do
 
   include_examples "record monitoring data to es"
 
+  it "gives pipelines stats" do
+    api = MonitoringAPI.new
+    stats = api.pipelines_stats
+    expect(stats.keys).not_to be_nil
+  end
+
   after :all do
     @logstash_service.stop unless @logstash_service.nil?
     @elasticsearch_service.stop unless @elasticsearch_service.nil?


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fixed an issue where the `/_node/stats` API displayed empty pipeline metrics when X-Pack monitoring was enabled

## What does this PR do?

When monitoring is enabled, the metrics store does not initialise data for monitoring pipeline. The api has null pointer when fetching the pipeline config like workers, batch_size. 

## Why is it important/What is the impact to the user?

`/_node/stats`  gives empty `pipelines: {}`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- closes: https://github.com/elastic/logstash/issues/17180
- 
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
