### PR TITLE
Internal collection doc update to reflect enabling legacy collection.

### DIFF
--- a/docs/reference/monitoring-internal-collection-legacy.md
+++ b/docs/reference/monitoring-internal-collection-legacy.md
@@ -106,6 +106,7 @@ To monitor Logstash nodes:
 3. Configure your Logstash nodes to send metrics by setting `xpack.monitoring.enabled` to `true` and specifying the destination {{es}} node(s) as `xpack.monitoring.elasticsearch.hosts` in `logstash.yml`. If {{security-features}} are enabled, you also need to specify the credentials for the [built-in `logstash_system` user](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md). For more information about these settings, see [Monitoring Settings](#monitoring-settings-legacy).
 
     ```yaml
+    xpack.monitoring.allow_legacy_collection: true
     xpack.monitoring.enabled: true
     xpack.monitoring.elasticsearch.hosts: ["http://es-prod-node-1:9200", "http://es-prod-node-2:9200"] <1>
     xpack.monitoring.elasticsearch.username: "logstash_system"


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Adds new param (`xpack.monitoring.allow_legacy_collection: true`) introduced in 9.0 stack for internal collection.

## Why is it important/What is the impact to the user?
Most users copy and paste the sources provided. If they copy current code example for 9.0, they will face an error says to include `allow_legacy_collection`. So, this PR reduces the path to successfully run internal monitoring in 9.0 stack.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- 

## Use cases


## Screenshots

## Logs
