### PR TITLE
Ensure env2yaml dep is properly expressed in observabilitySRE task

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -54,7 +54,7 @@ build-from-local-ubi8-artifacts: dockerfile env2yaml
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 
-build-from-local-observability-sre-artifacts: dockerfile
+build-from-local-observability-sre-artifacts: dockerfile env2yaml
 	docker run --rm -d --name=$(HTTPD) \
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The `build-from-local-observability-sre-artifacts` task depends on the `env2yaml` task. This was easy to miss in local development if other images had been built. This commit updates the makefile to properly define that dependency.

## Why is it important/What is the impact to the user?

N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Discovered in https://github.com/elastic/logstash/pull/17298 while trying to build image on fresh VM
- Relates to https://github.com/elastic/logstash/pull/17272

