### PR TITLE
Pluginmanager clean after mutate

### DIFF
--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -69,7 +69,7 @@ class LogStash::PluginManager::Command < Clamp::Command
     end
     puts "cleaned #{desc} #{spec.name} (#{spec.version})"
   rescue Gem::InstallError => e
-    fail "Failed to uninstall `#{spec.full_name}`"
+    report_exception("Failed to uninstall `#{spec.full_name}`", e)
   end
 
   def relative_path(path)

--- a/lib/pluginmanager/command.rb
+++ b/lib/pluginmanager/command.rb
@@ -47,6 +47,31 @@ class LogStash::PluginManager::Command < Clamp::Command
     end
   end
 
+  def remove_orphan_dependencies!
+    locked_gem_names = ::Bundler::LockfileParser.new(File.read(LogStash::Environment::LOCKFILE)).specs.map(&:full_name).to_set
+    orphan_gem_specs = ::Gem::Specification.each
+                                           .reject(&:stubbed?) # skipped stubbed (uninstalled) gems
+                                           .reject(&:default_gem?) # don't touch jruby-included default gems
+                                           .reject{ |spec| locked_gem_names.include?(spec.full_name) }
+                                           .sort
+
+    inactive_plugins, orphaned_dependencies = orphan_gem_specs.partition { |spec| LogStash::PluginManager.logstash_plugin_gem_spec?(spec) }
+
+    # uninstall plugins first, to limit damage should one fail to uninstall
+    inactive_plugins.each { |plugin| uninstall_gem!("inactive plugin", plugin) }
+    orphaned_dependencies.each { |dep| uninstall_gem!("orphaned dependency", dep) }
+  end
+
+  def uninstall_gem!(desc, spec)
+    require "rubygems/uninstaller"
+    Gem::DefaultUserInteraction.use_ui(debug? ? Gem::DefaultUserInteraction.ui : Gem::SilentUI.new) do
+      Gem::Uninstaller.new(spec.name, version: spec.version, force: true, executables: true).uninstall
+    end
+    puts "cleaned #{desc} #{spec.name} (#{spec.version})"
+  rescue Gem::InstallError => e
+    fail "Failed to uninstall `#{spec.full_name}`"
+  end
+
   def relative_path(path)
     require "pathname"
     ::Pathname.new(path).relative_path_from(::Pathname.new(LogStash::Environment::LOGSTASH_HOME)).to_s

--- a/lib/pluginmanager/gemfile.rb
+++ b/lib/pluginmanager/gemfile.rb
@@ -133,8 +133,8 @@ module LogStash
     # update existing or add new
     def update_gem(_gem)
       if old = find_gem(_gem.name)
-        # always overwrite requirements if specified
-        old.requirements = _gem.requirements unless no_constrains?(_gem.requirements)
+        # always overwrite requirements
+        old.requirements = _gem.requirements
         # but merge options
         old.options = old.options.merge(_gem.options)
       else

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -79,6 +79,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     install_gems_list!(gems)
     remove_unused_locally_installed_gems!
     remove_unused_integration_overlaps!
+    remove_orphan_dependencies!
   end
 
   private

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -67,6 +67,7 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     exit(1) unless ::Bundler::LogstashUninstall.uninstall!(plugin_list)
     LogStash::Bundler.genericize_platform
     remove_unused_locally_installed_gems!
+    remove_orphan_dependencies!
   rescue => exception
     report_exception("Operation aborted, cannot remove plugin", exception)
   end

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -95,10 +95,8 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
       output << LogStash::Bundler.genericize_platform unless output.nil?
     end
 
-    # We currently dont removed unused gems from the logstash installation
-    # see: https://github.com/elastic/logstash/issues/6339
-    # output = LogStash::Bundler.invoke!(:clean => true)
     display_updated_plugins(previous_gem_specs_map)
+    remove_orphan_dependencies!
   rescue => exception
     gemfile.restore!
     report_exception("Updated Aborted", exception)

