### PR TITLE
Backport 17203 and 17267 fedramp8x

### DIFF
--- a/lib/pluginmanager/gemfile.rb
+++ b/lib/pluginmanager/gemfile.rb
@@ -133,8 +133,8 @@ module LogStash
     # update existing or add new
     def update_gem(_gem)
       if old = find_gem(_gem.name)
-        # always overwrite requirements if specified
-        old.requirements = _gem.requirements unless no_constrains?(_gem.requirements)
+        # always overwrite requirements
+        old.requirements = _gem.requirements
         # but merge options
         old.options = old.options.merge(_gem.options)
       else

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -214,7 +214,9 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
       plugin_gem = gemfile.find(plugin)
       if preserve?
         puts("Preserving Gemfile gem options for plugin #{plugin}") if plugin_gem && !plugin_gem.options.empty?
-        gemfile.update(plugin, version, options)
+        # if the plugin exists and no version was specified, keep the existing requirements
+        requirements = (plugin_gem && version.nil? ? plugin_gem.requirements : [version]).compact
+        gemfile.update(plugin, *requirements, options)
       else
         gemfile.overwrite(plugin, version, options)
       end

--- a/lib/pluginmanager/install.rb
+++ b/lib/pluginmanager/install.rb
@@ -79,6 +79,7 @@ class LogStash::PluginManager::Install < LogStash::PluginManager::Command
     install_gems_list!(gems)
     remove_unused_locally_installed_gems!
     remove_unused_integration_overlaps!
+    remove_orphan_dependencies!
   end
 
   private

--- a/lib/pluginmanager/remove.rb
+++ b/lib/pluginmanager/remove.rb
@@ -67,6 +67,7 @@ class LogStash::PluginManager::Remove < LogStash::PluginManager::Command
     exit(1) unless ::Bundler::LogstashUninstall.uninstall!(plugin_list)
     LogStash::Bundler.genericize_platform
     remove_unused_locally_installed_gems!
+    remove_orphan_dependencies!
   rescue => exception
     report_exception("Operation aborted, cannot remove plugin", exception)
   end

--- a/lib/pluginmanager/update.rb
+++ b/lib/pluginmanager/update.rb
@@ -95,10 +95,8 @@ class LogStash::PluginManager::Update < LogStash::PluginManager::Command
       output << LogStash::Bundler.genericize_platform unless output.nil?
     end
 
-    # We currently dont removed unused gems from the logstash installation
-    # see: https://github.com/elastic/logstash/issues/6339
-    # output = LogStash::Bundler.invoke!(:clean => true)
     display_updated_plugins(previous_gem_specs_map)
+    remove_orphan_dependencies!
   rescue => exception
     gemfile.restore!
     report_exception("Updated Aborted", exception)

--- a/qa/integration/fixtures/update_spec.yml
+++ b/qa/integration/fixtures/update_spec.yml
@@ -1,0 +1,3 @@
+---
+services:
+  - logstash

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -165,11 +165,11 @@ describe "CLI > logstash-plugin install" do
 
   context "rubygems hosted plugin", :skip_fips do
     include_context "pluginmanager validation helpers"
-    shared_examples("overwriting existing") do
+    shared_context("install over existing") do
       before(:each) do
         aggregate_failures("precheck") do
           expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem
-          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+          expect("#{plugin_name}").to_not be_installed_gem
         end
         aggregate_failures("setup") do
           execute = @logstash_plugin.install(plugin_name, version: existing_plugin_version)
@@ -178,9 +178,12 @@ describe "CLI > logstash-plugin install" do
           expect(execute.exit_code).to eq(0)
 
           expect("#{plugin_name}-#{existing_plugin_version}").to be_installed_gem
-          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+          expect(plugin_name).to be_in_gemfile.with_requirements(existing_plugin_version)
         end
       end
+    end
+    shared_examples("overwriting existing with explicit version") do
+      include_context "install over existing"
       it "installs the specified version and removes the pre-existing one" do
         execute = @logstash_plugin.install(plugin_name, version: specified_plugin_version)
 
