### PR TITLE
[docs] Add missing `mapped_page`

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,24 +2,25 @@
 navigation_title: "Logstash"
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/releasenotes.html
+  - https://www.elastic.co/guide/en/logstash/master/upgrading-logstash-9.0.html
 ---
 
 # Logstash release notes [logstash-release-notes]
 
-Review the changes, fixes, and more in each version of Logstash. 
+Review the changes, fixes, and more in each version of Logstash.
 
 To check for security updates, go to [Security announcements for the Elastic stack](https://discuss.elastic.co/c/announcements/security-announcements/31).
 
-% Release notes include only features, enhancements, and fixes. Add breaking changes, deprecations, and known issues to the applicable release notes sections. 
+% Release notes include only features, enhancements, and fixes. Add breaking changes, deprecations, and known issues to the applicable release notes sections.
 
 % ## version.next [logstash-next-release-notes]
 % **Release date:** Month day, year
 
 % ### Features and enhancements [logstash-next-features-enhancements]
-% * 
+% *
 
 % ### Fixes [logstash-next-fixes]
-% * 
+% *
 
 ## 9.0.0 [logstash-900-release-notes]
 **Release date:** March 25, 2025


### PR DESCRIPTION
I revisited the IA inventory to make sure nothing slipped through the cracks during the most recent move. This just adds one URL to an existing page's `mapped_pages` for tracking purposes.