### PR TITLE
Doc: Update intro to match TOC order in API docs

### DIFF
--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -6,13 +6,14 @@ info:
     When you run Logstash, it automatically captures runtime metrics that you can use to monitor the health and performance of your Logstash deployment.
     The metrics collected by Logstash include:
     
-    - Logstash node info, like pipeline settings, OS info, and JVM info.
-    - Plugin info, including a list of installed plugins.
-    - Node stats, like JVM stats, process stats, event-related stats, and pipeline runtime stats.
+    - Health report.
     - Hot threads.
-    - Health report. 
+    - Logstash node info, like pipeline settings, OS info, and JVM info.
+    - Node stats, like JVM stats, process stats, event-related stats, and pipeline runtime stats.
+    - Plugins info, including a list of installed plugins.
 
-    The APIs that retrieve these metrics are available by default without requiring any extra configuration.
+
+    The APIs that retrieve these metrics are available by default, with no extra configuration needed.
 
     ## Documentation source and versions
 


### PR DESCRIPTION
Update intro content to align with left nav order in [published API docs](https://www.elastic.co/docs/api/doc/logstash/): 

    - Health report.
    - Hot threads.
    - Logstash node info, like pipeline settings, OS info, and JVM info.
    - Node stats, like JVM stats, process stats, event-related stats, and pipeline runtime stats.
    - Plugins info, including a list of installed plugins.|

<img width="317" alt="Screenshot 2025-03-14 at 2 43 23 PM" src="https://github.com/user-attachments/assets/69c58f83-6cf5-4e0b-9941-fcfeb263c922" />   




