### PR TITLE
Fix pqcheck and pqrepair on Windows

### DIFF
--- a/bin/pqcheck.bat
+++ b/bin/pqcheck.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-"%JAVACMD%" "%JAVA_OPTS%" -cp "%CLASSPATH%" org.logstash.ackedqueue.PqCheck %*
+"%JAVACMD%" %JAVA_OPTS% org.logstash.ackedqueue.PqCheck %*
 
 :concat
 IF not defined CLASSPATH (

--- a/bin/pqrepair.bat
+++ b/bin/pqrepair.bat
@@ -16,7 +16,7 @@ for %%i in ("%LS_HOME%\logstash-core\lib\jars\*.jar") do (
 	call :concat "%%i"
 )
 
-"%JAVACMD%" %JAVA_OPTS% -cp "%CLASSPATH%" org.logstash.ackedqueue.PqRepair %*
+"%JAVACMD%" %JAVA_OPTS% org.logstash.ackedqueue.PqRepair %*
 
 :concat
 IF not defined CLASSPATH (


### PR DESCRIPTION
A recent change to pqcheck, attempted to address an issue where the pqcheck would not on Windows mahcines when located in a folder containing a space, such as "C:\program files\elastic\logstash". While this fixed an issue with spaces in folders, it introduced a new issue related to Java options, and the pqcheck was still unable to run on Windows.

This PR attempts to address the issue, by removing the quotes around the Java options, which caused the option parsing to fail, and instead removes the explicit setting of the classpath - the use of `set CLASSPATH=` in the `:concat` function is sufficient to set the classpath, and should also fix the spaces issue

Fixes: #17209

