### PR TITLE
[test] ls2ls spec adds heartbeat to keep alive

### DIFF
--- a/qa/integration/fixtures/logstash_to_logstash_spec.yml
+++ b/qa/integration/fixtures/logstash_to_logstash_spec.yml
@@ -22,7 +22,6 @@ config:
       generator {
         count => '<%=options[:generator_count]%>'
       }
-      # workaround for flushing the last batch of PQ
       heartbeat {
         interval => 1
         message => "heartbeat"

--- a/qa/integration/fixtures/logstash_to_logstash_spec.yml
+++ b/qa/integration/fixtures/logstash_to_logstash_spec.yml
@@ -22,6 +22,7 @@ config:
       generator {
         count => '<%=options[:generator_count]%>'
       }
+      # workaround for flushing the last batch of PQ
       heartbeat {
         interval => 1
         message => "heartbeat"

--- a/qa/integration/fixtures/logstash_to_logstash_spec.yml
+++ b/qa/integration/fixtures/logstash_to_logstash_spec.yml
@@ -22,6 +22,15 @@ config:
       generator {
         count => '<%=options[:generator_count]%>'
       }
+      heartbeat {
+        interval => 1
+        message => "heartbeat"
+      }
+    }
+    filter {
+      if "heartbeat" == [message] {
+        drop {}
+      }
     }
     output {
       logstash {


### PR DESCRIPTION
From: Mashhurs  https://github.com/yaauie/logstash/pull/5

Adds heartbeat-input to the LS to LS integration test config to keep upstream Logstash alive.