### PR TITLE
Health report integration test migrate to the new artifacts-api

### DIFF
--- a/.buildkite/scripts/health-report-tests/bootstrap.py
+++ b/.buildkite/scripts/health-report-tests/bootstrap.py
@@ -12,7 +12,7 @@ import yaml
 
 
 class Bootstrap:
-    ELASTIC_STACK_VERSIONS_URL = "https://artifacts-api.elastic.co/v1/versions"
+    ELASTIC_STACK_RELEASED_VERSION = "https://storage.googleapis.com/artifacts-api/releases/current/"
 
     def __init__(self) -> None:
         f"""
@@ -43,20 +43,12 @@ class Bootstrap:
                                      f"rerun again")
 
     def __resolve_latest_stack_version_for(self, major_version: str) -> str:
-        resolved_version = ""
-        response = util.call_url_with_retry(self.ELASTIC_STACK_VERSIONS_URL)
-        release_versions = response.json()["versions"]
-        for release_version in reversed(release_versions):
-            if release_version.find("SNAPSHOT") > 0:
-                continue
-            if release_version.split(".")[0] == major_version:
-                print(f"Resolved latest version for {major_version} is {release_version}.")
-                resolved_version = release_version
-                break
+        release_version = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION + major_version)
+        print(f"Resolved latest version for {major_version} is {release_version}.")
 
-        if resolved_version == "":
+        if release_version == "":
             raise ValueError(f"Cannot resolve latest version for {major_version} major")
-        return resolved_version
+        return release_version
 
     def install_plugin(self, plugin_path: str) -> None:
         util.run_or_raise_error(

--- a/.buildkite/scripts/health-report-tests/bootstrap.py
+++ b/.buildkite/scripts/health-report-tests/bootstrap.py
@@ -12,7 +12,7 @@ import yaml
 
 
 class Bootstrap:
-    ELASTIC_STACK_RELEASED_VERSION = "https://storage.googleapis.com/artifacts-api/releases/current/"
+    ELASTIC_STACK_RELEASED_VERSION_URL = "https://storage.googleapis.com/artifacts-api/releases/current/"
 
     def __init__(self) -> None:
         f"""
@@ -43,7 +43,7 @@ class Bootstrap:
                                      f"rerun again")
 
     def __resolve_latest_stack_version_for(self, major_version: str) -> str:
-        resp = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION + major_version)
+        resp = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION_URL + major_version)
         release_version = resp.text.strip()
         print(f"Resolved latest version for {major_version} is {release_version}.")
 

--- a/.buildkite/scripts/health-report-tests/bootstrap.py
+++ b/.buildkite/scripts/health-report-tests/bootstrap.py
@@ -44,7 +44,7 @@ class Bootstrap:
 
     def __resolve_latest_stack_version_for(self, major_version: str) -> str:
         resp = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION + major_version)
-        release_version = resp.text
+        release_version = resp.text.strip()
         print(f"Resolved latest version for {major_version} is {release_version}.")
 
         if release_version == "":

--- a/.buildkite/scripts/health-report-tests/bootstrap.py
+++ b/.buildkite/scripts/health-report-tests/bootstrap.py
@@ -43,7 +43,8 @@ class Bootstrap:
                                      f"rerun again")
 
     def __resolve_latest_stack_version_for(self, major_version: str) -> str:
-        release_version = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION + major_version)
+        resp = util.call_url_with_retry(self.ELASTIC_STACK_RELEASED_VERSION + major_version)
+        release_version = resp.text
         print(f"Resolved latest version for {major_version} is {release_version}.")
 
         if release_version == "":


### PR DESCRIPTION
relates: https://github.com/elastic/ingest-dev/issues/5165

This commit replaced the deprecated artifacts-api by the new API