--- a/qa/integration/fixtures/update_spec.yml
+++ b/qa/integration/fixtures/update_spec.yml
@@ -1,0 +1,3 @@
+---
+services:
+  - logstash

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -19,6 +19,7 @@ require_relative "../../framework/fixture"
 require_relative "../../framework/settings"
 require_relative "../../services/logstash_service"
 require_relative "../../framework/helpers"
+require_relative "pluginmanager_spec_helper"
 require "logstash/devutils/rspec/spec_helper"
 require "stud/temporary"
 require "fileutils"
@@ -29,22 +30,31 @@ def gem_in_lock_file?(pattern, lock_file)
   content.match(pattern)
 end
 
+def plugin_filename_re(name, version)
+  %Q(\b#{Regexp.escape name}-#{Regexp.escape version}(-java)?\b)
+end
+
 # Bundler can mess up installation successful output: https://github.com/elastic/logstash/issues/15801
 INSTALL_SUCCESS_RE = /IB?nstall successful/
 INSTALLATION_SUCCESS_RE = /IB?nstallation successful/
 
+INSTALLATION_ABORTED_RE = /Installation aborted/
+
 describe "CLI > logstash-plugin install" do
-  before(:all) do
+  before(:each) do
     @fixture = Fixture.new(__FILE__)
     @logstash = @fixture.get_service("logstash")
     @logstash_plugin = @logstash.plugin_cli
-    @pack_directory =  File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-dummy-pack"))
   end
 
   shared_examples "install from a pack" do
     let(:pack) { "file://#{File.join(@pack_directory, "logstash-dummy-pack.zip")}" }
     let(:install_command) { "bin/logstash-plugin install" }
     let(:change_dir) { true }
+
+    before(:all) do
+      @pack_directory =  File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-dummy-pack"))
+    end
 
     # When you are on anything by linux we won't disable the internet with seccomp
     if RbConfig::CONFIG["host_os"] == "linux"
@@ -149,6 +159,97 @@ describe "CLI > logstash-plugin install" do
 
         installed = @logstash_plugin.list(plugin_name)
         expect(installed.stderr_and_stdout).to match(/#{plugin_name}/)
+      end
+    end
+  end
+
+  context "rubygems hosted plugin" do
+    include_context "pluginmanager validation helpers"
+    shared_examples("overwriting existing") do
+      # let(:plugin_name) { defined?(super) ? super() : fail }
+      # let(:existing_plugin_version) { defined?(super) ? super() : fail }
+      # let(:specified_plugin_version) { defined?(super) ? super() : fail }
+      before(:each) do
+        aggregate_failures("precheck") do
+          expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem
+          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+        end
+        aggregate_failures("setup") do
+          execute = @logstash_plugin.install(plugin_name, version: existing_plugin_version)
+
+          expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+          expect(execute.exit_code).to eq(0)
+
+          expect("#{plugin_name}-#{existing_plugin_version}").to be_installed_gem
+          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+        end
+      end
+      it "installs the specified version and removes the pre-existing one" do
+        execute = @logstash_plugin.install(plugin_name, version: specified_plugin_version)
+
+        aggregate_failures("command execution") do
+          expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+          expect(execute.exit_code).to eq(0)
+        end
+
+        installed = @logstash_plugin.list(plugin_name, verbose: true)
+        expect(installed.stderr_and_stdout).to match(/#{Regexp.escape plugin_name} [(]#{Regexp.escape(specified_plugin_version)}[)]/)
+
+        expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem
+        expect("#{plugin_name}-#{specified_plugin_version}").to be_installed_gem
+      end
+    end
+
+    context "when installing over an older version" do
+      let(:plugin_name) { "logstash-filter-qatest" }
+      let(:existing_plugin_version) { "0.1.0" }
+      let(:specified_plugin_version) { "0.1.1" }
+
+      include_examples "overwriting existing"
+    end
+
+    context "when installing over a newer version" do
+      let(:plugin_name) { "logstash-filter-qatest" }
+      let(:existing_plugin_version) { "0.1.0" }
+      let(:specified_plugin_version) { "0.1.1" }
+
+      include_examples "overwriting existing"
+    end
+
+    context "installing plugin that isn't present" do
+      it "installs the plugin" do
+        aggregate_failures("prevalidation") do
+          expect("logstash-filter-qatest").to_not be_installed_gem
+        end
+
+        execute = @logstash_plugin.install("logstash-filter-qatest")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+        expect(execute.exit_code).to eq(0)
+
+        installed = @logstash_plugin.list("logstash-filter-qatest")
+        expect(installed.stderr_and_stdout).to match(/logstash-filter-qatest/)
+        expect(installed.exit_code).to eq(0)
+
+        expect(gem_in_lock_file?(/logstash-filter-qatest/, @logstash.lock_file)).to be_truthy
+
+        expect("logstash-filter-qatest").to be_installed_gem
+      end
+    end
+    context "installing plugin that doesn't exist on rubygems" do
+      it "doesn't install anything" do
+        execute = @logstash_plugin.install("logstash-filter-404-no-exist")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_ABORTED_RE)
+        expect(execute.exit_code).to eq(1)
+      end
+    end
+    context "installing gem that isn't a plugin" do
+      it "doesn't install anything" do
+        execute = @logstash_plugin.install("dummy_gem")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_ABORTED_RE)
+        expect(execute.exit_code).to eq(1)
       end
     end
   end

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -166,9 +166,6 @@ describe "CLI > logstash-plugin install" do
   context "rubygems hosted plugin" do
     include_context "pluginmanager validation helpers"
     shared_examples("overwriting existing") do
-      # let(:plugin_name) { defined?(super) ? super() : fail }
-      # let(:existing_plugin_version) { defined?(super) ? super() : fail }
-      # let(:specified_plugin_version) { defined?(super) ? super() : fail }
       before(:each) do
         aggregate_failures("precheck") do
           expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem

--- a/qa/integration/specs/cli/pluginmanager_spec_helper.rb
+++ b/qa/integration/specs/cli/pluginmanager_spec_helper.rb
@@ -1,0 +1,59 @@
+require 'pathname'
+
+shared_context "pluginmanager validation helpers" do
+
+  matcher :be_installed_gem do
+    match do |actual|
+      common(actual)
+      @gemspec_present && @gem_installed
+    end
+
+    match_when_negated do |actual|
+      common(actual)
+      !@gemspec_present && !@gem_installed
+    end
+
+    define_method :common do |actual|
+      version_suffix = /-[0-9.]+(-java)?$/
+      filename_matcher = actual.match?(version_suffix) ? actual : /^#{Regexp.escape(actual)}#{version_suffix}/
+
+      @gems = (logstash_gemdir / "gems").glob("*-*")
+      @gemspecs = (logstash_gemdir / "specifications").glob("*-*.gemspec")
+
+      @gem_installed = @gems.find { |gem| gem.basename.to_s.match?(filename_matcher) }
+      @gemspec_present = @gemspecs.find { |gemspec| gemspec.basename(".gemspec").to_s.match?(filename_matcher) }
+    end
+
+    failure_message do |actual|
+      reasons = []
+      reasons << "the gem dir could not be found (#{@gems})" unless @gem_installed
+      reasons << "the gemspec could not be found (#{@gemspecs})" unless @gemspec_present
+
+      "expected that #{actual} would be installed, but #{reasons.join(' and ')}"
+    end
+    failure_message_when_negated do |actual|
+      reasons = []
+      reasons << "the gem dir is present (#{@gem_installed})" if @gem_installed
+      reasons << "the gemspec is present (#{@gemspec_present})" if @gemspec_present
+
+      "expected that #{actual} would not be installed, but #{reasons.join(' and ')}"
+    end
+  end
+
+  def logstash_home
+    return super() if defined?(super)
+    return @logstash.logstash_home if @logstash
+    fail("no @logstash, so we can't get logstash_home")
+  end
+
+  def logstash_gemdir
+    pathname_base = (Pathname.new(logstash_home) / "vendor" / "bundle" / "jruby")
+    candidate_dirs = pathname_base.glob("[0-9]*")
+    case candidate_dirs.size
+    when 0 then fail("no version dir found in #{pathname_base}")
+    when 1 then candidate_dirs.first
+    else
+      fail("multiple version dirs found in #{pathname_base} (#{candidate_dirs.map(&:basename)}")
+    end
+  end
+end

--- a/qa/integration/specs/cli/update_spec.rb
+++ b/qa/integration/specs/cli/update_spec.rb
@@ -1,0 +1,65 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative "../../framework/fixture"
+require_relative "../../framework/settings"
+require_relative "../../services/logstash_service"
+require_relative "../../framework/helpers"
+require_relative "pluginmanager_spec_helper"
+require "logstash/devutils/rspec/spec_helper"
+
+describe "CLI > logstash-plugin update" do
+
+  include_context "pluginmanager validation helpers"
+
+  before(:each) do
+    @fixture = Fixture.new(__FILE__)
+    @logstash = @fixture.get_service("logstash")
+    @logstash_plugin = @logstash.plugin_cli
+  end
+
+  context "upgrading a plugin" do
+    before(:each) do
+      aggregate_failures("precheck") do
+        expect("logstash-filter-qatest").to_not be_installed_gem
+      end
+      aggregate_failures("setup") do
+        execute = @logstash_plugin.install("logstash-filter-qatest", version: "0.1.0")
+
+        expect(execute.stderr_and_stdout).to match(/Installation successful/)
+        expect(execute.exit_code).to eq(0)
+
+        expect("logstash-filter-qatest-0.1.0").to be_installed_gem
+      end
+    end
+    it "upgrades the plugin and cleans the old one" do
+      execute = @logstash_plugin.update("logstash-filter-qatest")
+
+      aggregate_failures("command execution") do
+        expect(execute.stderr_and_stdout).to include("Updated logstash-filter-qatest 0.1.0 to 0.1.1")
+        expect(execute.exit_code).to eq(0)
+      end
+
+      installed = @logstash_plugin.list("logstash-filter-qatest", verbose: true)
+      expect(execute.exit_code).to eq(0)
+      expect(installed.stderr_and_stdout).to include("logstash-filter-qatest")
+
+      expect("logstash-filter-qatest-0.1.1").to be_installed_gem
+      expect("logstash-filter-qatest-0.1.0").to_not be_installed_gem
+    end
+  end
+end


### PR DESCRIPTION
## Release notes

 - FIX: The plugin manager now correctly cleans up plugins and gem dependencies that are no longer needed after invoking `install`, `remove`, or `update`.
 - FIX: The plugin manager's `update` command no longer fails to upgrade plugins that were initially installed with `--version` flag

## What does this PR do?

 - Takes the previously-reviewed guts of https://github.com/elastic/logstash/pull/16998 and attaches the `clean` operation to the successful completions of the `update`, `remove`, and `install` commands _instead of_ as its own stand-alone command.
 - Fixes https://github.com/elastic/logstash/issues/17196, in which the `update` command fails to update plugins that were initially installed with a `--version` flag

## Why is it important/What is the impact to the user?

  - For users who update, install, or remove plugins, cleaning out deactivated dependencies can reduce the disk footprint of the logstash installation
  - For building Logstash artifacts, this allows us to build a true subset of the dependency graph after removing plugins that are not needed in a minimalized artifact

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Likely the easiest is to install, remove, or update plugins, observe the output, and check how the `vendor/bundle` was changed:

1. Installing a plugin should remove overwritten plugins and orphaned dependencies
   ~~~
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
   bin/logstash-plugin install --version 4.1.2 logstash-output-email
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
   diff -u vendor_snapshot.txt vendor_compare.txt
   ~~~
2. Updating a plugin should remove the previous version (and its shared dependencies)
   ~~~
   bin/logstash-plugin install --version 4.1.2 logstash-output-email
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
   bin/logstash-plugin update logstash-output-email
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
   diff -u vendor_snapshot.txt vendor_compare.txt
   ~~~
3. Removing a plugin should remove the plugin gem _and_ its unshared dependencies:
   ~~~
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
   bin/logstash-plugin remove logstash-integration-aws
   find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
   diff -u vendor_snapshot.txt vendor_compare.txt
   ~~~

## Related issues

 - Resolves: https://github.com/elastic/logstash/issues/17196
 - Supersedes: https://github.com/elastic/logstash/pull/16998

