### PR TITLE
add ci shared qualified-version script

### DIFF
--- a/.buildkite/scripts/common/qualified-version.sh
+++ b/.buildkite/scripts/common/qualified-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# ********************************************************
+# Source this script to get the QUALIFIED_VERSION env var
+# or execute it to receive the qualified version on stdout
+# ********************************************************
+
+set -euo pipefail
+
+export QUALIFIED_VERSION="$(
+  # Extract the version number from the version.yml file
+  # e.g.: 8.6.0
+  printf '%s' "$(awk -F':' '{ if ("logstash" == $1) { gsub(/^ | $/,"",$2); printf $2; exit } }' versions.yml)"
+
+  # Qualifier is passed from CI as optional field and specify the version postfix
+  # in case of alpha or beta releases for staging builds only:
+  # e.g: 8.0.0-alpha1
+  printf '%s' "${VERSION_QUALIFIER:+-${VERSION_QUALIFIER}}"
+
+  # add the SNAPSHOT tag unless WORKFLOW_TYPE=="staging" or RELEASE=="1"
+  if [[ ! ( "${WORKFLOW_TYPE:-}" == "staging" || "${RELEASE:+$RELEASE}" == "1" ) ]]; then
+    printf '%s' "-SNAPSHOT"
+  fi
+)"
+
+# if invoked directly, output the QUALIFIED_VERSION to stdout
+if [[ "$0" == "${BASH_SOURCE:-${ZSH_SCRIPT:-}}" ]]; then
+  printf '%s' "${QUALIFIED_VERSION}"
+fi

--- a/.buildkite/scripts/dra/build_docker.sh
+++ b/.buildkite/scripts/dra/build_docker.sh
@@ -26,17 +26,7 @@ rake artifact:docker_oss || error "artifact:docker_oss build failed."
 rake artifact:docker_wolfi || error "artifact:docker_wolfi build failed."
 rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
 
-if [[ "$WORKFLOW_TYPE" == "staging" ]] && [[ -n "$VERSION_QUALIFIER" ]]; then
-    # Qualifier is passed from CI as optional field and specify the version postfix
-    # in case of alpha or beta releases for staging builds only:
-    # e.g: 8.0.0-alpha1
-    STACK_VERSION="${STACK_VERSION}-${VERSION_QUALIFIER}"
-fi
-
-if [[ "$WORKFLOW_TYPE" == "snapshot" ]]; then
-    STACK_VERSION="${STACK_VERSION}-SNAPSHOT"
-fi
-
+STACK_VERSION="$(./$(dirname "$0")/../common/qualified-version.sh)"
 info "Build complete, setting STACK_VERSION to $STACK_VERSION."
 
 info "Saving tar.gz for docker images"

--- a/.buildkite/scripts/dra/build_packages.sh
+++ b/.buildkite/scripts/dra/build_packages.sh
@@ -23,17 +23,7 @@ esac
 
 SKIP_DOCKER=1 rake artifact:all || error "rake artifact:all build failed."
 
-if [[ "$WORKFLOW_TYPE" == "staging" ]] && [[ -n "$VERSION_QUALIFIER" ]]; then
-    # Qualifier is passed from CI as optional field and specify the version postfix
-    # in case of alpha or beta releases for staging builds only:
-    # e.g: 8.0.0-alpha1
-    STACK_VERSION="${STACK_VERSION}-${VERSION_QUALIFIER}"
-fi
-
-if [[ "$WORKFLOW_TYPE" == "snapshot" ]]; then
-    STACK_VERSION="${STACK_VERSION}-SNAPSHOT"
-fi
-
+STACK_VERSION="$(./$(dirname "$0")/../common/qualified-version.sh)"
 info "Build complete, setting STACK_VERSION to $STACK_VERSION."
 
 info "Generated Artifacts"

--- a/.buildkite/scripts/dra/common.sh
+++ b/.buildkite/scripts/dra/common.sh
@@ -29,12 +29,12 @@ export JRUBY_OPTS="-J-Xmx4g"
 
 # Extract the version number from the version.yml file
 # e.g.: 8.6.0
