### PR TITLE
observabilitySRE: docker rake tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,6 +330,28 @@ tasks.register("compileGrammar") {
     }
 }
 
+tasks.register("artifactDockerObservabilitySRE") {
+    dependsOn bootstrap
+    inputs.files fileTree("${projectDir}/rakelib")
+    inputs.files fileTree("${projectDir}/bin")
+    inputs.files fileTree("${projectDir}/config")
+    inputs.files fileTree("${projectDir}/lib")
+    inputs.files fileTree("${projectDir}/logstash-core-plugin-api")
+    inputs.files fileTree("${projectDir}/logstash-core/lib")
+    inputs.files fileTree("${projectDir}/logstash-core/src")
+    inputs.files fileTree("${projectDir}/x-pack")
+    outputs.files fileTree("${buildDir}") {
+        include "Dockerfile-observability-sre"
+        include "logstash-observability-sre-${project.version}-SNAPSHOT-linux-*.tar.gz"
+        include "logstash-observability-sre-${project.version}-SNAPSHOT-docker-build-context.tar.gz"
+        include "plugin_aliases_hashed.yml"
+        include "jdk-*-linux-*.tar.gz"
+    }
+    doLast {
+        rake(projectDir, buildDir, 'artifact:build_docker_observabilitySRE')
+    }
+}
+
 tasks.register("assembleTarDistribution") {
   dependsOn bootstrap
   inputs.files fileTree("${projectDir}/rakelib")

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -60,7 +60,7 @@ build-from-local-observability-sre-artifacts: dockerfile
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
 	docker build --progress=plain --network=host -t $(IMAGE_TAG)-observability-sre:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-observability-sre data/logstash || \
-	  (docker kill $(HTTPD); false); \
+	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
 build-from-local-wolfi-artifacts: dockerfile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -61,7 +61,7 @@ build-from-local-observability-sre-artifacts: dockerfile
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
 	docker build --progress=plain --network=host -t $(IMAGE_TAG)-observability-sre:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-observability-sre data/logstash || \
 	  (docker kill $(HTTPD); false); \
-	docker kill $(HTTPD)
+	-docker kill $(HTTPD)
 
 build-from-local-wolfi-artifacts: dockerfile
 	docker run --rm -d --name=$(HTTPD) \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,13 +16,13 @@ else
   ARCHITECTURE := $(shell uname -m)
 endif
 
-IMAGE_FLAVORS ?= oss full ubi8 wolfi
+IMAGE_FLAVORS ?= oss full ubi8 wolfi observability-sre
 DEFAULT_IMAGE_FLAVOR ?= full
 
 IMAGE_TAG := $(ELASTIC_REGISTRY)/logstash/logstash
 HTTPD ?= logstash-docker-artifact-server
 
-all: build-from-local-artifacts build-from-local-oss-artifacts public-dockerfiles
+all: build-from-local-artifacts build-from-local-oss-artifacts build-from-local-observability-sre-artifacts public-dockerfiles
 
 # Build from artifacts on the local filesystem, using an http server (running
 # in a container) to provide the artifacts to the Dockerfile.
@@ -53,6 +53,15 @@ build-from-local-ubi8-artifacts: dockerfile env2yaml
 	docker build --progress=plain --network=host -t $(IMAGE_TAG)-ubi8:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-ubi8 data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
+
+build-from-local-observability-sre-artifacts: dockerfile
+	docker run --rm -d --name=$(HTTPD) \
+	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
+	           python:3 bash -c 'cd /mnt && python3 -m http.server'
+	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
+	docker build --progress=plain --network=host -t $(IMAGE_TAG)-observability-sre:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-observability-sre data/logstash || \
+	  (docker kill $(HTTPD); false); \
+	docker kill $(HTTPD)
 
 build-from-local-wolfi-artifacts: dockerfile
 	docker run --rm -d --name=$(HTTPD) \
@@ -118,7 +127,7 @@ ironbank_docker_paths:
 	mkdir -p $(ARTIFACTS_DIR)/ironbank/scripts/go/src/env2yaml/vendor
 	mkdir -p $(ARTIFACTS_DIR)/ironbank/scripts/pipeline
 
-public-dockerfiles: public-dockerfiles_oss public-dockerfiles_full public-dockerfiles_ubi8 public-dockerfiles_wolfi public-dockerfiles_ironbank
+public-dockerfiles: public-dockerfiles_oss public-dockerfiles_full public-dockerfiles_ubi8 public-dockerfiles_wolfi public-dockerfiles_observability-sre public-dockerfiles_ironbank
 
 public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -161,6 +170,20 @@ public-dockerfiles_ubi8: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-ubi8 Dockerfile && \
 	tar -zcf ../logstash-ubi8-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
+
+public-dockerfiles_observability-sre: templates/Dockerfile.erb docker_paths $(COPY_FILES)
+	../vendor/jruby/bin/jruby -S erb -T "-"\
+		created_date="${BUILD_DATE}" \
+		elastic_version="${ELASTIC_VERSION}" \
+		arch="${ARCHITECTURE}" \
+		version_tag="${VERSION_TAG}" \
+	  release="${RELEASE}" \
+		image_flavor="observability-sre" \
+		local_artifacts="false" \
+		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-observability-sre" && \
+	cd $(ARTIFACTS_DIR)/docker && \
+	cp $(ARTIFACTS_DIR)/Dockerfile-observability-sre Dockerfile && \
+	tar -zcf ../logstash-observability-sre-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
 
 public-dockerfiles_wolfi: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -1,5 +1,5 @@
 # This Dockerfile was generated from templates/Dockerfile.erb
-<% if image_flavor == 'wolfi' -%>
+<% if %w(wolfi observability-sre).include?(image_flavor) -%>
 FROM docker.elastic.co/wolfi/go:1-dev as builder-env2yaml
 
 COPY env2yaml/env2yaml.go /tmp/go/src/env2yaml/env2yaml.go
@@ -70,7 +70,7 @@ RUN dnf -y upgrade && \
   rm /tmp/logstash.tar.gz
 <%# End image_flavor 'ironbank' %>
 <% else -%>
-<%# Start image_flavor 'full', oss', 'ubi8', 'wolfi' %>
+<%# Start image_flavor 'full', oss', 'ubi8', 'wolfi', 'observability-sre' %>
   <% if local_artifacts == 'false' -%>
     <%   url_root = 'https://artifacts.elastic.co/downloads/logstash' -%>
   <% else -%>
@@ -79,6 +79,9 @@ RUN dnf -y upgrade && \
   <% if image_flavor == 'oss' -%>
     <%   tarball = "logstash-oss-#{elastic_version}-linux-$(arch).tar.gz" -%>
     <%   license = 'Apache 2.0' -%>
+  <% elsif image_flavor == 'observability-sre' %>
+    <%   tarball = "logstash-observability-sre-#{elastic_version}-linux-$(arch).tar.gz" -%>
+    <%   license = 'Elastic License' -%>
   <% else -%>
     <%   tarball = "logstash-#{elastic_version}-linux-$(arch).tar.gz" -%>
     <%   license = 'Elastic License' -%>
@@ -89,7 +92,7 @@ RUN dnf -y upgrade && \
     <%   arch_command = 'uname -m' -%>
     # Minimal distributions do not ship with en language packs.
     <%   locale = 'C.UTF-8' -%>
-  <% elsif image_flavor == 'wolfi' %>
+  <% elsif %w(wolfi observability-sre).include?(image_flavor) %>
     <%   base_image = 'docker.elastic.co/wolfi/chainguard-base' -%>
     <%   package_manager = 'apk' -%>
     <%   arch_command = 'uname -m' -%>
@@ -105,7 +108,7 @@ RUN dnf -y upgrade && \
 FROM <%= base_image %>
 
 RUN for iter in {1..10}; do \
-<% if image_flavor == 'wolfi' %>
+<% if %w(wolfi observability-sre).include?(image_flavor) %>
   <%= package_manager %> add --no-cache curl bash openssl && \
 <% else -%>
   <% if image_flavor == 'full' || image_flavor == 'oss' -%>
@@ -141,7 +144,7 @@ sleep 10; done; \
 (exit $exit_code)
 
 # Provide a non-root user to run the process.
-<% if image_flavor == 'wolfi' -%>
+<% if %w(wolfi observability-sre).include?(image_flavor) -%>
 RUN addgroup -g 1000 logstash && \
   adduser -u 1000 -G logstash \
   --disabled-password \
@@ -186,7 +189,7 @@ RUN chown --recursive logstash:root config/ pipeline/
 # Ensure Logstash gets the correct locale by default.
 ENV LANG=<%= locale %> LC_ALL=<%= locale %>
 
-<% if image_flavor == 'wolfi' -%>
+<% if %w(wolfi observability-sre).include?(image_flavor) -%>
 COPY --from=builder-env2yaml /tmp/go/src/env2yaml/env2yaml /usr/local/bin/env2yaml
 <% else -%>
 COPY env2yaml/env2yaml-amd64 env2yaml/env2yaml-arm64 env2yaml/
@@ -209,7 +212,7 @@ RUN set -eux; env2yamlarch="$(<%= arch_command %>)"; \
 COPY bin/docker-entrypoint /usr/local/bin/
 
 RUN chmod 0755 /usr/local/bin/docker-entrypoint
-<%# End image_flavor 'full', oss', 'ubi8', 'wolfi' %>
+<%# End image_flavor 'full', oss', 'ubi8', 'wolfi', 'observability-sre' %>
 <% end -%>
 
 USER 1000

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -103,7 +103,7 @@ namespace "artifact" do
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/gems/rexml-3.2.5/**/*'
     @exclude_paths << 'vendor/jruby/lib/ruby/gems/shared/specifications/rexml-3.2.5.gemspec'
 
-    @exclude_paths
+    @exclude_paths.freeze
   end
 
   def oss_exclude_paths
@@ -137,7 +137,7 @@ namespace "artifact" do
 
   desc "Generate rpm, deb, tar and zip artifacts"
   task "all" => ["prepare", "build"]
-  task "docker_only" => ["prepare", "build_docker_full", "build_docker_oss", "build_docker_ubi8", "build_docker_wolfi"]
+  task "docker_only" => ["prepare", "build_docker_full", "build_docker_oss", "build_docker_ubi8", "build_docker_wolfi", "build_docker_observabilitySRE"]
 
   desc "Build all (jdk bundled and not) tar.gz and zip of default logstash plugins with all dependencies"
   task "archives" => ["prepare", "generate_build_metadata"] do
@@ -163,25 +163,25 @@ namespace "artifact" do
     safe_system("./gradlew bootstrap") # force the build of Logstash jars
   end
 
-  def create_archive_pack(license_details, arch, *oses)
+  def create_archive_pack(license_details, arch, *oses, &tar_interceptor)
     oses.each do |os_name|
       puts("[artifact:archives] Building tar.gz/zip of default plugins for OS: #{os_name}, arch: #{arch}")
-      create_single_archive_pack(os_name, arch, license_details)
+      create_single_archive_pack(os_name, arch, license_details, &tar_interceptor)
     end
   end
 
-  def create_single_archive_pack(os_name, arch, license_details)
+  def create_single_archive_pack(os_name, arch, license_details, &tar_interceptor)
     safe_system("./gradlew copyJdk -Pjdk_bundle_os=#{os_name} -Pjdk_arch=#{arch}")
     if arch == 'arm64'
       arch = 'aarch64'
     end
     case os_name
     when "linux"
-      build_tar(*license_details, platform: "-linux-#{arch}")
+      build_tar(*license_details, platform: "-linux-#{arch}", &tar_interceptor)
     when "windows"
       build_zip(*license_details, platform: "-windows-#{arch}")
     when "darwin"
-      build_tar(*license_details, platform: "-darwin-#{arch}")
+      build_tar(*license_details, platform: "-darwin-#{arch}", &tar_interceptor)
     end
     safe_system("./gradlew deleteLocalJdk -Pjdk_bundle_os=#{os_name}")
   end
@@ -226,6 +226,23 @@ namespace "artifact" do
     license_details = ['APACHE-LICENSE-2.0', "-oss", oss_exclude_paths]
     create_archive_pack(license_details, "x86_64", "linux", "darwin")
     create_archive_pack(license_details, "arm64", "linux", "darwin")
+    safe_system("./gradlew bootstrap") # force the build of Logstash jars
+  end
+
+  desc "Build jdk bundled tar.gz of observabilitySRE logstash plugins with all dependencies for docker"
+  task "archives_docker_observabilitySRE" => ["prepare-observabilitySRE", "generate_build_metadata"] do
+    #with bundled JDKs
+    @bundles_jdk = true
+    # rejection point: if `license_details` has a third entry, it is used in place of the default_exclude_paths
+    # license_details = ['ELASTIC-LICENSE','-observability-sre', default_exclude_paths]
+    license_details = ['ELASTIC-LICENSE','-observability-sre']
+    %w(x86_64 arm64).each do |arch|
+      create_archive_pack(license_details, arch, "linux") do |dedicated_directory_tar|
+        # injection point: Use `DedicatedDirectoryTarball#write(source_file, destination_path)` to
+        # copy additional files into the tarball
+        puts "HELLO(#{dedicated_directory_tar})"
+      end
+    end
     safe_system("./gradlew bootstrap") # force the build of Logstash jars
   end
 
@@ -333,6 +350,12 @@ namespace "artifact" do
     build_docker('ubi8')
   end
 
+  desc "Build observabilitySRE docker image"
+  task "docker_observabilitySRE" => ["prepare-observabilitySRE", "generate_build_metadata", "archives_docker_observabilitySRE"] do
+    puts("[docker_observabilitySRE] Building observabilitySRE docker image")
+    build_docker('observability-sre')
+  end
+
   desc "Build wolfi docker image"
   task "docker_wolfi" => %w(prepare generate_build_metadata archives_docker) do
     puts("[docker_wolfi] Building Wolfi docker image")
@@ -346,6 +369,7 @@ namespace "artifact" do
     build_dockerfile('full')
     build_dockerfile('ubi8')
     build_dockerfile('wolfi')
+    build_dockerfile('observability-sre')
     build_dockerfile('ironbank')
   end
 
@@ -353,6 +377,12 @@ namespace "artifact" do
   task "dockerfile_oss" => ["prepare-oss", "generate_build_metadata"] do
     puts("[dockerfiles] Building oss Dockerfile")
     build_dockerfile('oss')
+  end
+
+  desc "Generate Dockerfile for observability-sre images"
+  task "dockerfile_observabilitySRE" => ["prepare-observabilitySRE", "generate_build_metadata"] do
+    puts("[dockerfiles] Building observability-sre Dockerfile")
+    build_dockerfile('observability-sre')
   end
 
   desc "Generate Dockerfile for full images"
@@ -392,6 +422,7 @@ namespace "artifact" do
       Rake::Task["artifact:docker_wolfi"].invoke
       Rake::Task["artifact:dockerfiles"].invoke
       Rake::Task["artifact:docker_oss"].invoke
+      Rake::Task["artifact:docker_observabilitySRE"].invoke
     end
 
     Rake::Task["artifact:deb_oss"].invoke
@@ -412,6 +443,11 @@ namespace "artifact" do
   task "build_docker_ubi8" => [:generate_build_metadata] do
     Rake::Task["artifact:docker_ubi8"].invoke
     Rake::Task["artifact:dockerfile_ubi8"].invoke
+  end
+
+  task "build_docker_observabilitySRE" => [:generate_build_metadata] do
+    Rake::Task["artifact:docker_observabilitySRE"].invoke
+    Rake::Task["artifact:dockerfile_observabilitySRE"].invoke
   end
 
   task "build_docker_wolfi" => [:generate_build_metadata] do
@@ -496,6 +532,17 @@ namespace "artifact" do
     end
   end
 
+  task "prepare-observabilitySRE" do
+    if ENV['SKIP_PREPARE'] != "1"
+      %w(
+        bootstrap
+        plugin:install-default
+        plugin:trim-for-observabilitySRE
+        artifact:clean-bundle-config
+      ).each {|task| Rake::Task[task].invoke }
+    end
+  end
+
   def ensure_logstash_version_constant_defined
     # we do not want this file required when rake (ruby) parses this file
     # only when there is a task executing, not at the very top of this file
@@ -504,7 +551,7 @@ namespace "artifact" do
     end
   end
 
-  def build_tar(license, tar_suffix = nil, exclude_paths = default_exclude_paths, platform: '')
+  def build_tar(license, tar_suffix = nil, exclude_paths = default_exclude_paths, platform: '', &tar_interceptor)
     require "zlib"
     require 'rubygems'
     require 'rubygems/package'
@@ -518,36 +565,80 @@ namespace "artifact" do
     puts("[artifact:tar] building #{tarpath}")
     gz = Zlib::GzipWriter.new(File.new(tarpath, "wb"), Zlib::BEST_COMPRESSION)
     Minitar::Writer.open(gz) do |tar|
+      dedicated_directory_tarball = DedicatedDirectoryTarball.new(tar, "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}")
       files(exclude_paths).each do |path|
-        write_to_tar(tar, path, "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/#{path}")
+        dedicated_directory_tarball.write(path)
       end
 
       source_license_path = "licenses/#{license}.txt"
       fail("Missing source license: #{source_license_path}") unless File.exist?(source_license_path)
-      write_to_tar(tar, source_license_path, "logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}/LICENSE.txt")
+      dedicated_directory_tarball.write(source_license_path, "LICENSE.txt")
 
       # add build.rb to tar
       metadata_file_path_in_tar = File.join("logstash-core", "lib", "logstash", "build.rb")
-      path_in_tar = File.join("logstash-#{LOGSTASH_VERSION}#{PACKAGE_SUFFIX}", metadata_file_path_in_tar)
-      write_to_tar(tar, BUILD_METADATA_FILE.path, path_in_tar)
+      dedicated_directory_tarball.write(BUILD_METADATA_FILE.path, metadata_file_path_in_tar)
+
+      # yield to the tar interceptor if we have one
+      yield(dedicated_directory_tarball) if block_given?
     end
     gz.close
   end
 
-  def write_to_tar(tar, path, path_in_tar)
-    stat = File.lstat(path)
-    if stat.directory?
-      tar.mkdir(path_in_tar, :mode => stat.mode)
-    elsif stat.symlink?
-      tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
-    else
-      tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size) do |io|
-        File.open(path, 'rb') do |fd|
-          chunk = nil
-          size = 0
-          size += io.write(chunk) while chunk = fd.read(16384)
-          if stat.size != size
-            raise "Failure to write the entire file (#{path}) to the tarball. Expected to write #{stat.size} bytes; actually write #{size}"
+  ##
+  # A `DedicatedDirectoryTarball` writes everything into a dedicated
+  # directory that is known at init-time (e.g., NOT a tarbomb). All paths are
+  class DedicatedDirectoryTarball
+    def initialize(minitar_writer, dedicated_directory)
+      @minitar_writer = minitar_writer
+      @dedicated_directory = Pathname.new(dedicated_directory)
+    end
+
+    ##
+    # Write the contents of the file, directory, or symlink in `source_path` to
+    # the `destination_path` inside the tarball's dedicated directory.
+    # @param source_path [String]: the path to the file to copy, relative to PWD
+    # @param destination_path [String]: the path, relative to the tarball's dedicated directory, to
+    #                                   write to (default: `source_path`)
+    # @return [void]
+    def write(source_path, destination_path=source_path)
+      write_to_tar(@minitar_writer, source_path, expand(destination_path))
+
+      nil
+    end
+
+    def to_s
+      "#<#{self.class.name}:#{@dedicated_directory}>"
+    end
+
+    private
+
+    ##
+    # Expands the given `destination_path` relative to the dedicated directory,
+    # ensuring that the result is inside the dedicated directory
+    # @param destination_path [String]
+    # @return [String]
+    def expand(destination_path)
+      expanded_destination_path = @dedicated_directory / destination_path
+      fail("illegal destination path `#{destination_path}`") unless expanded_destination_path.descend.peek == @dedicated_directory
+
+      expanded_destination_path.to_s
+    end
+
+    def write_to_tar(tar, path, path_in_tar)
+      stat = File.lstat(path)
+      if stat.directory?
+        tar.mkdir(path_in_tar, :mode => stat.mode)
+      elsif stat.symlink?
+        tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
+      else
+        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size) do |io|
+          File.open(path, 'rb') do |fd|
+            chunk = nil
+            size = 0
+            size += io.write(chunk) while chunk = fd.read(16384)
+            if stat.size != size
+              raise "Failure to write the entire file (#{path}) to the tarball. Expected to write #{stat.size} bytes; actually write #{size}"
+            end
           end
         end
       end

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -48,7 +48,7 @@ namespace "plugin" do
       # post-execution filtration is needed until 8.19 and 9.1
       # when list --[no-]expand flag is supported, use it instead
       # https://github.com/elastic/logstash/pull/17124
