### PR TITLE
Require shellwords in artifact rake task

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'shellwords'
+
 namespace "artifact" do
   SNAPSHOT_BUILD = ENV["RELEASE"] != "1"
   VERSION_QUALIFIER = ENV["VERSION_QUALIFIER"].to_s.strip.empty? ? nil : ENV["VERSION_QUALIFIER"]


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The https://github.com/elastic/logstash/pull/17310 PR changed the rake task for artifact creation to use shellwords from standard library. The acceptance tests need to explitily load that library. This commit updates the rake file to handle loading the required code.

## References

failing cell https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1515#01959199-086d-4bb5-8922-161dc535f3e0

```

2025-03-13 16:10:03 PDT | [docker] Building docker image
-- | --
  | 2025-03-13 16:10:03 PDT | rake aborted!
  | 2025-03-13 16:10:04 PDT | NameError: uninitialized constant Shellwords
  | 2025-03-13 16:10:04 PDT | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1741906760078483547/elastic/logstash-exhaustive-tests-pipeline/rakelib/artifacts.rake:143:in `block in safe_system'
  | 2025-03-13 16:10:04 PDT | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1741906760078483547/elastic/logstash-exhaustive-tests-pipeline/rakelib/artifacts.rake:142:in `safe_system'
  | 2025-03-13 16:10:04 PDT | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1741906760078483547/elastic/logstash-exhaustive-tests-pipeline/rakelib/artifacts.rake:828:in `block in build_docker'
  | 2025-03-13 16:10:04 PDT | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1741906760078483547/elastic/logstash-exhaustive-tests-pipeline/rakelib/artifacts.rake:827:in `build_docker'
  | 2025-03-13 16:10:04 PDT | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1741906760078483547/elastic/logstash-exhaustive-tests-pipeline/rakelib/artifacts.rake:341:in `block in <main>'
  | 2025-03-13 16:10:04 PDT | org/jruby/ext/monitor/Monitor.java:82:in `synchronize'


```