@@ -197,20 +200,72 @@ describe "CLI > logstash-plugin install" do
       end
     end
 
-    context "when installing over an older version" do
+    context "when installing over an older version using --version" do
       let(:plugin_name) { "logstash-filter-qatest" }
       let(:existing_plugin_version) { "0.1.0" }
       let(:specified_plugin_version) { "0.1.1" }
 
-      include_examples "overwriting existing"
+      include_examples "overwriting existing with explicit version"
     end
 
-    context "when installing over a newer version" do
+    context "when installing over a newer version using --version" do
       let(:plugin_name) { "logstash-filter-qatest" }
       let(:existing_plugin_version) { "0.1.0" }
       let(:specified_plugin_version) { "0.1.1" }
 
-      include_examples "overwriting existing"
+      include_examples "overwriting existing with explicit version"
+    end
+
+    context "when installing over existing without --version" do
+      let(:plugin_name) { "logstash-filter-qatest" }
+      let(:existing_plugin_version) { "0.1.0" }
+
+      include_context "install over existing"
+
+      context "with --preserve" do
+        it "succeeds without changing the requirements in the Gemfile" do
+          execute = @logstash_plugin.install(plugin_name, preserve: true)
+
+          aggregate_failures("command execution") do
+            expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+            expect(execute.exit_code).to eq(0)
+          end
+
+          installed = @logstash_plugin.list(verbose: true)
+          expect(installed.stderr_and_stdout).to match(/#{Regexp.escape plugin_name}/)
+
+          # we want to ensure that the act of installing an already-installed plugin
+          # does not change its requirements in the gemfile, and leaves the previously-installed
+          # version in-tact.
+          expect(plugin_name).to be_in_gemfile.with_requirements(existing_plugin_version)
+          expect("#{plugin_name}-#{existing_plugin_version}").to be_installed_gem
+        end
+      end
+
+      context "without --preserve" do
+        # this spec is OBSERVED behaviour, which I believe to be undesirable.
+        it "succeeds and removes the version requirement from the Gemfile" do
+          execute = @logstash_plugin.install(plugin_name)
+
+          aggregate_failures("command execution") do
+            expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+            expect(execute.exit_code).to eq(0)
+          end
+
+          installed = @logstash_plugin.list(plugin_name, verbose: true)
+          expect(installed.stderr_and_stdout).to match(/#{Regexp.escape plugin_name}/)
+
+          # This is the potentially-undesirable surprising behaviour, specified here
+          # as a means of documentation, not a promise of future behavior.
+          expect(plugin_name).to be_in_gemfile.without_requirements
+
+          # we expect _a_ version of the plugin to be installed, but cannot be opinionated
+          # about which version was installed because bundler won't necessarily re-resolve
+          # the dependency graph to get us an upgrade since the no-requirements dependency
+          # is still met (but it MAY do so if also installing plugins that are not present).
+          expect("#{plugin_name}").to be_installed_gem
+        end
+      end
     end
 
     context "installing plugin that isn't present" do

--- a/qa/integration/specs/cli/install_spec.rb
+++ b/qa/integration/specs/cli/install_spec.rb
@@ -19,6 +19,7 @@ require_relative "../../framework/fixture"
 require_relative "../../framework/settings"
 require_relative "../../services/logstash_service"
 require_relative "../../framework/helpers"
+require_relative "pluginmanager_spec_helper"
 require "logstash/devutils/rspec/spec_helper"
 require "stud/temporary"
 require "fileutils"
@@ -29,22 +30,31 @@ def gem_in_lock_file?(pattern, lock_file)
   content.match(pattern)
 end
 
+def plugin_filename_re(name, version)
+  %Q(\b#{Regexp.escape name}-#{Regexp.escape version}(-java)?\b)
+end
+
 # Bundler can mess up installation successful output: https://github.com/elastic/logstash/issues/15801
 INSTALL_SUCCESS_RE = /IB?nstall successful/
 INSTALLATION_SUCCESS_RE = /IB?nstallation successful/
 
+INSTALLATION_ABORTED_RE = /Installation aborted/
+
 describe "CLI > logstash-plugin install" do
-  before(:all) do
+  before(:each) do
     @fixture = Fixture.new(__FILE__)
     @logstash = @fixture.get_service("logstash")
     @logstash_plugin = @logstash.plugin_cli
-    @pack_directory =  File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-dummy-pack"))
   end
 
   shared_examples "install from a pack" do
     let(:pack) { "file://#{File.join(@pack_directory, "logstash-dummy-pack.zip")}" }
     let(:install_command) { "bin/logstash-plugin install" }
     let(:change_dir) { true }
+
+    before(:all) do
+      @pack_directory =  File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "fixtures", "logstash-dummy-pack"))
+    end
 
     # When you are on anything by linux we won't disable the internet with seccomp
     if RbConfig::CONFIG["host_os"] == "linux"
@@ -149,6 +159,94 @@ describe "CLI > logstash-plugin install" do
 
         installed = @logstash_plugin.list(plugin_name)
         expect(installed.stderr_and_stdout).to match(/#{plugin_name}/)
+      end
+    end
+  end
+
+  context "rubygems hosted plugin", :skip_fips do
+    include_context "pluginmanager validation helpers"
+    shared_examples("overwriting existing") do
+      before(:each) do
+        aggregate_failures("precheck") do
+          expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem
+          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+        end
+        aggregate_failures("setup") do
+          execute = @logstash_plugin.install(plugin_name, version: existing_plugin_version)
+
+          expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+          expect(execute.exit_code).to eq(0)
+
+          expect("#{plugin_name}-#{existing_plugin_version}").to be_installed_gem
+          expect("#{plugin_name}-#{specified_plugin_version}").to_not be_installed_gem
+        end
+      end
+      it "installs the specified version and removes the pre-existing one" do
+        execute = @logstash_plugin.install(plugin_name, version: specified_plugin_version)
+
+        aggregate_failures("command execution") do
+          expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+          expect(execute.exit_code).to eq(0)
+        end
+
+        installed = @logstash_plugin.list(plugin_name, verbose: true)
+        expect(installed.stderr_and_stdout).to match(/#{Regexp.escape plugin_name} [(]#{Regexp.escape(specified_plugin_version)}[)]/)
+
+        expect("#{plugin_name}-#{existing_plugin_version}").to_not be_installed_gem
+        expect("#{plugin_name}-#{specified_plugin_version}").to be_installed_gem
+      end
+    end
+
+    context "when installing over an older version" do
+      let(:plugin_name) { "logstash-filter-qatest" }
+      let(:existing_plugin_version) { "0.1.0" }
+      let(:specified_plugin_version) { "0.1.1" }
+
+      include_examples "overwriting existing"
+    end
+
+    context "when installing over a newer version" do
+      let(:plugin_name) { "logstash-filter-qatest" }
+      let(:existing_plugin_version) { "0.1.0" }
+      let(:specified_plugin_version) { "0.1.1" }
+
+      include_examples "overwriting existing"
+    end
+
+    context "installing plugin that isn't present" do
+      it "installs the plugin" do
+        aggregate_failures("prevalidation") do
+          expect("logstash-filter-qatest").to_not be_installed_gem
+        end
+
+        execute = @logstash_plugin.install("logstash-filter-qatest")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_SUCCESS_RE)
+        expect(execute.exit_code).to eq(0)
+
+        installed = @logstash_plugin.list("logstash-filter-qatest")
+        expect(installed.stderr_and_stdout).to match(/logstash-filter-qatest/)
+        expect(installed.exit_code).to eq(0)
+
+        expect(gem_in_lock_file?(/logstash-filter-qatest/, @logstash.lock_file)).to be_truthy
+
+        expect("logstash-filter-qatest").to be_installed_gem
+      end
+    end
+    context "installing plugin that doesn't exist on rubygems" do
+      it "doesn't install anything" do
+        execute = @logstash_plugin.install("logstash-filter-404-no-exist")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_ABORTED_RE)
+        expect(execute.exit_code).to eq(1)
+      end
+    end
+    context "installing gem that isn't a plugin" do
+      it "doesn't install anything" do
+        execute = @logstash_plugin.install("dummy_gem")
+
+        expect(execute.stderr_and_stdout).to match(INSTALLATION_ABORTED_RE)
+        expect(execute.exit_code).to eq(1)
       end
     end
   end

--- a/qa/integration/specs/cli/pluginmanager_spec_helper.rb
+++ b/qa/integration/specs/cli/pluginmanager_spec_helper.rb
@@ -1,0 +1,59 @@
+require 'pathname'
+
+shared_context "pluginmanager validation helpers" do
+
+  matcher :be_installed_gem do
+    match do |actual|
+      common(actual)
+      @gemspec_present && @gem_installed
+    end
+
+    match_when_negated do |actual|
+      common(actual)
+      !@gemspec_present && !@gem_installed
+    end
+
+    define_method :common do |actual|
+      version_suffix = /-[0-9.]+(-java)?$/
+      filename_matcher = actual.match?(version_suffix) ? actual : /^#{Regexp.escape(actual)}#{version_suffix}/
+
+      @gems = (logstash_gemdir / "gems").glob("*-*")
+      @gemspecs = (logstash_gemdir / "specifications").glob("*-*.gemspec")
+
+      @gem_installed = @gems.find { |gem| gem.basename.to_s.match?(filename_matcher) }
+      @gemspec_present = @gemspecs.find { |gemspec| gemspec.basename(".gemspec").to_s.match?(filename_matcher) }
+    end
+
+    failure_message do |actual|
+      reasons = []
+      reasons << "the gem dir could not be found (#{@gems})" unless @gem_installed
+      reasons << "the gemspec could not be found (#{@gemspecs})" unless @gemspec_present
+
+      "expected that #{actual} would be installed, but #{reasons.join(' and ')}"
+    end
+    failure_message_when_negated do |actual|
+      reasons = []
+      reasons << "the gem dir is present (#{@gem_installed})" if @gem_installed
+      reasons << "the gemspec is present (#{@gemspec_present})" if @gemspec_present
+
+      "expected that #{actual} would not be installed, but #{reasons.join(' and ')}"
+    end
+  end
+
+  def logstash_home
+    return super() if defined?(super)
+    return @logstash.logstash_home if @logstash
+    fail("no @logstash, so we can't get logstash_home")
+  end
+
+  def logstash_gemdir
+    pathname_base = (Pathname.new(logstash_home) / "vendor" / "bundle" / "jruby")
+    candidate_dirs = pathname_base.glob("[0-9]*")
+    case candidate_dirs.size
+    when 0 then fail("no version dir found in #{pathname_base}")
+    when 1 then candidate_dirs.first
+    else
+      fail("multiple version dirs found in #{pathname_base} (#{candidate_dirs.map(&:basename)}")
+    end
+  end
+end

--- a/qa/integration/specs/cli/remove_spec.rb
+++ b/qa/integration/specs/cli/remove_spec.rb
@@ -19,12 +19,17 @@ require_relative '../../framework/fixture'
 require_relative '../../framework/settings'
 require_relative '../../services/logstash_service'
 require_relative '../../framework/helpers'
+require_relative "pluginmanager_spec_helper"
 require "logstash/devutils/rspec/spec_helper"
 
 describe "CLI > logstash-plugin remove", :skip_fips do
+
+  include_context "pluginmanager validation helpers"
+
   before(:each) do
     @fixture = Fixture.new(__FILE__)
-    @logstash_plugin = @fixture.get_service("logstash").plugin_cli
+    @logstash = @fixture.get_service("logstash")
+    @logstash_plugin = @logstash.plugin_cli
   end
 
   if RbConfig::CONFIG["host_os"] == "linux"
@@ -55,6 +60,8 @@ describe "CLI > logstash-plugin remove", :skip_fips do
           presence_check = @logstash_plugin.list(test_plugin)
           expect(presence_check.exit_code).to eq(1)
           expect(presence_check.stderr_and_stdout).to match(/ERROR: No plugins found/)
+
+          expect("logstash-filter-qatest").to_not be_installed_gem
         end
       end
 
@@ -92,6 +99,38 @@ describe "CLI > logstash-plugin remove", :skip_fips do
       presence_check = @logstash_plugin.list(test_plugin)
       expect(presence_check.exit_code).to eq(1)
       expect(presence_check.stderr_and_stdout).to match(/ERROR: No plugins found/)
+
+      expect("logstash-filter-qatest").to_not be_installed_gem
+    end
+  end
+
+  context "plugins with unshared dependencies" do
+    let(:plugin_to_remove) {  }
+
+    it "successfully removes the plugin and its unshared dependencies" do
+      execute = @logstash_plugin.remove("logstash-integration-aws")
+
+      expect(execute.exit_code).to eq(0)
+      expect(execute.stderr_and_stdout).to match(/Successfully removed logstash-integration-aws/)
+
+      expect("logstash-integration-aws").to_not be_installed_gem
+
+      # known unshared dependencies, including transitive dependencies
+      aggregate_failures("known unshared dependencies") do
+        expect("aws-sdk-core").to_not be_installed_gem
+        expect("aws-sdk-s3").to_not be_installed_gem
+        expect("aws-sdk-kms").to_not be_installed_gem
+        expect("aws-sdk-cloudfront").to_not be_installed_gem
+        expect("aws-sdk-cloudwatch").to_not be_installed_gem
+        expect("aws-eventstream").to_not be_installed_gem
+        expect("aws-partitions").to_not be_installed_gem
+      end
+
+      # known shared dependencies
+      aggregate_failures("known shared dependencies") do
+        expect("concurrent-ruby").to be_installed_gem
+        expect("logstash-codec-json").to be_installed_gem
+      end
     end
   end
 
@@ -108,6 +147,8 @@ describe "CLI > logstash-plugin remove", :skip_fips do
 
       expect(presence_check.exit_code).to eq(0)
       expect(presence_check.stderr_and_stdout).to match(/logstash-codec-json/)
+
+      expect("logstash-codec-json").to be_installed_gem
     end
   end
 

--- a/qa/integration/specs/cli/update_spec.rb
+++ b/qa/integration/specs/cli/update_spec.rb
@@ -22,7 +22,7 @@ require_relative "../../framework/helpers"
 require_relative "pluginmanager_spec_helper"
 require "logstash/devutils/rspec/spec_helper"
 
-describe "CLI > logstash-plugin update" do
+describe "CLI > logstash-plugin update", :skip_fips do
 
   include_context "pluginmanager validation helpers"
 

--- a/qa/integration/specs/cli/update_spec.rb
+++ b/qa/integration/specs/cli/update_spec.rb
@@ -1,0 +1,65 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative "../../framework/fixture"
+require_relative "../../framework/settings"
+require_relative "../../services/logstash_service"
+require_relative "../../framework/helpers"
+require_relative "pluginmanager_spec_helper"
+require "logstash/devutils/rspec/spec_helper"
+
+describe "CLI > logstash-plugin update" do
+
+  include_context "pluginmanager validation helpers"
+
+  before(:each) do
+    @fixture = Fixture.new(__FILE__)
+    @logstash = @fixture.get_service("logstash")
+    @logstash_plugin = @logstash.plugin_cli
+  end
+
+  context "upgrading a plugin" do
+    before(:each) do
+      aggregate_failures("precheck") do
+        expect("logstash-filter-qatest").to_not be_installed_gem
+      end
+      aggregate_failures("setup") do
+        execute = @logstash_plugin.install("logstash-filter-qatest", version: "0.1.0")
+
+        expect(execute.stderr_and_stdout).to match(/Installation successful/)
+        expect(execute.exit_code).to eq(0)
+
+        expect("logstash-filter-qatest-0.1.0").to be_installed_gem
+      end
+    end
+    it "upgrades the plugin and cleans the old one" do
+      execute = @logstash_plugin.update("logstash-filter-qatest")
+
+      aggregate_failures("command execution") do
+        expect(execute.stderr_and_stdout).to include("Updated logstash-filter-qatest 0.1.0 to 0.1.1")
+        expect(execute.exit_code).to eq(0)
+      end
+
+      installed = @logstash_plugin.list("logstash-filter-qatest", verbose: true)
+      expect(execute.exit_code).to eq(0)
+      expect(installed.stderr_and_stdout).to include("logstash-filter-qatest")
+
+      expect("logstash-filter-qatest-0.1.1").to be_installed_gem
+      expect("logstash-filter-qatest-0.1.0").to_not be_installed_gem
+    end
+  end
+end


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

From #17203:

>  - FIX: The plugin manager now correctly cleans up plugins and gem dependencies that are no longer needed after invoking `install`, `remove`, or `update`.
>  - FIX: The plugin manager's `update` command no longer fails to upgrade plugins that were initially installed with `--version` flag


## What does this PR do?

Combined backports of #17203 and #17267 to `feature/fedramp-high-8.x`

#17203 includes a regression to the behavior of `bin/logstash-plugin install`'s `--preserve` flag, which was addressed in #17267.

CONFLICTS: `:skip_fips` flags were added

## Why is it important/What is the impact to the user?

>   - For users who update, install, or remove plugins, cleaning out deactivated dependencies can reduce the disk footprint of the logstash installation
>   - For building Logstash artifacts, this allows us to build a true subset of the dependency graph after removing plugins that are not needed in a minimalized artifact

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

From #17203:

> 1. Installing a plugin should remove overwritten plugins and orphaned dependencies
>    ~~~
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
>    bin/logstash-plugin install --version 4.1.2 logstash-output-email
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
>    diff -u vendor_snapshot.txt vendor_compare.txt
>    ~~~
> 2. Updating a plugin should remove the previous version (and its shared dependencies)
>    ~~~
>    bin/logstash-plugin install --version 4.1.2 logstash-output-email
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
>    bin/logstash-plugin update logstash-output-email
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
>    diff -u vendor_snapshot.txt vendor_compare.txt
>    ~~~
> 3. Removing a plugin should remove the plugin gem _and_ its unshared dependencies:
>    ~~~
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_snapshot.txt
>    bin/logstash-plugin remove logstash-integration-aws
>    find vendor/bundle/jruby/*/* -depth 1 | sort > vendor_compare.txt
>    diff -u vendor_snapshot.txt vendor_compare.txt
>    ~~~

From #17267 (edited to be relevant to this PR):

> 1. check out the branch
> 2. revert the fixing [behavior] and observe test failures:
>    back-out the portion of the breaking commit
>    ~~~
>    git diff eac157aac1003bb3694c783727b1859cb4a93583^! -- lib/pluginmanager/install.rb | patch --strip 1 --reverse
>    ci/integration_tests.sh specs/cli/install_spec.rb
>    ~~~
> 3. revert [the portion](https://github.com/elastic/logstash/pull/17203/files#diff-7a7c56f3a27fd43aa2c1a8ecf2452ccb9908add2f6b2467039b4e3545f28e631) of #17203 that caused the regression, and observe that tests pass:
>    ~~~
>    git diff 7d813cba7ace963a0e0a43488412ea2d756113e4^! -- lib/pluginmanager/gemfile.rb | patch --strip 1 --reverse
>    ci/integration_tests.sh specs/cli/install_spec.rb
>    ~~~
