### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/extend/codec-new-plugin.md
+++ b/docs/extend/codec-new-plugin.md
@@ -402,7 +402,7 @@ With these both defined, the install process will search for the required jar fi
 
 ## Document your plugin [_document_your_plugin_2]
 
-Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://docs/reference/integration-plugins.md).
+Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://reference/integration-plugins.md).
 
 See [Document your plugin](/extend/plugin-doc.md) for tips and guidelines.
 

--- a/docs/extend/filter-new-plugin.md
+++ b/docs/extend/filter-new-plugin.md
@@ -403,7 +403,7 @@ With these both defined, the install process will search for the required jar fi
 
 ## Document your plugin [_document_your_plugin_3]
 
-Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://docs/reference/integration-plugins.md).
+Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://reference/integration-plugins.md).
 
 See [Document your plugin](/extend/plugin-doc.md) for tips and guidelines.
 

--- a/docs/extend/input-new-plugin.md
+++ b/docs/extend/input-new-plugin.md
@@ -443,7 +443,7 @@ With these both defined, the install process will search for the required jar fi
 
 ## Document your plugin [_document_your_plugin]
 
-Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://docs/reference/integration-plugins.md).
+Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://reference/integration-plugins.md).
 
 See [Document your plugin](/extend/plugin-doc.md) for tips and guidelines.
 

--- a/docs/extend/output-new-plugin.md
+++ b/docs/extend/output-new-plugin.md
@@ -360,7 +360,7 @@ With these both defined, the install process will search for the required jar fi
 
 ## Document your plugin [_document_your_plugin_4]
 
-Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://docs/reference/integration-plugins.md).
+Documentation is an important part of your plugin. All plugin documentation is rendered and placed in the [Logstash Reference](/reference/index.md) and the [Versioned plugin docs](logstash-docs://reference/integration-plugins.md).
 
 See [Document your plugin](/extend/plugin-doc.md) for tips and guidelines.
 

--- a/docs/extend/plugin-doc.md
+++ b/docs/extend/plugin-doc.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 Documentation is a required component of your plugin. Quality documentation with good examples contributes to the adoption of your plugin.
 
-The documentation that you write for your plugin will be generated and published in the [Logstash Reference](/reference/index.md) and the [Logstash Versioned Plugin Reference](logstash-docs://docs/reference/integration-plugins.md).
+The documentation that you write for your plugin will be generated and published in the [Logstash Reference](/reference/index.md) and the [Logstash Versioned Plugin Reference](logstash-docs://reference/integration-plugins.md).
 
 ::::{admonition} Plugin listing in {{ls}} Reference
 :class: note
@@ -26,7 +26,7 @@ Documentation belongs in a single file called *docs/index.asciidoc*. It belongs 
 
 ## Heading IDs [heading-ids]
 
-Format heading anchors with variables that can support generated IDs. This approach creates unique IDs when the [Logstash Versioned Plugin Reference](logstash-docs://docs/reference/integration-plugins.md) is built. Unique heading IDs are required to avoid duplication over multiple versions of a plugin.
+Format heading anchors with variables that can support generated IDs. This approach creates unique IDs when the [Logstash Versioned Plugin Reference](logstash-docs://reference/integration-plugins.md) is built. Unique heading IDs are required to avoid duplication over multiple versions of a plugin.
 
 **Example**
 
@@ -39,7 +39,7 @@ Instead, use variables to define it:
 ==== Configuration models
 ```
 
-If you hardcode an ID, the [Logstash Versioned Plugin Reference](logstash-docs://docs/reference/integration-plugins.md) builds correctly the first time. The second time the doc build runs, the ID is flagged as a duplicate, and the build fails.
+If you hardcode an ID, the [Logstash Versioned Plugin Reference](logstash-docs://reference/integration-plugins.md) builds correctly the first time. The second time the doc build runs, the ID is flagged as a duplicate, and the build fails.
 
 
 ## Link formats [link-format]
@@ -136,7 +136,7 @@ match => {
 
 ## Where’s my doc? [_wheres_my_doc]
 
-Plugin documentation goes through several steps before it gets published in the [Logstash Versioned Plugin Reference](logstash-docs://docs/reference/integration-plugins.md) and the [Logstash Reference](/reference/index.md).
+Plugin documentation goes through several steps before it gets published in the [Logstash Versioned Plugin Reference](logstash-docs://reference/integration-plugins.md) and the [Logstash Reference](/reference/index.md).
 
 Here’s an overview of the workflow:
 
@@ -145,7 +145,7 @@ Here’s an overview of the workflow:
 * Wait for the continuous integration build to complete successfully.
 * Publish the plugin to [https://rubygems.org](https://rubygems.org).
 * A script detects the new or changed version, and picks up the `index.asciidoc` file for inclusion in the doc build.
-* The documentation for your new plugin is published in the [Logstash Versioned Plugin Reference](logstash-docs://docs/reference/integration-plugins.md).
+* The documentation for your new plugin is published in the [Logstash Versioned Plugin Reference](logstash-docs://reference/integration-plugins.md).
 
 We’re not done yet.
 

--- a/docs/reference/advanced-pipeline.md
+++ b/docs/reference/advanced-pipeline.md
@@ -22,7 +22,7 @@ In a typical use case, Filebeat runs on a separate machine from the machine runn
 
 The default Logstash installation includes the [`Beats input`](/reference/plugins-inputs-beats.md) plugin. The Beats input plugin enables Logstash to receive events from the Elastic Beats framework, which means that any Beat written to work with the Beats framework, such as Packetbeat and Metricbeat, can also send event data to Logstash.
 
-To install Filebeat on your data source machine, download the appropriate package from the Filebeat [product page](https://www.elastic.co/downloads/beats/filebeat). You can also refer to [Filebeat quick start](beats://docs/reference/filebeat/filebeat-installation-configuration.md) for additional installation instructions.
+To install Filebeat on your data source machine, download the appropriate package from the Filebeat [product page](https://www.elastic.co/downloads/beats/filebeat). You can also refer to [Filebeat quick start](beats://reference/filebeat/filebeat-installation-configuration.md) for additional installation instructions.
 
 After installing Filebeat, you need to configure it. Open the `filebeat.yml` file located in your Filebeat installation directory, and replace the contents with the following lines. Make sure `paths` points to the example Apache log file, `logstash-tutorial.log`, that you downloaded earlier:
 
@@ -49,7 +49,7 @@ sudo ./filebeat -e -c filebeat.yml -d "publish"
 ```
 
 ::::{note}
-If you run Filebeat as root, you need to change ownership of the configuration file (see [Config File Ownership and Permissions](beats://docs/reference/libbeat/config-file-permissions.md) in the *Beats Platform Reference*).
+If you run Filebeat as root, you need to change ownership of the configuration file (see [Config File Ownership and Permissions](beats://reference/libbeat/config-file-permissions.md) in the *Beats Platform Reference*).
 ::::
 
 
@@ -605,7 +605,7 @@ If you are using Kibana to visualize your data, you can also explore the Filebea
 :alt: Discovering Filebeat data in Kibana
 :::
 
-See the [Filebeat quick start docs](beats://docs/reference/filebeat/filebeat-installation-configuration.md) for info about loading the Kibana index pattern for Filebeat.
+See the [Filebeat quick start docs](beats://reference/filebeat/filebeat-installation-configuration.md) for info about loading the Kibana index pattern for Filebeat.
 
 You’ve successfully created a pipeline that uses Filebeat to take Apache web logs as input, parses those logs to create specific, named fields from the logs, and writes the parsed data to an Elasticsearch cluster. Next, you learn how to create a pipeline that uses multiple input and output plugins.
 

--- a/docs/reference/dashboard-monitoring-with-elastic-agent.md
+++ b/docs/reference/dashboard-monitoring-with-elastic-agent.md
@@ -42,7 +42,7 @@ monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
 ::::{dropdown} Create a monitoring user (standalone agent only)
 :name: create-user-db
 
-Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://docs/reference/elasticsearch/roles.md).
+Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
 
 ::::
 

--- a/docs/reference/deploying-scaling-logstash.md
+++ b/docs/reference/deploying-scaling-logstash.md
@@ -12,7 +12,7 @@ The goal of this document is to highlight the most common architecture patterns 
 
 ## Getting Started [deploying-getting-started]
 
-For first time users, if you simply want to tail a log file to grasp the power of the Elastic Stack, we recommend trying [Filebeat Modules](beats://docs/reference/filebeat/filebeat-modules-overview.md). Filebeat Modules enable you to quickly collect, parse, and index popular log types and view pre-built Kibana dashboards within minutes. [Metricbeat Modules](beats://docs/reference/metricbeat/metricbeat-modules.md) provide a similar experience, but with metrics data. In this context, Beats will ship data directly to Elasticsearch where [Ingest Nodes](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) will process and index your data.
+For first time users, if you simply want to tail a log file to grasp the power of the Elastic Stack, we recommend trying [Filebeat Modules](beats://reference/filebeat/filebeat-modules-overview.md). Filebeat Modules enable you to quickly collect, parse, and index popular log types and view pre-built Kibana dashboards within minutes. [Metricbeat Modules](beats://reference/metricbeat/metricbeat-modules.md) provide a similar experience, but with metrics data. In this context, Beats will ship data directly to Elasticsearch where [Ingest Nodes](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) will process and index your data.
 
 :::{image} ../images/deploy1.png
 :alt: deploy1
@@ -56,7 +56,7 @@ Enabling persistent queues is strongly recommended, and these architecture chara
 
 Logstash is horizontally scalable and can form groups of nodes running the same pipeline. Logstash’s adaptive buffering capabilities will facilitate smooth streaming even through variable throughput loads. If the Logstash layer becomes an ingestion bottleneck, simply add more nodes to scale out. Here are a few general recommendations:
 
-* Beats should [load balance](beats://docs/reference/filebeat/elasticsearch-output.md#_loadbalance) across a group of Logstash nodes.
+* Beats should [load balance](beats://reference/filebeat/elasticsearch-output.md#_loadbalance) across a group of Logstash nodes.
 * A minimum of two Logstash nodes are recommended for high availability.
 * It’s common to deploy just one Beats input per Logstash node, but multiple Beats inputs can also be deployed per Logstash node to expose independent endpoints for different data sources.
 
@@ -82,7 +82,7 @@ Logstash will commonly extract fields with [grok](/reference/plugins-filters-gro
 
 Enterprise-grade security is available across the entire delivery chain.
 
-* Wire encryption is recommended for both the transport from [Beats to Logstash](beats://docs/reference/filebeat/configuring-ssl-logstash.md) and from [Logstash to Elasticsearch](/reference/secure-connection.md).
+* Wire encryption is recommended for both the transport from [Beats to Logstash](beats://reference/filebeat/configuring-ssl-logstash.md) and from [Logstash to Elasticsearch](/reference/secure-connection.md).
 * There’s a wealth of security options when communicating with Elasticsearch including basic authentication, TLS, PKI, LDAP, AD, and other custom realms. To enable Elasticsearch security, see [Secure a cluster](docs-content://deploy-manage/security.md).
 
 

--- a/docs/reference/ecs-ls.md
+++ b/docs/reference/ecs-ls.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # ECS in Logstash [ecs-ls]
 
-The [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) is an open source specification, developed with support from the Elastic user community. ECS defines a common set of fields to be used for storing event data, such as logs and metrics, in {{es}}. With ECS, users can normalize event data to better analyze, visualize, and correlate the data represented in their events.
+The [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) is an open source specification, developed with support from the Elastic user community. ECS defines a common set of fields to be used for storing event data, such as logs and metrics, in {{es}}. With ECS, users can normalize event data to better analyze, visualize, and correlate the data represented in their events.
 
 ## ECS compatibility [ecs-compatibility]
 

--- a/docs/reference/ls-to-ls-http.md
+++ b/docs/reference/ls-to-ls-http.md
@@ -67,7 +67,7 @@ It is important that you secure the communication between Logstash instances. Us
 1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
     ::::{tip}
-    We recommend you use the [elasticsearch-certutil](elasticsearch://docs/reference/elasticsearch/command-line-tools/certutil.md) tool to generate your certificates.
+    We recommend you use the [elasticsearch-certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) tool to generate your certificates.
     ::::
 
 2. Configure the downstream (receiving) Logstash to use SSL. Add these settings to the HTTP Input configuration:

--- a/docs/reference/ls-to-ls-native.md
+++ b/docs/reference/ls-to-ls-native.md
@@ -62,7 +62,7 @@ It is important that you secure the communication between Logstash instances. Us
 1. Create a certificate authority (CA) in order to sign the certificates that you plan to use between Logstash instances. Creating a correct SSL/TLS infrastructure is outside the scope of this document.
 
     ::::{tip}
-    We recommend you use the [elasticsearch-certutil](elasticsearch://docs/reference/elasticsearch/command-line-tools/certutil.md) tool to generate your certificates.
+    We recommend you use the [elasticsearch-certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) tool to generate your certificates.
     ::::
 
 2. Configure the downstream (receiving) Logstash to use SSL. Add these settings to the Logstash input configuration:

--- a/docs/reference/monitoring-with-elastic-agent.md
+++ b/docs/reference/monitoring-with-elastic-agent.md
@@ -50,7 +50,7 @@ monitoring.cluster_uuid: PRODUCTION_ES_CLUSTER_UUID
 ::::{dropdown} Create a monitoring user (standalone agent only)
 :name: create-user-ea
 
-Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://docs/reference/elasticsearch/roles.md).
+Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
 
 ::::
 

--- a/docs/reference/monitoring-with-metricbeat.md
+++ b/docs/reference/monitoring-with-metricbeat.md
@@ -44,7 +44,7 @@ Refer to [{{es}} cluster stats page](https://www.elastic.co/docs/api/doc/elastic
 
 ## Install and configure {{metricbeat}} [configure-metricbeat]
 
-1. [Install {{metricbeat}}](beats://docs/reference/metricbeat/metricbeat-installation-configuration.md) on the same server as {{ls}}.
+1. [Install {{metricbeat}}](beats://reference/metricbeat/metricbeat-installation-configuration.md) on the same server as {{ls}}.
 2. Enable the `logstash-xpack` module in {{metricbeat}}.<br>
 
     To enable the default configuration in the {{metricbeat}} `modules.d` directory, run:
@@ -67,7 +67,7 @@ Refer to [{{es}} cluster stats page](https://www.elastic.co/docs/api/doc/elastic
     PS > .\metricbeat.exe modules enable logstash-xpack
     ```
 
-    For more information, see [Specify which modules to run](beats://docs/reference/metricbeat/configuration-metricbeat.md) and [beat module](beats://docs/reference/metricbeat/metricbeat-module-beat.md).
+    For more information, see [Specify which modules to run](beats://reference/metricbeat/configuration-metricbeat.md) and [beat module](beats://reference/metricbeat/metricbeat-module-beat.md).
 
 3. Configure the `logstash-xpack` module in {{metricbeat}}.<br>
 
@@ -97,12 +97,12 @@ Refer to [{{es}} cluster stats page](https://www.elastic.co/docs/api/doc/elastic
 
     **Elastic security.** The Elastic {{security-features}} are enabled by default. You must provide a user ID and password so that {{metricbeat}} can collect metrics successfully:
 
-    1. Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://docs/reference/elasticsearch/roles.md).
+    1. Create a user on the production cluster that has the `remote_monitoring_collector` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
     2. Add the `username` and `password` settings to the module configuration file (`logstash-xpack.yml`).
 
 4. Optional: Disable the system module in the {{metricbeat}}.
 
-    By default, the [system module](beats://docs/reference/metricbeat/metricbeat-module-system.md) is enabled. The information it collects, however, is not shown on the **Stack Monitoring** page in {{kib}}. Unless you want to use that information for other purposes, run the following command:
+    By default, the [system module](beats://reference/metricbeat/metricbeat-module-system.md) is enabled. The information it collects, however, is not shown on the **Stack Monitoring** page in {{kib}}. Unless you want to use that information for other purposes, run the following command:
 
     ```sh
     metricbeat modules disable system
@@ -140,7 +140,7 @@ Refer to [{{es}} cluster stats page](https://www.elastic.co/docs/api/doc/elastic
 
     **Elastic security.** The Elastic {{security-features}} are enabled by default. You must provide a user ID and password so that {{metricbeat}} can send metrics successfully:
 
-    1. Create a user on the monitoring cluster that has the `remote_monitoring_agent` [built-in role](elasticsearch://docs/reference/elasticsearch/roles.md). Alternatively, use the `remote_monitoring_user` [built-in user](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md).
+    1. Create a user on the monitoring cluster that has the `remote_monitoring_agent` [built-in role](elasticsearch://reference/elasticsearch/roles.md). Alternatively, use the `remote_monitoring_user` [built-in user](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md).
 
         ::::{tip}
         If you’re using index lifecycle management, the remote monitoring user requires additional privileges to create and read indices. For more information, see `<<feature-roles>>`.
@@ -148,9 +148,9 @@ Refer to [{{es}} cluster stats page](https://www.elastic.co/docs/api/doc/elastic
 
     2. Add the `username` and `password` settings to the {{es}} output information in the {{metricbeat}} configuration file.
 
-    For more information about these configuration options, see [Configure the {{es}} output](beats://docs/reference/metricbeat/elasticsearch-output.md).
+    For more information about these configuration options, see [Configure the {{es}} output](beats://reference/metricbeat/elasticsearch-output.md).
 
-6. [Start {{metricbeat}}](beats://docs/reference/metricbeat/metricbeat-starting.md) to begin collecting monitoring data.
+6. [Start {{metricbeat}}](beats://reference/metricbeat/metricbeat-starting.md) to begin collecting monitoring data.
 7. [View the monitoring data in {{kib}}](docs-content://deploy-manage/monitor/stack-monitoring/kibana-monitoring-data.md).
 
 Your monitoring setup is complete.

--- a/docs/reference/plugins-codecs-avro.md
+++ b/docs/reference/plugins-codecs-avro.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-16
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-avro/blob/v3.4.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-avro-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-avro-index.md).
 
 ## Getting help [_getting_help_172]
 
@@ -90,7 +90,7 @@ output {
     * `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `encoding` [plugins-codecs-avro-encoding]

--- a/docs/reference/plugins-codecs-cef.md
+++ b/docs/reference/plugins-codecs-cef.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-10-22
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-cef/blob/v6.2.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-cef-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-cef-index.md).
 
 ## Getting help [_getting_help_173]
 
@@ -425,7 +425,7 @@ If the codec handles data from a variety of sources, the ECS recommendation is t
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `fields` [plugins-codecs-cef-fields]

--- a/docs/reference/plugins-codecs-cloudfront.md
+++ b/docs/reference/plugins-codecs-cloudfront.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-cloudfront-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-cloudfront-index.md).
 
 ## Getting help [_getting_help_174]
 

--- a/docs/reference/plugins-codecs-cloudtrail.md
+++ b/docs/reference/plugins-codecs-cloudtrail.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-cloudtrail-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-cloudtrail-index.md).
 
 ## Getting help [_getting_help_175]
 

--- a/docs/reference/plugins-codecs-collectd.md
+++ b/docs/reference/plugins-codecs-collectd.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-collectd/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-collectd-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-collectd-index.md).
 
 ## Getting help [_getting_help_176]
 

--- a/docs/reference/plugins-codecs-csv.md
+++ b/docs/reference/plugins-codecs-csv.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-07-28
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-csv/blob/v1.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-csv-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-csv-index.md).
 
 ## Installation [_installation_68]
 
@@ -122,7 +122,7 @@ Define a set of datatype conversions to be applied to columns. Possible conversi
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `include_headers` [plugins-codecs-csv-include_headers]

--- a/docs/reference/plugins-codecs-dots.md
+++ b/docs/reference/plugins-codecs-dots.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-dots/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-dots-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-dots-index.md).
 
 ## Getting help [_getting_help_178]
 

--- a/docs/reference/plugins-codecs-edn.md
+++ b/docs/reference/plugins-codecs-edn.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-edn/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-edn-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-edn-index.md).
 
 ## Getting help [_getting_help_179]
 

--- a/docs/reference/plugins-codecs-edn_lines.md
+++ b/docs/reference/plugins-codecs-edn_lines.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-edn_lines/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-edn_lines-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-edn_lines-index.md).
 
 ## Getting help [_getting_help_180]
 

--- a/docs/reference/plugins-codecs-es_bulk.md
+++ b/docs/reference/plugins-codecs-es_bulk.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-19
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-es_bulk/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-es_bulk-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-es_bulk-index.md).
 
 ## Getting help [_getting_help_181]
 
@@ -53,7 +53,7 @@ When ECS compatibility is disabled, the metadata is stored in the `[@metadata]` 
     * `v1`: uses `[@metadata][codec][es_bulk]` fields
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `target` [plugins-codecs-es_bulk-target]

--- a/docs/reference/plugins-codecs-fluent.md
+++ b/docs/reference/plugins-codecs-fluent.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-06-25
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-fluent/blob/v3.4.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-fluent-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-fluent-index.md).
 
 ## Getting help [_getting_help_182]
 

--- a/docs/reference/plugins-codecs-graphite.md
+++ b/docs/reference/plugins-codecs-graphite.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-12
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-graphite/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-graphite-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-graphite-index.md).
 
 ## Getting help [_getting_help_183]
 

--- a/docs/reference/plugins-codecs-gzip_lines.md
+++ b/docs/reference/plugins-codecs-gzip_lines.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-07-23
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-gzip_lines/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-gzip_lines-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-gzip_lines-index.md).
 
 ## Installation [_installation_69]
 

--- a/docs/reference/plugins-codecs-json.md
+++ b/docs/reference/plugins-codecs-json.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-10-03
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-json/blob/v3.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-json-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-json-index.md).
 
 ## Getting help [_getting_help_188]
 
@@ -65,7 +65,7 @@ For nxlog users, you may to set this to "CP1252".
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `target` [plugins-codecs-json-target]

--- a/docs/reference/plugins-codecs-json_lines.md
+++ b/docs/reference/plugins-codecs-json_lines.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-09-06
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-json_lines/blob/v3.2.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-json_lines-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-json_lines-index.md).
 
 ## Getting help [_getting_help_189]
 
@@ -77,7 +77,7 @@ Change the delimiter that separates lines
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `target` [plugins-codecs-json_lines-target]

--- a/docs/reference/plugins-codecs-line.md
+++ b/docs/reference/plugins-codecs-line.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-07-15
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-line/blob/v3.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-line-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-line-index.md).
 
 ## Getting help [_getting_help_190]
 
@@ -31,7 +31,7 @@ Encoding behavior
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-codecs-line-ecs]
 
-This plugin is compatible with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). No additional configuration is required.
+This plugin is compatible with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). No additional configuration is required.
 
 
 ## Line codec configuration options [plugins-codecs-line-options]

--- a/docs/reference/plugins-codecs-msgpack.md
+++ b/docs/reference/plugins-codecs-msgpack.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-09
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-msgpack/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-msgpack-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-msgpack-index.md).
 
 ## Getting help [_getting_help_191]
 

--- a/docs/reference/plugins-codecs-multiline.md
+++ b/docs/reference/plugins-codecs-multiline.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-04-25
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-multiline/blob/v3.1.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-multiline-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-multiline-index.md).
 
 ## Getting help [_getting_help_192]
 
@@ -149,7 +149,7 @@ This only affects "plain" format logs since JSON is `UTF-8` already.
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `max_bytes` [plugins-codecs-multiline-max_bytes]

--- a/docs/reference/plugins-codecs-netflow.md
+++ b/docs/reference/plugins-codecs-netflow.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-12-22
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.3.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-netflow-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-netflow-index.md).
 
 ## Getting help [_getting_help_193]
 

--- a/docs/reference/plugins-codecs-nmap.md
+++ b/docs/reference/plugins-codecs-nmap.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-11-16
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-nmap/blob/v0.0.22/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-nmap-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-nmap-index.md).
 
 ## Installation [_installation_70]
 

--- a/docs/reference/plugins-codecs-plain.md
+++ b/docs/reference/plugins-codecs-plain.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-07-27
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-plain/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-plain-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-plain-index.md).
 
 ## Getting help [_getting_help_195]
 
@@ -61,7 +61,7 @@ This only affects "plain" format logs since json is `UTF-8` already.
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `format` [plugins-codecs-plain-format]

--- a/docs/reference/plugins-codecs-protobuf.md
+++ b/docs/reference/plugins-codecs-protobuf.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-09-20
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-protobuf/blob/v1.3.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-protobuf-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-protobuf-index.md).
 
 ## Installation [_installation_71]
 

--- a/docs/reference/plugins-codecs-rubydebug.md
+++ b/docs/reference/plugins-codecs-rubydebug.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-07-08
 * [Changelog](https://github.com/logstash-plugins/logstash-codec-rubydebug/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/codec-rubydebug-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/codec-rubydebug-index.md).
 
 ## Getting help [_getting_help_197]
 

--- a/docs/reference/plugins-filters-age.md
+++ b/docs/reference/plugins-filters-age.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-10-29
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-age/blob/v1.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-age-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-age-index.md).
 
 ## Installation [_installation_54]
 

--- a/docs/reference/plugins-filters-aggregate.md
+++ b/docs/reference/plugins-filters-aggregate.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-10-11
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-aggregate/blob/v2.10.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-aggregate-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-aggregate-index.md).
 
 ## Getting help [_getting_help_124]
 

--- a/docs/reference/plugins-filters-alter.md
+++ b/docs/reference/plugins-filters-alter.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-alter/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-alter-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-alter-index.md).
 
 ## Installation [_installation_55]
 

--- a/docs/reference/plugins-filters-bytes.md
+++ b/docs/reference/plugins-filters-bytes.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-08-18
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-bytes/blob/v1.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-bytes-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-bytes-index.md).
 
 ## Installation [_installation_56]
 

--- a/docs/reference/plugins-filters-cidr.md
+++ b/docs/reference/plugins-filters-cidr.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-09-18
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-cidr/blob/v3.1.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-cidr-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-cidr-index.md).
 
 ## Getting help [_getting_help_127]
 

--- a/docs/reference/plugins-filters-cipher.md
+++ b/docs/reference/plugins-filters-cipher.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-06-21
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-cipher/blob/v4.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-cipher-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-cipher-index.md).
 
 ## Installation [_installation_57]
 

--- a/docs/reference/plugins-filters-clone.md
+++ b/docs/reference/plugins-filters-clone.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-11-10
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-clone/blob/v4.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-clone-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-clone-index.md).
 
 ## Getting help [_getting_help_129]
 
@@ -72,7 +72,7 @@ Note: setting an empty array will not create any clones. A warning message is lo
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the behavior of the [`clones`](#plugins-filters-clone-clones)
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the behavior of the [`clones`](#plugins-filters-clone-clones)
 
 Example:
 

--- a/docs/reference/plugins-filters-csv.md
+++ b/docs/reference/plugins-filters-csv.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-06-08
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-csv/blob/v3.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-csv-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-csv-index.md).
 
 ## Getting help [_getting_help_130]
 
@@ -112,7 +112,7 @@ Example:
     * `v1`: uses the value in `target` as field name
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-csv-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-csv-ecs_metadata) for detailed information.
 
 
 ### `quote_char` [plugins-filters-csv-quote_char]

--- a/docs/reference/plugins-filters-date.md
+++ b/docs/reference/plugins-filters-date.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-06-29
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-date/blob/v3.1.15/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-date-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-date-index.md).
 
 ## Getting help [_getting_help_131]
 

--- a/docs/reference/plugins-filters-de_dot.md
+++ b/docs/reference/plugins-filters-de_dot.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-05-27
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-de_dot/blob/v1.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-de_dot-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-de_dot-index.md).
 
 ## Getting help [_getting_help_132]
 

--- a/docs/reference/plugins-filters-dissect.md
+++ b/docs/reference/plugins-filters-dissect.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-02-14
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-dissect/blob/v1.2.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-dissect-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-dissect-index.md).
 
 ## Getting help [_getting_help_133]
 

--- a/docs/reference/plugins-filters-dns.md
+++ b/docs/reference/plugins-filters-dns.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-01-26
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-dns/blob/v3.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-dns-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-dns-index.md).
 
 ## Getting help [_getting_help_134]
 

--- a/docs/reference/plugins-filters-drop.md
+++ b/docs/reference/plugins-filters-drop.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-drop/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-drop-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-drop-index.md).
 
 ## Getting help [_getting_help_135]
 

--- a/docs/reference/plugins-filters-elapsed.md
+++ b/docs/reference/plugins-filters-elapsed.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-07-31
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-elapsed/blob/v4.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-elapsed-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-elapsed-index.md).
 
 ## Installation [_installation_58]
 

--- a/docs/reference/plugins-filters-elastic_integration.md
+++ b/docs/reference/plugins-filters-elastic_integration.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-08
 * [Changelog](https://github.com/elastic/logstash-filter-elastic_integration/blob/v8.17.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-elastic_integration-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-elastic_integration-index.md).
 
 ## Getting help [_getting_help_137]
 
@@ -29,7 +29,7 @@ Use of this plugin requires an active Elastic Enterprise [subscription](https://
 Use this filter to process Elastic integrations powered by {{es}} Ingest Node in {{ls}}.
 
 ::::{admonition} Extending Elastic integrations with {ls}
-This plugin can help you take advantage of the extensive, built-in capabilities of [Elastic {{integrations}}](integration-docs://docs/reference/index.md)—​such as managing data collection, transformation, and visualization—​and then use {{ls}} for additional data processing and output options. For more info about extending Elastic integrations with {{ls}}, check out [Using {{ls}} with Elastic Integrations](/reference/using-logstash-with-elastic-integrations.md).
+This plugin can help you take advantage of the extensive, built-in capabilities of [Elastic {{integrations}}](integration-docs://reference/index.md)—​such as managing data collection, transformation, and visualization—​and then use {{ls}} for additional data processing and output options. For more info about extending Elastic integrations with {{ls}}, check out [Using {{ls}} with Elastic Integrations](/reference/using-logstash-with-elastic-integrations.md).
 
 ::::
 
@@ -185,7 +185,7 @@ This filter can run {{es}} Ingest Node pipelines that are *wholly* comprised of 
 | `uppercase` | *none* |
 | `uri_parts` | *none* |
 | `urldecode` | *none* |
-| `user_agent` | side-loading a custom regex file is not supported; the processor will use the default user agent definitions as specified in [Elasticsearch processor definition](elasticsearch://docs/reference/ingestion-tools/enrich-processor/user-agent-processor.md) |
+| `user_agent` | side-loading a custom regex file is not supported; the processor will use the default user agent definitions as specified in [Elasticsearch processor definition](elasticsearch://reference/ingestion-tools/enrich-processor/user-agent-processor.md) |
 | Redact | `redact` | *none* |
 | GeoIp | `geoip` | requires MaxMind GeoIP2 databases, which may be provided by Logstash’s Geoip Database Management *OR* configured using [`geoip_database_directory`](#plugins-filters-elastic_integration-geoip_database_directory) |
 

--- a/docs/reference/plugins-filters-elasticsearch.md
+++ b/docs/reference/plugins-filters-elasticsearch.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-10
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-elasticsearch/blob/v4.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-elasticsearch-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-elasticsearch-index.md).
 
 ## Getting help [_getting_help_138]
 
@@ -290,7 +290,7 @@ Set the address of a forward HTTP proxy. An empty string is treated as if proxy 
 * Value type is [string](/reference/configuration-file-structure.md#string)
 * There is no default value for this setting.
 
-Elasticsearch query string. More information is available in the [Elasticsearch query string documentation](elasticsearch://docs/reference/query-languages/query-dsl-query-string-query.md#query-string-syntax). Use either `query` or `query_template`.
+Elasticsearch query string. More information is available in the [Elasticsearch query string documentation](elasticsearch://reference/query-languages/query-dsl-query-string-query.md#query-string-syntax). Use either `query` or `query_template`.
 
 
 ### `query_template` [plugins-filters-elasticsearch-query_template]
@@ -298,7 +298,7 @@ Elasticsearch query string. More information is available in the [Elasticsearch 
 * Value type is [string](/reference/configuration-file-structure.md#string)
 * There is no default value for this setting.
 
-File path to elasticsearch query in DSL format. More information is available in the [Elasticsearch query documentation](elasticsearch://docs/reference/query-languages/querydsl.md). Use either `query` or `query_template`.
+File path to elasticsearch query in DSL format. More information is available in the [Elasticsearch query documentation](elasticsearch://reference/query-languages/querydsl.md). Use either `query` or `query_template`.
 
 
 ### `result_size` [plugins-filters-elasticsearch-result_size]

--- a/docs/reference/plugins-filters-environment.md
+++ b/docs/reference/plugins-filters-environment.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-environment/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-environment-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-environment-index.md).
 
 ## Installation [_installation_59]
 

--- a/docs/reference/plugins-filters-extractnumbers.md
+++ b/docs/reference/plugins-filters-extractnumbers.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-extractnumbers/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-extractnumbers-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-extractnumbers-index.md).
 
 ## Installation [_installation_60]
 

--- a/docs/reference/plugins-filters-fingerprint.md
+++ b/docs/reference/plugins-filters-fingerprint.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-03-19
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-fingerprint/blob/v3.4.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-fingerprint-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-fingerprint-index.md).
 
 ## Getting help [_getting_help_141]
 
@@ -135,7 +135,7 @@ When set to `true` and `method` isn’t `UUID` or `PUNCTUATION`, the plugin conc
     * `v1`: uses `[event][hash]` fields that are compatible with Elastic Common Schema
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-fingerprint-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-fingerprint-ecs_metadata) for detailed information.
 
 
 ### `key` [plugins-filters-fingerprint-key]

--- a/docs/reference/plugins-filters-geoip.md
+++ b/docs/reference/plugins-filters-geoip.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-10-11
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-geoip/blob/v7.3.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-geoip-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-geoip-index.md).
 
 ## Getting help [_getting_help_142]
 
@@ -210,7 +210,7 @@ When this plugin is run with [`ecs_compatibility`](#plugins-filters-geoip-ecs_co
 
 When using a City database, the enrichment is aborted if no latitude/longitude pair is available.
 
-The `location` field combines the latitude and longitude into a structure called [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946). When you are using a default [`target`](#plugins-filters-geoip-target), the templates provided by the [elasticsearch output](/reference/plugins-outputs-elasticsearch.md) map the field to an [Elasticsearch Geo_point datatype](elasticsearch://docs/reference/elasticsearch/mapping-reference/geo-point.md).
+The `location` field combines the latitude and longitude into a structure called [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946). When you are using a default [`target`](#plugins-filters-geoip-target), the templates provided by the [elasticsearch output](/reference/plugins-outputs-elasticsearch.md) map the field to an [Elasticsearch Geo_point datatype](elasticsearch://reference/elasticsearch/mapping-reference/geo-point.md).
 
 As this field is a `geo_point` *and* it is still valid GeoJSON, you get the awesomeness of Elasticsearch’s geospatial query, facet and filter functions and the flexibility of having GeoJSON for all other applications (like Kibana’s map visualization).
 
@@ -299,7 +299,7 @@ For a complete list of available fields and how they map to an event’s structu
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-geoip-target).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-geoip-target).
 
 
 ### `source` [plugins-filters-geoip-source]

--- a/docs/reference/plugins-filters-grok.md
+++ b/docs/reference/plugins-filters-grok.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-10-28
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-grok/blob/v4.4.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-grok-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-grok-index.md).
 
 ## Getting help [_getting_help_143]
 
@@ -158,7 +158,7 @@ Another option is to define patterns *inline* in the filter using `pattern_defin
 
 ## Migrating to Elastic Common Schema (ECS) [plugins-filters-grok-ecs]
 
-To ease migration to the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)), the filter plugin offers a new set of ECS-compliant patterns in addition to the existing patterns. The new ECS pattern definitions capture event field names that are compliant with the schema.
+To ease migration to the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)), the filter plugin offers a new set of ECS-compliant patterns in addition to the existing patterns. The new ECS pattern definitions capture event field names that are compliant with the schema.
 
 The ECS pattern set has all of the pattern definitions from the legacy set, and is a drop-in replacement. Use the [`ecs_compatibility`](#plugins-filters-grok-ecs_compatibility) setting to switch modes.
 
@@ -211,7 +211,7 @@ Break on first match. The first successful match by grok will result in the filt
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects extracted event field names when a composite pattern (such as `HTTPD_COMMONLOG`) is matched.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects extracted event field names when a composite pattern (such as `HTTPD_COMMONLOG`) is matched.
 
 
 ### `keep_empty_captures` [plugins-filters-grok-keep_empty_captures]

--- a/docs/reference/plugins-filters-http.md
+++ b/docs/reference/plugins-filters-http.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-18
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-http/blob/v2.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-http-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-http-index.md).
 
 ## Getting help [_getting_help_144]
 
@@ -126,7 +126,7 @@ If set to `"json"` and the [`body`](#plugins-filters-http-body) is a type of [ar
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`target_body`](#plugins-filters-http-target_body) and [`target_headers`](#plugins-filters-http-target_headers).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`target_body`](#plugins-filters-http-target_body) and [`target_headers`](#plugins-filters-http-target_headers).
 
 
 ### `headers` [plugins-filters-http-headers]

--- a/docs/reference/plugins-filters-i18n.md
+++ b/docs/reference/plugins-filters-i18n.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-i18n/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-i18n-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-i18n-index.md).
 
 ## Installation [_installation_61]
 

--- a/docs/reference/plugins-filters-jdbc_static.md
+++ b/docs/reference/plugins-filters-jdbc_static.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-12-23
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.5.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-jdbc_static-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-jdbc_static-index.md).
 
 ## Getting help [_getting_help_147]
 
@@ -240,7 +240,7 @@ For loader performance reasons, the loading mechanism uses a CSV style file with
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-filters-jdbc_static-ecs]
 
-This plugin is compatible with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). It behaves the same regardless of ECS compatibility, except giving a warning when ECS is enabled and `target` isn’t set.
+This plugin is compatible with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). It behaves the same regardless of ECS compatibility, except giving a warning when ECS is enabled and `target` isn’t set.
 
 ::::{tip}
 Set the `target` option to avoid potential schema conflicts.

--- a/docs/reference/plugins-filters-jdbc_streaming.md
+++ b/docs/reference/plugins-filters-jdbc_streaming.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-12-23
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.5.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-jdbc_streaming-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-jdbc_streaming-index.md).
 
 ## Getting help [_getting_help_148]
 

--- a/docs/reference/plugins-filters-json.md
+++ b/docs/reference/plugins-filters-json.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-12-18
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-json/blob/v3.2.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-json-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-json-index.md).
 
 ## Getting help [_getting_help_149]
 
@@ -64,7 +64,7 @@ Also see [Common options](#plugins-filters-json-common-options) for a list of op
     * `v1`: Elastic Common Schema compliant behavior (warns when `target` isn’t set)
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-json-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-json-ecs_metadata) for detailed information.
 
 
 ### `skip_on_invalid_json` [plugins-filters-json-skip_on_invalid_json]

--- a/docs/reference/plugins-filters-json_encode.md
+++ b/docs/reference/plugins-filters-json_encode.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-json_encode/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-json_encode-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-json_encode-index.md).
 
 ## Installation [_installation_62]
 

--- a/docs/reference/plugins-filters-kv.md
+++ b/docs/reference/plugins-filters-kv.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-03-04
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-kv/blob/v4.7.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-kv-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-kv-index.md).
 
 ## Getting help [_getting_help_151]
 
@@ -143,7 +143,7 @@ A hash specifying the default keys and their values which should be added to the
     * `v1`: Elastic Common Schema compliant behavior (warns when `target` isn’t set)
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-kv-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-filters-kv-ecs_metadata) for detailed information.
 
 
 ### `exclude_keys` [plugins-filters-kv-exclude_keys]

--- a/docs/reference/plugins-filters-memcached.md
+++ b/docs/reference/plugins-filters-memcached.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-01-18
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-memcached/blob/v1.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-memcached-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-memcached-index.md).
 
 ## Getting help [_getting_help_152]
 

--- a/docs/reference/plugins-filters-metricize.md
+++ b/docs/reference/plugins-filters-metricize.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-metricize/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-metricize-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-metricize-index.md).
 
 ## Installation [_installation_63]
 

--- a/docs/reference/plugins-filters-metrics.md
+++ b/docs/reference/plugins-filters-metrics.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-01-20
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-metrics/blob/v4.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-metrics-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-metrics-index.md).
 
 ## Getting help [_getting_help_154]
 

--- a/docs/reference/plugins-filters-mutate.md
+++ b/docs/reference/plugins-filters-mutate.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-11-22
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-mutate/blob/v3.5.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-mutate-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-mutate-index.md).
 
 ## Getting help [_getting_help_155]
 

--- a/docs/reference/plugins-filters-prune.md
+++ b/docs/reference/plugins-filters-prune.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-09-12
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-prune/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-prune-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-prune-index.md).
 
 ## Getting help [_getting_help_156]
 

--- a/docs/reference/plugins-filters-range.md
+++ b/docs/reference/plugins-filters-range.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-range/blob/v3.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-range-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-range-index.md).
 
 ## Installation [_installation_64]
 

--- a/docs/reference/plugins-filters-ruby.md
+++ b/docs/reference/plugins-filters-ruby.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-01-24
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-ruby/blob/v3.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-ruby-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-ruby-index.md).
 
 ## Getting help [_getting_help_158]
 

--- a/docs/reference/plugins-filters-sleep.md
+++ b/docs/reference/plugins-filters-sleep.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-09-04
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-sleep/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-sleep-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-sleep-index.md).
 
 ## Getting help [_getting_help_159]
 

--- a/docs/reference/plugins-filters-split.md
+++ b/docs/reference/plugins-filters-split.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-01-21
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-split/blob/v3.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-split-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-split-index.md).
 
 ## Getting help [_getting_help_160]
 

--- a/docs/reference/plugins-filters-syslog_pri.md
+++ b/docs/reference/plugins-filters-syslog_pri.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-01-17
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-syslog_pri/blob/v3.2.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-syslog_pri-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-syslog_pri-index.md).
 
 ## Getting help [_getting_help_161]
 
@@ -55,7 +55,7 @@ Also see [Common options](#plugins-filters-syslog_pri-common-options) for a list
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`syslog_pri_field_name`](#plugins-filters-syslog_pri-syslog_pri_field_name).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`syslog_pri_field_name`](#plugins-filters-syslog_pri-syslog_pri_field_name).
 
 
 ### `facility_labels` [plugins-filters-syslog_pri-facility_labels]

--- a/docs/reference/plugins-filters-throttle.md
+++ b/docs/reference/plugins-filters-throttle.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-throttle/blob/v4.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-throttle-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-throttle-index.md).
 
 ## Getting help [_getting_help_163]
 

--- a/docs/reference/plugins-filters-tld.md
+++ b/docs/reference/plugins-filters-tld.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-19
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-tld/blob/v3.1.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-tld-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-tld-index.md).
 
 ## Installation [_installation_66]
 

--- a/docs/reference/plugins-filters-translate.md
+++ b/docs/reference/plugins-filters-translate.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-06-14
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-translate/blob/v3.4.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-translate-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-translate-index.md).
 
 ## Getting help [_getting_help_165]
 
@@ -168,7 +168,7 @@ The currently supported formats are YAML, JSON, and CSV. Format selection is bas
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-translate-target).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-translate-target).
 
 
 ### `exact` [plugins-filters-translate-exact]

--- a/docs/reference/plugins-filters-truncate.md
+++ b/docs/reference/plugins-filters-truncate.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-10
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-truncate/blob/v1.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-truncate-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-truncate-index.md).
 
 ## Getting help [_getting_help_166]
 

--- a/docs/reference/plugins-filters-urldecode.md
+++ b/docs/reference/plugins-filters-urldecode.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-urldecode/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-urldecode-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-urldecode-index.md).
 
 ## Getting help [_getting_help_167]
 

--- a/docs/reference/plugins-filters-useragent.md
+++ b/docs/reference/plugins-filters-useragent.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-09-19
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-useragent/blob/v3.3.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-useragent-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-useragent-index.md).
 
 ## Getting help [_getting_help_168]
 
@@ -127,7 +127,7 @@ Also see [Common options](#plugins-filters-useragent-common-options) for a list 
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-useragent-target).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`target`](#plugins-filters-useragent-target).
 
 
 ### `lru_cache_size` [plugins-filters-useragent-lru_cache_size]

--- a/docs/reference/plugins-filters-uuid.md
+++ b/docs/reference/plugins-filters-uuid.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-uuid/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-uuid-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-uuid-index.md).
 
 ## Getting help [_getting_help_169]
 

--- a/docs/reference/plugins-filters-xml.md
+++ b/docs/reference/plugins-filters-xml.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-10-29
 * [Changelog](https://github.com/logstash-plugins/logstash-filter-xml/blob/v4.2.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/filter-xml-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/filter-xml-index.md).
 
 ## Getting help [_getting_help_171]
 

--- a/docs/reference/plugins-inputs-azure_event_hubs.md
+++ b/docs/reference/plugins-inputs-azure_event_hubs.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-03
 * [Changelog](https://github.com/logstash-plugins/logstash-input-azure_event_hubs/blob/v1.5.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-azure_event_hubs-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-azure_event_hubs-index.md).
 
 ## Getting help [_getting_help_8]
 

--- a/docs/reference/plugins-inputs-beats.md
+++ b/docs/reference/plugins-inputs-beats.md
@@ -16,7 +16,7 @@ The `input-elastic_agent` plugin is the next generation of the `input-beats` plu
 * Released on: 2024-12-02
 * [Changelog](https://github.com/logstash-plugins/logstash-input-beats/blob/v7.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-beats-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-beats-index.md).
 
 ## Getting help [_getting_help_9]
 
@@ -66,7 +66,7 @@ Be sure that heap and direct memory combined does not exceed the total memory av
 
 ### Multi-line events [plugins-inputs-beats-multiline]
 
-If you are shipping events that span multiple lines, you need to use the [configuration options available in Filebeat](beats://docs/reference/filebeat/multiline-examples.md) to handle multiline events before sending the event data to Logstash. You cannot use the [Multiline codec plugin](/reference/plugins-codecs-multiline.md) to handle multiline events. Doing so will result in the failure to start Logstash.
+If you are shipping events that span multiple lines, you need to use the [configuration options available in Filebeat](beats://reference/filebeat/multiline-examples.md) to handle multiline events before sending the event data to Logstash. You cannot use the [Multiline codec plugin](/reference/plugins-codecs-multiline.md) to handle multiline events. Doing so will result in the failure to start Logstash.
 
 
 

--- a/docs/reference/plugins-inputs-cloudwatch.md
+++ b/docs/reference/plugins-inputs-cloudwatch.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-cloudwatch-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-cloudwatch-index.md).
 
 ## Getting help [_getting_help_10]
 

--- a/docs/reference/plugins-inputs-couchdb_changes.md
+++ b/docs/reference/plugins-inputs-couchdb_changes.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-04-15
 * [Changelog](https://github.com/logstash-plugins/logstash-input-couchdb_changes/blob/v3.1.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-couchdb_changes-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-couchdb_changes-index.md).
 
 ## Getting help [_getting_help_11]
 

--- a/docs/reference/plugins-inputs-dead_letter_queue.md
+++ b/docs/reference/plugins-inputs-dead_letter_queue.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-09-04
 * [Changelog](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/blob/v2.0.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-dead_letter_queue-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-dead_letter_queue-index.md).
 
 ## Getting help [_getting_help_12]
 

--- a/docs/reference/plugins-inputs-elastic_agent.md
+++ b/docs/reference/plugins-inputs-elastic_agent.md
@@ -16,7 +16,7 @@ The `input-elastic_agent` plugin is the next generation of the `input-beats` plu
 * Released on: 2024-12-02
 * [Changelog](https://github.com/logstash-plugins/logstash-input-beats/blob/v7.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-elastic_agent-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-elastic_agent-index.md).
 
 ## Getting help [_getting_help_13]
 

--- a/docs/reference/plugins-inputs-elastic_serverless_forwarder.md
+++ b/docs/reference/plugins-inputs-elastic_serverless_forwarder.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-23
 * [Changelog](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/blob/v2.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-elastic_serverless_forwarder-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-elastic_serverless_forwarder-index.md).
 
 ## Getting help [_getting_help_14]
 

--- a/docs/reference/plugins-inputs-elasticsearch.md
+++ b/docs/reference/plugins-inputs-elasticsearch.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-18
 * [Changelog](https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/v5.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-elasticsearch-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-elasticsearch-index.md).
 
 ## Getting help [_getting_help_15]
 
@@ -253,7 +253,7 @@ Example
 * Value type is [array](/reference/configuration-file-structure.md#array)
 * Default value is `["_index", "_type", "_id"]`
 
-If document metadata storage is requested by enabling the `docinfo` option, this option lists the metadata fields to save in the current event. See [Meta-Fields](elasticsearch://docs/reference/elasticsearch/mapping-reference/document-metadata-fields.md) in the Elasticsearch documentation for more information.
+If document metadata storage is requested by enabling the `docinfo` option, this option lists the metadata fields to save in the current event. See [Meta-Fields](elasticsearch://reference/elasticsearch/mapping-reference/document-metadata-fields.md) in the Elasticsearch documentation for more information.
 
 
 ### `docinfo_target` [plugins-inputs-elasticsearch-docinfo_target]
@@ -282,7 +282,7 @@ If document metadata storage is requested by enabling the `docinfo` option, this
     * Otherwise, the default value is `disabled`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `hosts` [plugins-inputs-elasticsearch-hosts]
@@ -298,7 +298,7 @@ List of one or more Elasticsearch hosts to use for querying. Each host can be ei
 * Value type is [string](/reference/configuration-file-structure.md#string)
 * Default value is `"logstash-*"`
 
-The index or alias to search. Check out [Multi Indices documentation](elasticsearch://docs/reference/elasticsearch/rest-apis/api-conventions.md#api-multi-index) in the Elasticsearch documentation for info on referencing multiple indices.
+The index or alias to search. Check out [Multi Indices documentation](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-multi-index) in the Elasticsearch documentation for info on referencing multiple indices.
 
 
 ### `password` [plugins-inputs-elasticsearch-password]
@@ -322,9 +322,9 @@ Set the address of a forward HTTP proxy. An empty string is treated as if proxy 
 * Value type is [string](/reference/configuration-file-structure.md#string)
 * Default value is `'{ "sort": [ "_doc" ] }'`
 
-The query to be executed. Read the [Elasticsearch query DSL documentation](elasticsearch://docs/reference/query-languages/querydsl.md) for more information.
+The query to be executed. Read the [Elasticsearch query DSL documentation](elasticsearch://reference/query-languages/querydsl.md) for more information.
 
-When [`search_api`](#plugins-inputs-elasticsearch-search_api) resolves to `search_after` and the query does not specify `sort`, the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Please refer to the [Elasticsearch search_after](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md#search-after) parameter to know more.
+When [`search_api`](#plugins-inputs-elasticsearch-search_api) resolves to `search_after` and the query does not specify `sort`, the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Please refer to the [Elasticsearch search_after](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md#search-after) parameter to know more.
 
 
 ### `response_type` [plugins-inputs-elasticsearch-response_type]
@@ -383,7 +383,7 @@ With `auto` the plugin uses the `search_after` parameter for Elasticsearch versi
 
 `search_after` uses [point in time](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time) and sort value to search. The query requires at least one `sort` field, as described in the [`query`](#plugins-inputs-elasticsearch-query) parameter.
 
-`scroll` uses [scroll](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md#scroll-search-results) API to search, which is no longer recommended.
+`scroll` uses [scroll](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md#scroll-search-results) API to search, which is no longer recommended.
 
 
 ### `size` [plugins-inputs-elasticsearch-size]
@@ -400,7 +400,7 @@ This allows you to set the maximum number of hits returned per scroll.
 * There is no default value.
 * Sensible values range from 2 to about 8.
 
-In some cases, it is possible to improve overall throughput by consuming multiple distinct slices of a query simultaneously using [sliced scrolls](elasticsearch://docs/reference/elasticsearch/rest-apis/paginate-search-results.md#slice-scroll), especially if the pipeline is spending significant time waiting on Elasticsearch to provide results.
+In some cases, it is possible to improve overall throughput by consuming multiple distinct slices of a query simultaneously using [sliced scrolls](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md#slice-scroll), especially if the pipeline is spending significant time waiting on Elasticsearch to provide results.
 
 If set, the `slices` parameter tells the plugin how many slices to divide the work into, and will produce events from the slices in parallel until all of them are done scrolling.
 

--- a/docs/reference/plugins-inputs-exec.md
+++ b/docs/reference/plugins-inputs-exec.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-06-15
 * [Changelog](https://github.com/logstash-plugins/logstash-input-exec/blob/v3.6.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-exec-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-exec-index.md).
 
 ## Getting help [_getting_help_16]
 
@@ -50,7 +50,7 @@ This will execute `echo` command every 30 seconds.
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-exec-ecs]
 
-This plugin adds metadata about the event’s source, and can be configured to do so in an [ECS-compatible](ecs://docs/reference/index.md) way with [`ecs_compatibility`](#plugins-inputs-exec-ecs_compatibility). This metadata is added after the event has been decoded by the appropriate codec, and will not overwrite existing values.
+This plugin adds metadata about the event’s source, and can be configured to do so in an [ECS-compatible](ecs://reference/index.md) way with [`ecs_compatibility`](#plugins-inputs-exec-ecs_compatibility). This metadata is added after the event has been decoded by the appropriate codec, and will not overwrite existing values.
 
 | ECS Disabled | ECS v1 , v8 | Description |
 | --- | --- | --- |
@@ -94,7 +94,7 @@ Command to run. For example, `uptime`
     * `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-exec-ecs) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-exec-ecs) for detailed information.
 
 **Sample output: ECS enabled**
 

--- a/docs/reference/plugins-inputs-file.md
+++ b/docs/reference/plugins-inputs-file.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-12-13
 * [Changelog](https://github.com/logstash-plugins/logstash-input-file/blob/v4.4.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-file-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-file-index.md).
 
 ## Getting help [_getting_help_17]
 
@@ -49,7 +49,7 @@ In the past attempts to simulate a Read mode while still assuming infinite strea
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-file-ecs]
 
-This plugin adds metadata about event’s source, and can be configured to do so in an [ECS-compatible](ecs://docs/reference/index.md) way with [`ecs_compatibility`](#plugins-inputs-file-ecs_compatibility). This metadata is added after the event has been decoded by the appropriate codec, and will never overwrite existing values.
+This plugin adds metadata about event’s source, and can be configured to do so in an [ECS-compatible](ecs://reference/index.md) way with [`ecs_compatibility`](#plugins-inputs-file-ecs_compatibility). This metadata is added after the event has been decoded by the appropriate codec, and will never overwrite existing values.
 
 | ECS Disabled | ECS `v1`, `v8` | Description |
 | --- | --- | --- |
@@ -177,7 +177,7 @@ How often we expand the filename patterns in the `path` option to discover new f
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `exclude` [plugins-inputs-file-exclude]
@@ -306,7 +306,7 @@ You may also configure multiple paths. See an example on the [Logstash configura
 * The default value for this setting is "2 weeks".
 * If a number is specified then it is interpreted as **days** and can be decimal e.g. 0.5 is 12 hours.
 
-The sincedb record now has a last active timestamp associated with it. If no changes are detected in a tracked file in the last N days its sincedb tracking record expires and will not be persisted. This option helps protect against the inode recycling problem. Filebeat has an [FAQ about inode recycling](beats://docs/reference/filebeat/inode-reuse-issue.md).
+The sincedb record now has a last active timestamp associated with it. If no changes are detected in a tracked file in the last N days its sincedb tracking record expires and will not be persisted. This option helps protect against the inode recycling problem. Filebeat has an [FAQ about inode recycling](beats://reference/filebeat/inode-reuse-issue.md).
 
 
 ### `sincedb_path` [plugins-inputs-file-sincedb_path]

--- a/docs/reference/plugins-inputs-ganglia.md
+++ b/docs/reference/plugins-inputs-ganglia.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-ganglia/blob/v3.1.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-ganglia-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-ganglia-index.md).
 
 ## Getting help [_getting_help_18]
 

--- a/docs/reference/plugins-inputs-gelf.md
+++ b/docs/reference/plugins-inputs-gelf.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-08-22
 * [Changelog](https://github.com/logstash-plugins/logstash-input-gelf/blob/v3.3.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-gelf-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-gelf-index.md).
 
 ## Getting help [_getting_help_19]
 

--- a/docs/reference/plugins-inputs-generator.md
+++ b/docs/reference/plugins-inputs-generator.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-11-04
 * [Changelog](https://github.com/logstash-plugins/logstash-input-generator/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-generator-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-generator-index.md).
 
 ## Getting help [_getting_help_20]
 
@@ -29,7 +29,7 @@ An event is generated first
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-generator-ecs]
 
-This plugin uses different field names depending on whether [ECS-compatibility](ecs://docs/reference/index.md) in enabled (see also [`ecs_compatibility`](#plugins-inputs-generator-ecs_compatibility)).
+This plugin uses different field names depending on whether [ECS-compatibility](ecs://reference/index.md) in enabled (see also [`ecs_compatibility`](#plugins-inputs-generator-ecs_compatibility)).
 
 | ECS Disabled | ECS v1, v8 | Description |
 | --- | --- | --- |
@@ -72,7 +72,7 @@ The default, `0`, means generate an unlimited number of events.
     * `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-generator-ecs) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-generator-ecs) for detailed information.
 
 **Sample output: ECS enabled**
 

--- a/docs/reference/plugins-inputs-github.md
+++ b/docs/reference/plugins-inputs-github.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-30
 * [Changelog](https://github.com/logstash-plugins/logstash-input-github/blob/v3.0.11/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-github-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-github-index.md).
 
 ## Installation [_installation]
 

--- a/docs/reference/plugins-inputs-google_cloud_storage.md
+++ b/docs/reference/plugins-inputs-google_cloud_storage.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-08-22
 * [Changelog](https://github.com/logstash-plugins/logstash-input-google_cloud_storage/blob/v0.15.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-google_cloud_storage-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-google_cloud_storage-index.md).
 
 ## Installation [_installation_2]
 

--- a/docs/reference/plugins-inputs-google_pubsub.md
+++ b/docs/reference/plugins-inputs-google_pubsub.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-10-15
 * [Changelog](https://github.com/logstash-plugins/logstash-input-google_pubsub/blob/v1.4.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-google_pubsub-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-google_pubsub-index.md).
 
 ## Installation [_installation_3]
 

--- a/docs/reference/plugins-inputs-graphite.md
+++ b/docs/reference/plugins-inputs-graphite.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-graphite/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-graphite-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-graphite-index.md).
 
 ## Getting help [_getting_help_24]
 

--- a/docs/reference/plugins-inputs-heartbeat.md
+++ b/docs/reference/plugins-inputs-heartbeat.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-input-heartbeat/blob/v3.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-heartbeat-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-heartbeat-index.md).
 
 ## Getting help [_getting_help_25]
 
@@ -78,7 +78,7 @@ How many times to iterate. This is typically used only for testing purposes.
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). Refer to [Elastic Common Schema (ECS)](#plugins-inputs-heartbeat-ecs) in this topic for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). Refer to [Elastic Common Schema (ECS)](#plugins-inputs-heartbeat-ecs) in this topic for detailed information.
 
 
 ### `interval` [plugins-inputs-heartbeat-interval]

--- a/docs/reference/plugins-inputs-http.md
+++ b/docs/reference/plugins-inputs-http.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-19
 * [Changelog](https://github.com/logstash-plugins/logstash-input-http/blob/v4.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-http-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-http-index.md).
 
 ## Getting help [_getting_help_26]
 
@@ -125,7 +125,7 @@ Apply specific codecs for specific content types. The default codec will be appl
     * `v1`,`v8`: headers added under `[@metadata][http][header]`. Some are copied to structured ECS fields `http`, `url`, `user_agent` and `host`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-http-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-http-ecs_metadata) for detailed information.
 
 **Sample output: ECS disabled**
 

--- a/docs/reference/plugins-inputs-http_poller.md
+++ b/docs/reference/plugins-inputs-http_poller.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-18
 * [Changelog](https://github.com/logstash-plugins/logstash-input-http_poller/blob/v6.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-http_poller-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-http_poller-index.md).
 
 ## Getting help [_getting_help_27]
 
@@ -188,7 +188,7 @@ Enable cookie support. With this enabled the client will persist cookies across 
     * `v1`: uses `error`, `url` and `http` fields that are compatible with Elastic Common Schema
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-http_poller-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-http_poller-ecs_metadata) for detailed information.
 
 Example output:
 

--- a/docs/reference/plugins-inputs-imap.md
+++ b/docs/reference/plugins-inputs-imap.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-03
 * [Changelog](https://github.com/logstash-plugins/logstash-input-imap/blob/v3.2.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-imap-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-imap-index.md).
 
 ## Getting help [_getting_help_28]
 
@@ -107,7 +107,7 @@ For multipart messages, use the first part that has this content-type as the eve
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`headers_target`](#plugins-inputs-imap-headers_target) and [`attachments_target`](#plugins-inputs-imap-attachments_target).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`headers_target`](#plugins-inputs-imap-headers_target) and [`attachments_target`](#plugins-inputs-imap-attachments_target).
 
 
 ### `expunge` [plugins-inputs-imap-expunge]

--- a/docs/reference/plugins-inputs-irc.md
+++ b/docs/reference/plugins-inputs-irc.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-irc/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-irc-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-irc-index.md).
 
 ## Installation [_installation_4]
 

--- a/docs/reference/plugins-inputs-jdbc.md
+++ b/docs/reference/plugins-inputs-jdbc.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-12-23
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.5.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-jdbc-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-jdbc-index.md).
 
 ## Getting help [_getting_help_32]
 

--- a/docs/reference/plugins-inputs-jms.md
+++ b/docs/reference/plugins-inputs-jms.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-06-13
 * [Changelog](https://github.com/logstash-plugins/logstash-input-jms/blob/v3.2.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-jms-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-jms-index.md).
 
 ## Getting help [_getting_help_33]
 
@@ -443,7 +443,7 @@ This represents the value of the subscriber name for a durable subscribtion, and
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the *default* value of [`headers_target`](#plugins-inputs-jms-headers_target) and [`properties_target`](#plugins-inputs-jms-properties_target).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the *default* value of [`headers_target`](#plugins-inputs-jms-headers_target) and [`properties_target`](#plugins-inputs-jms-properties_target).
 
 
 ### `factory` [plugins-inputs-jms-factory]

--- a/docs/reference/plugins-inputs-jmx.md
+++ b/docs/reference/plugins-inputs-jmx.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-08-13
 * [Changelog](https://github.com/logstash-plugins/logstash-input-jmx/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-jmx-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-jmx-index.md).
 
 ## Installation [_installation_5]
 

--- a/docs/reference/plugins-inputs-kafka.md
+++ b/docs/reference/plugins-inputs-kafka.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2025-01-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-kafka/blob/v11.6.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-kafka-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-kafka-index.md).
 
 ## Getting help [_getting_help_35]
 

--- a/docs/reference/plugins-inputs-kinesis.md
+++ b/docs/reference/plugins-inputs-kinesis.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-08-28
 * [Changelog](https://github.com/logstash-plugins/logstash-input-kinesis/blob/v2.3.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-kinesis-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-kinesis-index.md).
 
 ## Installation [_installation_6]
 

--- a/docs/reference/plugins-inputs-log4j.md
+++ b/docs/reference/plugins-inputs-log4j.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-log4j/blob/v3.1.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-log4j-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-log4j-index.md).
 
 ## Installation [_installation_7]
 
@@ -58,7 +58,7 @@ Configuring log4j.properties in more detail is outside the scope of this migrati
 
 ### Configuring filebeat [_configuring_filebeat]
 
-Next, [install Filebeat](beats://docs/reference/filebeat/filebeat-installation-configuration.md). Based on the above log4j.properties, we can use this filebeat configuration:
+Next, [install Filebeat](beats://reference/filebeat/filebeat-installation-configuration.md). Based on the above log4j.properties, we can use this filebeat configuration:
 
 ```
 # filebeat.yml
@@ -72,7 +72,7 @@ output:
   logstash:
     hosts: ["your-logstash-host:5000"]
 ```
-For more details on configuring filebeat, see [Configure Filebeat](beats://docs/reference/filebeat/configuring-howto-filebeat.md).
+For more details on configuring filebeat, see [Configure Filebeat](beats://reference/filebeat/configuring-howto-filebeat.md).
 
 
 ### Configuring Logstash to receive from filebeat [_configuring_logstash_to_receive_from_filebeat]

--- a/docs/reference/plugins-inputs-logstash.md
+++ b/docs/reference/plugins-inputs-logstash.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-12-10
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-logstash/blob/v1.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-logstash-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-logstash-index.md).
 
 ## Getting help [_getting_help_37]
 

--- a/docs/reference/plugins-inputs-lumberjack.md
+++ b/docs/reference/plugins-inputs-lumberjack.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-04-15
 * [Changelog](https://github.com/logstash-plugins/logstash-input-lumberjack/blob/v3.1.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-lumberjack-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-lumberjack-index.md).
 
 ## Installation [_installation_8]
 

--- a/docs/reference/plugins-inputs-meetup.md
+++ b/docs/reference/plugins-inputs-meetup.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-meetup/blob/v3.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-meetup-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-meetup-index.md).
 
 ## Installation [_installation_9]
 

--- a/docs/reference/plugins-inputs-pipe.md
+++ b/docs/reference/plugins-inputs-pipe.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-11-18
 * [Changelog](https://github.com/logstash-plugins/logstash-input-pipe/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-pipe-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-pipe-index.md).
 
 ## Getting help [_getting_help_41]
 
@@ -27,7 +27,7 @@ By default, each event is assumed to be one line. If you want to join lines, you
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-pipe-ecs]
 
-This plugin adds extra fields about the event’s source. Configure the [`ecs_compatibility`](#plugins-inputs-pipe-ecs_compatibility) option if you want to ensure that these fields are compatible with [ECS](ecs://docs/reference/index.md).
+This plugin adds extra fields about the event’s source. Configure the [`ecs_compatibility`](#plugins-inputs-pipe-ecs_compatibility) option if you want to ensure that these fields are compatible with [ECS](ecs://reference/index.md).
 
 These fields are added after the event has been decoded by the appropriate codec, and will not overwrite existing values.
 
@@ -78,7 +78,7 @@ input {
     * `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-pipe-ecs) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-pipe-ecs) for detailed information.
 
 **Sample output: ECS enabled**
 

--- a/docs/reference/plugins-inputs-puppet_facter.md
+++ b/docs/reference/plugins-inputs-puppet_facter.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-puppet_facter/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-puppet_facter-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-puppet_facter-index.md).
 
 ## Installation [_installation_10]
 

--- a/docs/reference/plugins-inputs-rabbitmq.md
+++ b/docs/reference/plugins-inputs-rabbitmq.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-09-16
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.4.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-rabbitmq-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-rabbitmq-index.md).
 
 ## Getting help [_getting_help_43]
 

--- a/docs/reference/plugins-inputs-redis.md
+++ b/docs/reference/plugins-inputs-redis.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-08-01
 * [Changelog](https://github.com/logstash-plugins/logstash-input-redis/blob/v3.7.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-redis-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-redis-index.md).
 
 ## Getting help [_getting_help_44]
 

--- a/docs/reference/plugins-inputs-relp.md
+++ b/docs/reference/plugins-inputs-relp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-relp/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-relp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-relp-index.md).
 
 ## Installation [_installation_11]
 

--- a/docs/reference/plugins-inputs-rss.md
+++ b/docs/reference/plugins-inputs-rss.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-11-03
 * [Changelog](https://github.com/logstash-plugins/logstash-input-rss/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-rss-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-rss-index.md).
 
 ## Installation [_installation_12]
 

--- a/docs/reference/plugins-inputs-s3.md
+++ b/docs/reference/plugins-inputs-s3.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-s3-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-s3-index.md).
 
 ## Getting help [_getting_help_47]
 
@@ -180,7 +180,7 @@ Whether to delete processed files from the original bucket.
     * `v1`,`v8`: uses metadata fields that are compatible with Elastic Common Schema
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-s3-ecs_metadata) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Event Metadata and the Elastic Common Schema (ECS)](#plugins-inputs-s3-ecs_metadata) for detailed information.
 
 
 ### `endpoint` [plugins-inputs-s3-endpoint]

--- a/docs/reference/plugins-inputs-salesforce.md
+++ b/docs/reference/plugins-inputs-salesforce.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-30
 * [Changelog](https://github.com/logstash-plugins/logstash-input-salesforce/blob/v3.2.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-salesforce-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-salesforce-index.md).
 
 ## Installation [_installation_14]
 

--- a/docs/reference/plugins-inputs-snmp.md
+++ b/docs/reference/plugins-inputs-snmp.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2025-01-06
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-snmp/blob/v4.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-snmp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-snmp-index.md).
 
 ## Getting help [_getting_help_50]
 
@@ -107,7 +107,7 @@ Also see [Common options](#plugins-inputs-snmp-common-options) for a list of opt
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `get` [plugins-inputs-snmp-get]

--- a/docs/reference/plugins-inputs-snmptrap.md
+++ b/docs/reference/plugins-inputs-snmptrap.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2025-01-06
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-snmp/blob/v4.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-snmptrap-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-snmptrap-index.md).
 
 ## Getting help [_getting_help_51]
 
@@ -157,7 +157,7 @@ input {
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `host` [plugins-inputs-snmptrap-host]

--- a/docs/reference/plugins-inputs-sqlite.md
+++ b/docs/reference/plugins-inputs-sqlite.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-sqlite/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-sqlite-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-sqlite-index.md).
 
 ## Installation [_installation_15]
 

--- a/docs/reference/plugins-inputs-sqs.md
+++ b/docs/reference/plugins-inputs-sqs.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-sqs-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-sqs-index.md).
 
 ## Getting help [_getting_help_53]
 

--- a/docs/reference/plugins-inputs-stdin.md
+++ b/docs/reference/plugins-inputs-stdin.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-input-stdin/blob/v3.4.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-stdin-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-stdin-index.md).
 
 ## Getting help [_getting_help_54]
 
@@ -51,7 +51,7 @@ Also see [Common options](#plugins-inputs-stdin-common-options) for a list of op
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 

--- a/docs/reference/plugins-inputs-stomp.md
+++ b/docs/reference/plugins-inputs-stomp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-stomp/blob/v3.0.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-stomp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-stomp-index.md).
 
 ## Installation [_installation_16]
 

--- a/docs/reference/plugins-inputs-syslog.md
+++ b/docs/reference/plugins-inputs-syslog.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-17
 * [Changelog](https://github.com/logstash-plugins/logstash-input-syslog/blob/v3.7.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-syslog-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-syslog-index.md).
 
 ## Getting help [_getting_help_56]
 
@@ -67,7 +67,7 @@ Also see [Common options](#plugins-inputs-syslog-common-options) for a list of o
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `facility_labels` [plugins-inputs-syslog-facility_labels]

--- a/docs/reference/plugins-inputs-tcp.md
+++ b/docs/reference/plugins-inputs-tcp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-10
 * [Changelog](https://github.com/logstash-plugins/logstash-input-tcp/blob/v7.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-tcp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-tcp-index.md).
 
 ## Getting help [_getting_help_57]
 
@@ -84,7 +84,7 @@ Historically, this metadata was added to a variety of non-standard top-level fie
 | [@metadata][input][tcp][proxy][port] | [proxy_port] |
 | SSL Subject Metadata from a secured TCPconnection. Available when `ssl_enabled => true`AND `ssl_client_authentication => 'optional' or 'required'` | [@metadata][input][tcp][ssl][subject] | [sslsubject] |
 
-For example, the Elastic Common Schema reserves the [top-level `host` field](ecs://docs/reference/ecs-host.md) for information about the host on which the event happened. If an event is missing this metadata, it can be copied into place from the source TCP connection metadata that has been added to the event:
+For example, the Elastic Common Schema reserves the [top-level `host` field](ecs://reference/ecs-host.md) for information about the host on which the event happened. If an event is missing this metadata, it can be copied into place from the source TCP connection metadata that has been added to the event:
 
 ```txt
 filter {
@@ -155,7 +155,7 @@ It is possible to avoid DNS reverse-lookups by disabling this setting. If disabl
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). The value of this setting affects the [placement of a TCP connection’s metadata](#plugins-inputs-tcp-ecs_metadata) on events.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). The value of this setting affects the [placement of a TCP connection’s metadata](#plugins-inputs-tcp-ecs_metadata) on events.
 
 
 ### `host` [plugins-inputs-tcp-host]

--- a/docs/reference/plugins-inputs-twitter.md
+++ b/docs/reference/plugins-inputs-twitter.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-11-16
 * [Changelog](https://github.com/logstash-plugins/logstash-input-twitter/blob/v4.1.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-twitter-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-twitter-index.md).
 
 ## Getting help [_getting_help_58]
 
@@ -59,7 +59,7 @@ Sample event fields generated:
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-twitter-ecs]
 
-Twitter streams are very specific and do not map easily to the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). We recommend setting a [`target`](#plugins-inputs-twitter-target) when [ECS compatibility mode](#plugins-inputs-twitter-ecs_compatibility) is enabled. The plugin issues a warning in the log when a `target` isn’t set.
+Twitter streams are very specific and do not map easily to the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). We recommend setting a [`target`](#plugins-inputs-twitter-target) when [ECS compatibility mode](#plugins-inputs-twitter-ecs_compatibility) is enabled. The plugin issues a warning in the log when a `target` isn’t set.
 
 
 ## Twitter Input Configuration Options [plugins-inputs-twitter-options]
@@ -126,7 +126,7 @@ If you don’t have one of these, you can create one by registering a new applic
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 
 ### `follows` [plugins-inputs-twitter-follows]

--- a/docs/reference/plugins-inputs-udp.md
+++ b/docs/reference/plugins-inputs-udp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-04
 * [Changelog](https://github.com/logstash-plugins/logstash-input-udp/blob/v3.5.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-udp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-udp-index.md).
 
 ## Getting help [_getting_help_59]
 
@@ -24,7 +24,7 @@ Read messages as events over the network via udp. The only required configuratio
 
 ### Event Metadata and the Elastic Common Schema (ECS) [plugins-inputs-udp-ecs_metadata]
 
-This plugin adds a field containing the source IP address of the UDP packet. By default, the IP address is stored in the host field. When [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) is enabled (in [`ecs_compatibility`](#plugins-inputs-udp-ecs_compatibility)), the source IP address is stored in the [host][ip] field.
+This plugin adds a field containing the source IP address of the UDP packet. By default, the IP address is stored in the host field. When [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) is enabled (in [`ecs_compatibility`](#plugins-inputs-udp-ecs_compatibility)), the source IP address is stored in the [host][ip] field.
 
 You can customize the field name using the [`source_ip_fieldname`](#plugins-inputs-udp-source_ip_fieldname). See [`ecs_compatibility`](#plugins-inputs-udp-ecs_compatibility) for more information.
 
@@ -71,7 +71,7 @@ The maximum packet size to read from the network
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)).
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)).
 
 The value of this setting affects the placement of a TCP connection’s metadata on events.
 

--- a/docs/reference/plugins-inputs-unix.md
+++ b/docs/reference/plugins-inputs-unix.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2022-10-03
 * [Changelog](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.1.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-unix-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-unix-index.md).
 
 ## Getting help [_getting_help_60]
 
@@ -29,7 +29,7 @@ Can either accept connections from clients or connect to a server, depending on 
 
 ## Compatibility with the Elastic Common Schema (ECS) [plugins-inputs-unix-ecs]
 
-This plugin adds extra fields about the event’s source. Configure the [`ecs_compatibility`](#plugins-inputs-unix-ecs_compatibility) option if you want to ensure that these fields are compatible with [ECS](ecs://docs/reference/index.md).
+This plugin adds extra fields about the event’s source. Configure the [`ecs_compatibility`](#plugins-inputs-unix-ecs_compatibility) option if you want to ensure that these fields are compatible with [ECS](ecs://reference/index.md).
 
 These fields are added after the event has been decoded by the appropriate codec, and will not overwrite existing values.
 
@@ -75,7 +75,7 @@ If you never want to timeout, use -1.
     * `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-unix-ecs) for detailed information.
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)). See [Compatibility with the Elastic Common Schema (ECS)](#plugins-inputs-unix-ecs) for detailed information.
 
 **Sample output: ECS enabled**
 

--- a/docs/reference/plugins-inputs-varnishlog.md
+++ b/docs/reference/plugins-inputs-varnishlog.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-varnishlog/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-varnishlog-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-varnishlog-index.md).
 
 ## Installation [_installation_17]
 

--- a/docs/reference/plugins-inputs-websocket.md
+++ b/docs/reference/plugins-inputs-websocket.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-websocket/blob/v4.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-websocket-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-websocket-index.md).
 
 ## Installation [_installation_18]
 

--- a/docs/reference/plugins-inputs-wmi.md
+++ b/docs/reference/plugins-inputs-wmi.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-wmi/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-wmi-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-wmi-index.md).
 
 ## Installation [_installation_19]
 

--- a/docs/reference/plugins-inputs-xmpp.md
+++ b/docs/reference/plugins-inputs-xmpp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-input-xmpp/blob/v3.1.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/input-xmpp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/input-xmpp-index.md).
 
 ## Installation [_installation_20]
 

--- a/docs/reference/plugins-integrations-aws.md
+++ b/docs/reference/plugins-integrations-aws.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-aws-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-aws-index.md).
 
 ## Getting help [_getting_help]
 

--- a/docs/reference/plugins-integrations-elastic_enterprise_search.md
+++ b/docs/reference/plugins-integrations-elastic_enterprise_search.md
@@ -10,7 +10,7 @@ mapped_pages:
 * Released on: 2023-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v3.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-elastic_enterprise_search-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-elastic_enterprise_search-index.md).
 
 ## Getting help [_getting_help_2]
 

--- a/docs/reference/plugins-integrations-jdbc.md
+++ b/docs/reference/plugins-integrations-jdbc.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-23
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-jdbc/blob/v5.5.2/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-jdbc-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-jdbc-index.md).
 
 ## Getting help [_getting_help_3]
 

--- a/docs/reference/plugins-integrations-kafka.md
+++ b/docs/reference/plugins-integrations-kafka.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-kafka/blob/v11.6.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-kafka-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-kafka-index.md).
 
 ## Getting help [_getting_help_4]
 

--- a/docs/reference/plugins-integrations-logstash.md
+++ b/docs/reference/plugins-integrations-logstash.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-12-10
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-logstash/blob/v1.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-logstash-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-logstash-index.md).
 
 ## Getting help [_getting_help_5]
 

--- a/docs/reference/plugins-integrations-rabbitmq.md
+++ b/docs/reference/plugins-integrations-rabbitmq.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-09-16
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.4.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-rabbitmq-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-rabbitmq-index.md).
 
 ## Getting help [_getting_help_6]
 

--- a/docs/reference/plugins-integrations-snmp.md
+++ b/docs/reference/plugins-integrations-snmp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-06
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-snmp/blob/v4.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/integration-snmp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/integration-snmp-index.md).
 
 ## Getting help [_getting_help_7]
 

--- a/docs/reference/plugins-outputs-boundary.md
+++ b/docs/reference/plugins-outputs-boundary.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-30
 * [Changelog](https://github.com/logstash-plugins/logstash-output-boundary/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-boundary-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-boundary-index.md).
 
 ## Installation [_installation_21]
 

--- a/docs/reference/plugins-outputs-circonus.md
+++ b/docs/reference/plugins-outputs-circonus.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-30
 * [Changelog](https://github.com/logstash-plugins/logstash-output-circonus/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-circonus-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-circonus-index.md).
 
 ## Installation [_installation_22]
 

--- a/docs/reference/plugins-outputs-cloudwatch.md
+++ b/docs/reference/plugins-outputs-cloudwatch.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-cloudwatch-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-cloudwatch-index.md).
 
 ## Getting help [_getting_help_67]
 

--- a/docs/reference/plugins-outputs-csv.md
+++ b/docs/reference/plugins-outputs-csv.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-12-19
 * [Changelog](https://github.com/logstash-plugins/logstash-output-csv/blob/v3.0.10/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-csv-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-csv-index.md).
 
 ## Getting help [_getting_help_68]
 

--- a/docs/reference/plugins-outputs-datadog.md
+++ b/docs/reference/plugins-outputs-datadog.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-05-31
 * [Changelog](https://github.com/logstash-plugins/logstash-output-datadog/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-datadog-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-datadog-index.md).
 
 ## Installation [_installation_23]
 

--- a/docs/reference/plugins-outputs-datadog_metrics.md
+++ b/docs/reference/plugins-outputs-datadog_metrics.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-10-25
 * [Changelog](https://github.com/logstash-plugins/logstash-output-datadog_metrics/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-datadog_metrics-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-datadog_metrics-index.md).
 
 ## Installation [_installation_24]
 

--- a/docs/reference/plugins-outputs-elastic_app_search.md
+++ b/docs/reference/plugins-outputs-elastic_app_search.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2023-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v3.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-elastic_app_search-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-elastic_app_search-index.md).
 
 ## Getting help [_getting_help_72]
 

--- a/docs/reference/plugins-outputs-elastic_workplace_search.md
+++ b/docs/reference/plugins-outputs-elastic_workplace_search.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2023-11-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-elastic_enterprise_search/blob/v3.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-elastic_workplace_search-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-elastic_workplace_search-index.md).
 
 ## Getting help [_getting_help_73]
 

--- a/docs/reference/plugins-outputs-elasticsearch.md
+++ b/docs/reference/plugins-outputs-elasticsearch.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-14
 * [Changelog](https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v12.0.1/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-elasticsearch-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-elasticsearch-index.md).
 
 ## Getting help [_getting_help_74]
 
@@ -559,7 +559,7 @@ This sets the document type to write events to. Generally you should try to writ
     * Otherwise, the default value is `disabled`.
 
 
-Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)), including the installation of ECS-compatible index templates. The value of this setting affects the *default* values of:
+Controls this plugin’s compatibility with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)), including the installation of ECS-compatible index templates. The value of this setting affects the *default* values of:
 
 * [`index`](#plugins-outputs-elasticsearch-index)
 * [`template_name`](#plugins-outputs-elasticsearch-template_name)
@@ -598,7 +598,7 @@ HTTP Path where a HEAD request is sent when a backend is marked down the request
 * Value type is [uri](/reference/configuration-file-structure.md#uri)
 * Default value is `[//127.0.0.1]`
 
-Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter. Remember the `http` protocol uses the [http](elasticsearch://docs/reference/elasticsearch/configuration-reference/networking-settings.md) address (eg. 9200, not 9300).
+Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter. Remember the `http` protocol uses the [http](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md) address (eg. 9200, not 9300).
 
 Examples:
 
@@ -609,7 +609,7 @@ Examples:
 `["https://127.0.0.1:9200"]`
 `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 ```
-Exclude [dedicated master nodes](elasticsearch://docs/reference/elasticsearch/configuration-reference/node-settings.md) from the `hosts` list to prevent Logstash from sending bulk requests to the master nodes. This parameter should reference only data or client nodes in Elasticsearch.
+Exclude [dedicated master nodes](elasticsearch://reference/elasticsearch/configuration-reference/node-settings.md) from the `hosts` list to prevent Logstash from sending bulk requests to the master nodes. This parameter should reference only data or client nodes in Elasticsearch.
 
 Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
 

--- a/docs/reference/plugins-outputs-email.md
+++ b/docs/reference/plugins-outputs-email.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-03
 * [Changelog](https://github.com/logstash-plugins/logstash-output-email/blob/v4.1.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-email-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-email-index.md).
 
 ## Getting help [_getting_help_75]
 

--- a/docs/reference/plugins-outputs-exec.md
+++ b/docs/reference/plugins-outputs-exec.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-exec/blob/v3.1.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-exec-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-exec-index.md).
 
 ## Installation [_installation_26]
 

--- a/docs/reference/plugins-outputs-file.md
+++ b/docs/reference/plugins-outputs-file.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-04-27
 * [Changelog](https://github.com/logstash-plugins/logstash-output-file/blob/v4.3.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-file-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-file-index.md).
 
 ## Getting help [_getting_help_77]
 

--- a/docs/reference/plugins-outputs-ganglia.md
+++ b/docs/reference/plugins-outputs-ganglia.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-ganglia/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-ganglia-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-ganglia-index.md).
 
 ## Installation [_installation_27]
 

--- a/docs/reference/plugins-outputs-gelf.md
+++ b/docs/reference/plugins-outputs-gelf.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-gelf/blob/v3.1.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-gelf-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-gelf-index.md).
 
 ## Installation [_installation_28]
 

--- a/docs/reference/plugins-outputs-google_bigquery.md
+++ b/docs/reference/plugins-outputs-google_bigquery.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-09-16
 * [Changelog](https://github.com/logstash-plugins/logstash-output-google_bigquery/blob/v4.6.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-google_bigquery-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-google_bigquery-index.md).
 
 ## Installation [_installation_29]
 

--- a/docs/reference/plugins-outputs-google_cloud_storage.md
+++ b/docs/reference/plugins-outputs-google_cloud_storage.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-09-16
 * [Changelog](https://github.com/logstash-plugins/logstash-output-google_cloud_storage/blob/v4.5.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-google_cloud_storage-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-google_cloud_storage-index.md).
 
 ## Installation [_installation_30]
 

--- a/docs/reference/plugins-outputs-google_pubsub.md
+++ b/docs/reference/plugins-outputs-google_pubsub.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-08-22
 * [Changelog](https://github.com/logstash-plugins/logstash-output-google_pubsub/blob/v1.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-google_pubsub-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-google_pubsub-index.md).
 
 ## Installation [_installation_31]
 

--- a/docs/reference/plugins-outputs-graphite.md
+++ b/docs/reference/plugins-outputs-graphite.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-07-11
 * [Changelog](https://github.com/logstash-plugins/logstash-output-graphite/blob/v3.1.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-graphite-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-graphite-index.md).
 
 ## Getting help [_getting_help_83]
 

--- a/docs/reference/plugins-outputs-graphtastic.md
+++ b/docs/reference/plugins-outputs-graphtastic.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-graphtastic/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-graphtastic-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-graphtastic-index.md).
 
 ## Installation [_installation_32]
 

--- a/docs/reference/plugins-outputs-http.md
+++ b/docs/reference/plugins-outputs-http.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-11-21
 * [Changelog](https://github.com/logstash-plugins/logstash-output-http/blob/v6.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-http-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-http-index.md).
 
 ## Getting help [_getting_help_85]
 

--- a/docs/reference/plugins-outputs-influxdb.md
+++ b/docs/reference/plugins-outputs-influxdb.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-06-07
 * [Changelog](https://github.com/logstash-plugins/logstash-output-influxdb/blob/v5.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-influxdb-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-influxdb-index.md).
 
 ## Installation [_installation_33]
 

--- a/docs/reference/plugins-outputs-irc.md
+++ b/docs/reference/plugins-outputs-irc.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-irc/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-irc-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-irc-index.md).
 
 ## Installation [_installation_34]
 

--- a/docs/reference/plugins-outputs-juggernaut.md
+++ b/docs/reference/plugins-outputs-juggernaut.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-juggernaut/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-juggernaut-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-juggernaut-index.md).
 
 ## Installation [_installation_35]
 

--- a/docs/reference/plugins-outputs-kafka.md
+++ b/docs/reference/plugins-outputs-kafka.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2025-01-07
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-kafka/blob/v11.6.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-kafka-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-kafka-index.md).
 
 ## Getting help [_getting_help_90]
 

--- a/docs/reference/plugins-outputs-librato.md
+++ b/docs/reference/plugins-outputs-librato.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-10-09
 * [Changelog](https://github.com/logstash-plugins/logstash-output-librato/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-librato-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-librato-index.md).
 
 ## Installation [_installation_36]
 

--- a/docs/reference/plugins-outputs-loggly.md
+++ b/docs/reference/plugins-outputs-loggly.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-07-03
 * [Changelog](https://github.com/logstash-plugins/logstash-output-loggly/blob/v6.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-loggly-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-loggly-index.md).
 
 ## Installation [_installation_37]
 

--- a/docs/reference/plugins-outputs-logstash.md
+++ b/docs/reference/plugins-outputs-logstash.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-12-10
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-logstash/blob/v1.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-logstash-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-logstash-index.md).
 
 ## Getting help [_getting_help_92]
 

--- a/docs/reference/plugins-outputs-lumberjack.md
+++ b/docs/reference/plugins-outputs-lumberjack.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-08-30
 * [Changelog](https://github.com/logstash-plugins/logstash-output-lumberjack/blob/v3.1.9/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-lumberjack-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-lumberjack-index.md).
 
 ## Getting help [_getting_help_94]
 

--- a/docs/reference/plugins-outputs-metriccatcher.md
+++ b/docs/reference/plugins-outputs-metriccatcher.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-metriccatcher/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-metriccatcher-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-metriccatcher-index.md).
 
 ## Installation [_installation_38]
 

--- a/docs/reference/plugins-outputs-mongodb.md
+++ b/docs/reference/plugins-outputs-mongodb.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-02
 * [Changelog](https://github.com/logstash-plugins/logstash-output-mongodb/blob/v3.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-mongodb-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-mongodb-index.md).
 
 ## Installation [_installation_39]
 

--- a/docs/reference/plugins-outputs-nagios.md
+++ b/docs/reference/plugins-outputs-nagios.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-nagios/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-nagios-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-nagios-index.md).
 
 ## Getting help [_getting_help_97]
 

--- a/docs/reference/plugins-outputs-nagios_nsca.md
+++ b/docs/reference/plugins-outputs-nagios_nsca.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-09-20
 * [Changelog](https://github.com/logstash-plugins/logstash-output-nagios_nsca/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-nagios_nsca-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-nagios_nsca-index.md).
 
 ## Installation [_installation_40]
 

--- a/docs/reference/plugins-outputs-opentsdb.md
+++ b/docs/reference/plugins-outputs-opentsdb.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-opentsdb/blob/v3.1.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-opentsdb-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-opentsdb-index.md).
 
 ## Installation [_installation_41]
 

--- a/docs/reference/plugins-outputs-pagerduty.md
+++ b/docs/reference/plugins-outputs-pagerduty.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-01-27
 * [Changelog](https://github.com/logstash-plugins/logstash-output-pagerduty/blob/v3.0.9/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-pagerduty-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-pagerduty-index.md).
 
 ## Installation [_installation_42]
 

--- a/docs/reference/plugins-outputs-pipe.md
+++ b/docs/reference/plugins-outputs-pipe.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-pipe/blob/v3.0.6/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-pipe-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-pipe-index.md).
 
 ## Getting help [_getting_help_101]
 

--- a/docs/reference/plugins-outputs-rabbitmq.md
+++ b/docs/reference/plugins-outputs-rabbitmq.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-09-16
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/v7.4.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-rabbitmq-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-rabbitmq-index.md).
 
 ## Getting help [_getting_help_102]
 

--- a/docs/reference/plugins-outputs-redis.md
+++ b/docs/reference/plugins-outputs-redis.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-06-04
 * [Changelog](https://github.com/logstash-plugins/logstash-output-redis/blob/v5.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-redis-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-redis-index.md).
 
 ## Getting help [_getting_help_103]
 

--- a/docs/reference/plugins-outputs-redmine.md
+++ b/docs/reference/plugins-outputs-redmine.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-redmine/blob/v3.0.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-redmine-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-redmine-index.md).
 
 ## Installation [_installation_43]
 

--- a/docs/reference/plugins-outputs-riak.md
+++ b/docs/reference/plugins-outputs-riak.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2019-10-09
 * [Changelog](https://github.com/logstash-plugins/logstash-output-riak/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-riak-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-riak-index.md).
 
 ## Installation [_installation_44]
 

--- a/docs/reference/plugins-outputs-riemann.md
+++ b/docs/reference/plugins-outputs-riemann.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2020-07-15
 * [Changelog](https://github.com/logstash-plugins/logstash-output-riemann/blob/v3.0.7/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-riemann-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-riemann-index.md).
 
 ## Installation [_installation_45]
 

--- a/docs/reference/plugins-outputs-s3.md
+++ b/docs/reference/plugins-outputs-s3.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-s3-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-s3-index.md).
 
 ## Getting help [_getting_help_107]
 

--- a/docs/reference/plugins-outputs-sns.md
+++ b/docs/reference/plugins-outputs-sns.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-sns-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-sns-index.md).
 
 ## Getting help [_getting_help_109]
 

--- a/docs/reference/plugins-outputs-solr_http.md
+++ b/docs/reference/plugins-outputs-solr_http.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-solr_http/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-solr_http-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-solr_http-index.md).
 
 ## Installation [_installation_46]
 

--- a/docs/reference/plugins-outputs-sqs.md
+++ b/docs/reference/plugins-outputs-sqs.md
@@ -12,7 +12,7 @@ mapped_pages:
 * Released on: 2024-07-26
 * [Changelog](https://github.com/logstash-plugins/logstash-integration-aws/blob/v7.1.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-sqs-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-sqs-index.md).
 
 ## Getting help [_getting_help_111]
 

--- a/docs/reference/plugins-outputs-statsd.md
+++ b/docs/reference/plugins-outputs-statsd.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-06-05
 * [Changelog](https://github.com/logstash-plugins/logstash-output-statsd/blob/v3.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-statsd-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-statsd-index.md).
 
 ## Installation [_installation_47]
 

--- a/docs/reference/plugins-outputs-stdout.md
+++ b/docs/reference/plugins-outputs-stdout.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-stdout/blob/v3.1.4/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-stdout-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-stdout-index.md).
 
 ## Getting help [_getting_help_113]
 

--- a/docs/reference/plugins-outputs-stomp.md
+++ b/docs/reference/plugins-outputs-stomp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-stomp/blob/v3.0.9/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-stomp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-stomp-index.md).
 
 ## Installation [_installation_48]
 

--- a/docs/reference/plugins-outputs-syslog.md
+++ b/docs/reference/plugins-outputs-syslog.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-syslog/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-syslog-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-syslog-index.md).
 
 ## Installation [_installation_49]
 

--- a/docs/reference/plugins-outputs-tcp.md
+++ b/docs/reference/plugins-outputs-tcp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2025-01-10
 * [Changelog](https://github.com/logstash-plugins/logstash-output-tcp/blob/v7.0.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-tcp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-tcp-index.md).
 
 ## Getting help [_getting_help_116]
 

--- a/docs/reference/plugins-outputs-timber.md
+++ b/docs/reference/plugins-outputs-timber.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2017-09-02
 * [Changelog](https://github.com/logstash-plugins/logstash-output-timber/blob/v1.0.3/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-timber-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-timber-index.md).
 
 ## Installation [_installation_50]
 

--- a/docs/reference/plugins-outputs-udp.md
+++ b/docs/reference/plugins-outputs-udp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2021-07-14
 * [Changelog](https://github.com/logstash-plugins/logstash-output-udp/blob/v3.2.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-udp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-udp-index.md).
 
 ## Getting help [_getting_help_118]
 

--- a/docs/reference/plugins-outputs-webhdfs.md
+++ b/docs/reference/plugins-outputs-webhdfs.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2023-10-03
 * [Changelog](https://github.com/logstash-plugins/logstash-output-webhdfs/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-webhdfs-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-webhdfs-index.md).
 
 ## Getting help [_getting_help_119]
 

--- a/docs/reference/plugins-outputs-websocket.md
+++ b/docs/reference/plugins-outputs-websocket.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2024-01-11
 * [Changelog](https://github.com/logstash-plugins/logstash-output-websocket/blob/v3.1.0/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-websocket-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-websocket-index.md).
 
 ## Installation [_installation_51]
 

--- a/docs/reference/plugins-outputs-xmpp.md
+++ b/docs/reference/plugins-outputs-xmpp.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-xmpp/blob/v3.0.8/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-xmpp-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-xmpp-index.md).
 
 ## Installation [_installation_52]
 

--- a/docs/reference/plugins-outputs-zabbix.md
+++ b/docs/reference/plugins-outputs-zabbix.md
@@ -11,7 +11,7 @@ mapped_pages:
 * Released on: 2018-04-06
 * [Changelog](https://github.com/logstash-plugins/logstash-output-zabbix/blob/v3.0.5/CHANGELOG.md)
 
-For other versions, see the [Versioned plugin docs](logstash-docs://docs/reference/output-zabbix-index.md).
+For other versions, see the [Versioned plugin docs](logstash-docs://reference/output-zabbix-index.md).
 
 ## Installation [_installation_53]
 

--- a/docs/reference/use-filebeat-modules-kafka.md
+++ b/docs/reference/use-filebeat-modules-kafka.md
@@ -5,9 +5,9 @@ mapped_pages:
 
 # Example: Set up Filebeat modules to work with Kafka and Logstash [use-filebeat-modules-kafka]
 
-This section shows how to set up {{filebeat}} [modules](beats://docs/reference/filebeat/filebeat-modules-overview.md) to work with {{ls}} when you are using Kafka in between {{filebeat}} and {{ls}} in your publishing pipeline. The main goal of this example is to show how to load ingest pipelines from {{filebeat}} and use them with {{ls}}.
+This section shows how to set up {{filebeat}} [modules](beats://reference/filebeat/filebeat-modules-overview.md) to work with {{ls}} when you are using Kafka in between {{filebeat}} and {{ls}} in your publishing pipeline. The main goal of this example is to show how to load ingest pipelines from {{filebeat}} and use them with {{ls}}.
 
-The examples in this section show simple configurations with topic names hard coded. For a full list of configuration options, see documentation about configuring the [Kafka input plugin](/reference/plugins-inputs-kafka.md). Also see [Configure the Kafka output](beats://docs/reference/filebeat/kafka-output.md) in the *{{filebeat}} Reference*.
+The examples in this section show simple configurations with topic names hard coded. For a full list of configuration options, see documentation about configuring the [Kafka input plugin](/reference/plugins-inputs-kafka.md). Also see [Configure the Kafka output](beats://reference/filebeat/kafka-output.md) in the *{{filebeat}} Reference*.
 
 ## Set up and run {{filebeat}} [_set_up_and_run_filebeat]
 
@@ -19,7 +19,7 @@ The examples in this section show simple configurations with topic names hard co
 
     The `-e` flag is optional and sends output to standard error instead of syslog.
 
-    A connection to {{es}} and {{kib}} is required for this one-time setup step because {{filebeat}} needs to create the index template in {{es}} and load the sample dashboards into {{kib}}. For more information about configuring the connection to {{es}}, see the Filebeat [quick start](beats://docs/reference/filebeat/filebeat-installation-configuration.md).
+    A connection to {{es}} and {{kib}} is required for this one-time setup step because {{filebeat}} needs to create the index template in {{es}} and load the sample dashboards into {{kib}}. For more information about configuring the connection to {{es}}, see the Filebeat [quick start](beats://reference/filebeat/filebeat-installation-configuration.md).
 
     After the template and dashboards are loaded, you’ll see the message `INFO {{kib}} dashboards successfully loaded. Loaded dashboards`.
 
@@ -62,7 +62,7 @@ The examples in this section show simple configurations with topic names hard co
     {{filebeat}} will attempt to send messages to {{ls}} and continue until {{ls}} is available to receive them.
 
     ::::{note}
-    Depending on how you’ve installed {{filebeat}}, you might see errors related to file ownership or permissions when you try to run {{filebeat}} modules. See [Config File Ownership and Permissions](beats://docs/reference/libbeat/config-file-permissions.md) in the *Beats Platform Reference* if you encounter errors related to file ownership or permissions.
+    Depending on how you’ve installed {{filebeat}}, you might see errors related to file ownership or permissions when you try to run {{filebeat}} modules. See [Config File Ownership and Permissions](beats://reference/libbeat/config-file-permissions.md) in the *Beats Platform Reference* if you encounter errors related to file ownership or permissions.
     ::::
 
 

--- a/docs/reference/use-ingest-pipelines.md
+++ b/docs/reference/use-ingest-pipelines.md
@@ -59,7 +59,7 @@ output {
 3. Configures {{ls}} to select the correct ingest pipeline based on metadata passed in the event.
 
 
-See the {{filebeat}} [Modules](beats://docs/reference/filebeat/filebeat-modules-overview.md) documentation for more information about setting up and running modules.
+See the {{filebeat}} [Modules](beats://reference/filebeat/filebeat-modules-overview.md) documentation for more information about setting up and running modules.
 
 For a full example, see [Example: Set up {{filebeat}} modules to work with Kafka and {{ls}}](/reference/use-filebeat-modules-kafka.md).
 

--- a/docs/reference/using-logstash-with-elastic-integrations.md
+++ b/docs/reference/using-logstash-with-elastic-integrations.md
@@ -10,14 +10,14 @@ You can take advantage of the extensive, built-in capabilities of Elastic {{inte
 
 ## Elastic {{integrations}}: ingesting to visualizing [integrations-value]
 
-[Elastic {{integrations}}](integration-docs://docs/reference/index.md) provide quick, end-to-end solutions for:
+[Elastic {{integrations}}](integration-docs://reference/index.md) provide quick, end-to-end solutions for:
 
 * ingesting data from a variety of data sources,
-* ensuring compliance with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)),
+* ensuring compliance with the [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)),
 * getting the data into the {{stack}}, and
 * visualizing it with purpose-built dashboards.
 
-{{integrations}} are available for [popular services and platforms](integration-docs://docs/reference/all_integrations.md), such as Nginx, AWS, and MongoDB, as well as many generic input types like log files. Each integration includes pre-packaged assets to help reduce the time between ingest and insights.
+{{integrations}} are available for [popular services and platforms](integration-docs://reference/all_integrations.md), such as Nginx, AWS, and MongoDB, as well as many generic input types like log files. Each integration includes pre-packaged assets to help reduce the time between ingest and insights.
 
 To see available integrations, go to the {{kib}} home page, and click **Add {{integrations}}**. You can use the query bar to search for integrations you may want to use. When you find an integration for your data source, the UI walks you through adding and configuring it.
 

--- a/docs/reference/working-with-filebeat-modules.md
+++ b/docs/reference/working-with-filebeat-modules.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Working with Filebeat modules [filebeat-modules]
 
-{{filebeat}} comes packaged with pre-built [modules](beats://docs/reference/filebeat/filebeat-modules.md) that contain the configurations needed to collect, parse, enrich, and visualize data from various log file formats. Each {{filebeat}} module consists of one or more filesets that contain ingest node pipelines, {{es}} templates, {{filebeat}} input configurations, and {{kib}} dashboards.
+{{filebeat}} comes packaged with pre-built [modules](beats://reference/filebeat/filebeat-modules.md) that contain the configurations needed to collect, parse, enrich, and visualize data from various log file formats. Each {{filebeat}} module consists of one or more filesets that contain ingest node pipelines, {{es}} templates, {{filebeat}} input configurations, and {{kib}} dashboards.
 
 You can use {{filebeat}} modules with {{ls}}, but you need to do some extra setup. The simplest approach is to [set up and use the ingest pipelines](/reference/use-ingest-pipelines.md) provided by {{filebeat}}.
 

--- a/docs/reference/working-with-winlogbeat-modules.md
+++ b/docs/reference/working-with-winlogbeat-modules.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Working with Winlogbeat modules [winlogbeat-modules]
 
-{{winlogbeat}} comes packaged with pre-built [modules](beats://docs/reference/winlogbeat/winlogbeat-modules.md) that contain the configurations needed to collect, parse, enrich, and visualize data from various Windows logging providers. Each {{winlogbeat}} module consists of one or more filesets that contain ingest node pipelines, {{es}} templates, {{winlogbeat}} input configurations, and {{kib}} dashboards.
+{{winlogbeat}} comes packaged with pre-built [modules](beats://reference/winlogbeat/winlogbeat-modules.md) that contain the configurations needed to collect, parse, enrich, and visualize data from various Windows logging providers. Each {{winlogbeat}} module consists of one or more filesets that contain ingest node pipelines, {{es}} templates, {{winlogbeat}} input configurations, and {{kib}} dashboards.
 
 You can use {{winlogbeat}} modules with {{ls}}, but you need to do some extra setup. The simplest approach is to [set up and use the ingest pipelines](#use-winlogbeat-ingest-pipelines) provided by {{winlogbeat}}.
 
@@ -66,5 +66,5 @@ output {
 3. Configures {{ls}} to select the correct ingest pipeline based on metadata passed in the event.
 
 
-See the {{winlogbeat}} [Modules](beats://docs/reference/winlogbeat/winlogbeat-modules.md) documentation for more information about setting up and running modules.
+See the {{winlogbeat}} [Modules](beats://reference/winlogbeat/winlogbeat-modules.md) documentation for more information about setting up and running modules.
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -203,4 +203,4 @@ We’ve removed deprecated SSL settings in some {{ls}} plugins, and have replace
 
 We’ve deprecated the {{ls}} Enterprise_search integration plugin, and its component App Search and Workplace Search plugins. These plugins will receive only security updates and critical fixes moving forward.
 
-We recommend using our native {{es}} tools for your Search use cases. For more details, please visit [Search UI with Elasticsearch](search-ui://docs/tutorials-elasticsearch.md).
+We recommend using our native {{es}} tools for your Search use cases. For more details, please visit [Search UI with Elasticsearch](search-ui://tutorials-elasticsearch.md).


### PR DESCRIPTION
Follow up to #17159

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).