### PR TITLE
mergify: support for some backport aliases

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -112,3 +112,59 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to all active minor branches for the 8 major.
+    conditions:
+      - merged
+      - label=backport-active-8
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "8.x"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+
+  - name: backport patches to all active minor branches for the 9 major.
+    conditions:
+      - merged
+      - label=backport-active-9
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "9.0"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+
+  - name: backport patches to all active branches
+    conditions:
+      - merged
+      - label=backport-active-all
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing release branch reached EOL.
+        branches:
+          - "9.0"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+          - "8.x"
+          - "7.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -113,7 +113,7 @@ pull_request_rules:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
 
- - name: backport patches to 8.18 branch
+  - name: backport patches to 8.18 branch
     conditions:
       - merged
       - base=main
@@ -128,7 +128,7 @@ pull_request_rules:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
 
- - name: backport patches to 9.0 branch
+  - name: backport patches to 9.0 branch
     conditions:
       - merged
       - base=main


### PR DESCRIPTION
this should help with backporting to the current active branches

without knowing the active minor but using the major one

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

> Maybe this is solved already, but is there a way we can get an automatically kept up to date “backport-active-minors” label that auto backports to the set of minor releases that are still supported? I’d want this in Beats, Elastic Agent, and Fleet Server if it already exists. I’ve noticed an increase in forgotten backports because there are more releases to keep track of. If we can abstract this it’d make life easier, I think Kibana does something like this


We, observability robots team, are responsible for keeping those aliases in sync - we are working on the automation for that.

## Why is it important/What is the impact to the user?

Enable `backport-active-all`, `backport-active-8` and `backport-active-9` GitHub labels in Mergify to backport to a set of active branches in addition to the existing automation with the `backport-<major>.<minor>` labels. This can help with the current 6 active branches, which we have today.

Therefore, if a PR takes longer to be merged, these aliases can help avoid the burden of updating the `backport-[major].[minor]` labels.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Similarly solved in other projects:
  - https://github.com/elastic/fleet-server/pull/4404
  - 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
