### PR TITLE
Pluginmanager install preserve

### DIFF
--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -214,7 +214,9 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       plugin_gem = gemfile.find(plugin)
       if preserve?
         puts("Preserving Gemfile gem options for plugin #{plugin}") if plugin_gem && !plugin_gem.options.empty?
-        gemfile.update(plugin, version, options)
+        # if the plugin exists and no version was specified, keep the existing requirements
+        requirements = (plugin_gem && version.nil? ? plugin_gem.requirements : [version]).compact
+        gemfile.update(plugin, *requirements, options)
       else
         gemfile.overwrite(plugin, version, options)
       end


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Fixes a regression introduced in https://github.com/elastic/logstash/pull/17203 that caused the `bin/logstash-plugin install --preserve` flag to not preserve.

## Why is it important/What is the impact to the user?

 - When a plugin is installed with `--version`, the `Gemfile` is amended to add the plugin and its version requirement.
 - When this version requirement is present, installing it again with the `--preserve` flag should preserve the requirement.
 - A fix to allow plugins installed with `--version` to be _upgraded_ had the side-effect of making the install command's `--preserve` not work.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works


## How to test this PR locally

This PR comes with tests and a fix separately. The tests can be used to verify the pre-broken behaviour as so:

1. check out the branch
2. revert the fixing commit and observe test failures:
   back-out the portion of the breaking commit
   ~~~
   git revert --no-commit HEAD
   ci/integration_tests.sh specs/cli/install_spec.rb
   ~~~
3. revert [the portion](https://github.com/elastic/logstash/pull/17203/files#diff-7a7c56f3a27fd43aa2c1a8ecf2452ccb9908add2f6b2467039b4e3545f28e631) of #17203 that caused the regression, and observe that tests pass:
   ~~~
   git diff 8c969138073b98de7a99daf3c62527e5758711f9^! -- lib/pluginmanager/gemfile.rb | patch --strip 1 --reverse
   ci/integration_tests.sh specs/cli/install_spec.rb
   ~~~