-# The suffix part like alpha1 etc is managed by the optional VERSION_QUALIFIER_OPT environment variable
+# The suffix part like alpha1 etc is managed by the optional VERSION_QUALIFIER environment variable
 STACK_VERSION=`cat versions.yml | sed -n 's/^logstash\:[[:space:]]\([[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\)$/\1/p'`
 
 info "Agent is running on architecture [$(uname -i)]"
 
-export VERSION_QUALIFIER_OPT=${VERSION_QUALIFIER_OPT:-""}
+export VERSION_QUALIFIER=${VERSION_QUALIFIER:-""}
 export DRA_DRY_RUN=${DRA_DRY_RUN:-""}
 
 if [[ ! -z $DRA_DRY_RUN && $BUILDKITE_STEP_KEY == "logstash_publish_dra" ]]; then

--- a/.buildkite/scripts/dra/publish.sh
+++ b/.buildkite/scripts/dra/publish.sh
@@ -45,14 +45,7 @@ fi
 info "Downloaded ARTIFACTS sha report"
 for file in build/logstash-*; do shasum $file;done
 
-FINAL_VERSION=$STACK_VERSION
-if [[ -n "$VERSION_QUALIFIER" ]]; then
-  FINAL_VERSION="$FINAL_VERSION-${VERSION_QUALIFIER}"
-fi
-
-if [[ "$WORKFLOW_TYPE" == "snapshot" ]]; then
-    FINAL_VERSION="${STACK_VERSION}-SNAPSHOT"
-fi
+FINAL_VERSION="$(./$(dirname "$0")/../common/qualified-version.sh)"
 
 mv build/distributions/dependencies-reports/logstash-${FINAL_VERSION}.csv build/distributions/dependencies-${FINAL_VERSION}.csv
 


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?

Adds a shareable script for buildkite to get a fully-qualified version, including:
 - the base version from `${LOGSTASH_HOME}/versions.yml`
 - the qualifier from optional `VERSION_QUALIFIER` environment variable
 - the `SNAPSHOT` tag from either `WORKFLOW_TYPE` or `RELEASE` environment variables

## Why is it important/What is the impact to the user?

In https://github.com/elastic/logstash/pull/17298 we are adding tasks to smoke-test built artifacts, so we need the qualified version. Instead of duplicating the logic yet again, I extracted it to a share-able helper. I plan to backport this and reuse it elsewhere.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

Sourcing sets the `QUALIFIED_VERSION` environment variable

> ~~~
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (source .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> QUALIFIED_VERSION=9.1.0-SNAPSHOT
> [success]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (RELEASE=1 source .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> QUALIFIED_VERSION=9.1.0
> [success]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (WORKFLOW_TYPE=staging source .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION)) 
> QUALIFIED_VERSION=9.1.0
> [success]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (VERSION_QUALIFIER=beta1 WORKFLOW_TYPE=staging source .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> QUALIFIED_VERSION=9.1.0-beta1
> [success]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (VERSION_QUALIFIER=beta1 source .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION)) 
> QUALIFIED_VERSION=9.1.0-beta1-SNAPSHOT
> [success]
> ~~~


Invoking outputs the qualified version, but doesn't set the env var (the `%` is my shell's way of saying that there was no trailing newline, and the commands "error" because the grep fails to find `QUALIFIED_VERSION` in the output of `env` ):


> ~~~
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (.buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))                 
> 9.1.0-SNAPSHOT%
> [error: 1]    
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (RELEASE=1 .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> 9.1.0%[error: 1]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (WORKFLOW_TYPE=staging .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> 9.1.0%
> [error: 1]
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (VERSION_QUALIFIER=beta1 WORKFLOW_TYPE=staging .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION))
> 9.1.0-beta1%
> [error: 1] 
> 
> ╭─{ rye@perhaps:~/src/elastic/logstash@main (build-script-qualified-version ✔) }
> ╰─● (VERSION_QUALIFIER=beta1 .buildkite/scripts/common/qualified-version.sh; (env | grep QUALIFIED_VERSION)) 
> 9.1.0-beta1-SNAPSHOT%
> [error: 1]
> ~~~