-      expand || p.match?(/^[a-z]/)
+      expand || line.match?(/^[a-z]/)
     end.map(&:chomp)
   end
 

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -52,10 +52,6 @@ namespace "plugin" do
     end.map(&:chomp)
   end
 
-  def clean_plugins
-    invoke_plugin_manager!("clean")
-  end
-
   # the plugin manager's list command (and possibly others)
   def invoke_plugin_manager!(command, *args)
     plugin_manager_bin = Pathname.new(LogStash::Environment::LOGSTASH_HOME) / "bin" / "logstash-plugin"

--- a/x-pack/distributions/internal/observabilitySRE/plugin-allow-list.txt
+++ b/x-pack/distributions/internal/observabilitySRE/plugin-allow-list.txt
@@ -1,0 +1,15 @@
+logstash-codec-json
+logstash-codec-multiline
+logstash-codec-plain
+logstash-filter-age
+logstash-filter-date
+logstash-filter-drop
+logstash-filter-fingerprint
+logstash-filter-grok
+logstash-filter-json
+logstash-filter-mutate
+logstash-input-beats
+logstash-input-pipeline
+logstash-output-elasticsearch
+logstash-output-pipeline
+logstash-patterns-core


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

 - Adds various `observabilitySRE` rake, make, and gradle tasks for creating docker artifacts
 - Includes rejection-point for filtering out files, and an injection-point for adding files to the tarball.
 - Fairly significant delta from how this patch would apply to main since main has a major refactor -> https://github.com/elastic/logstash/pull/16599/files

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

~~~
./gradlew --stacktrace artifactDockerObservabilitySRE
~~~

NOTE: until https://github.com/elastic/logstash/pull/17271 is merged, the docker image will include the files from removed gems.
