### PR TITLE
Use org.logstash.common.Util to hashing by default to SHA256

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     implementation('org.reflections:reflections:0.10.2') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation 'commons-codec:commons-codec:1.17.0'
+    implementation 'commons-codec:commons-codec:1.17.0' // transitively required by httpclient
     // Jackson version moved to versions.yml in the project root (the JrJackson version is there too)
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"

--- a/logstash-core/src/main/java/org/logstash/common/Util.java
+++ b/logstash-core/src/main/java/org/logstash/common/Util.java
@@ -35,6 +35,13 @@ public class Util {
         }
     }
 
+    /**
+     * Returns the hexadecimal string of UTF-8 bytes that make up the string.
+     * @param base
+     *      the string to hash.
+     * @return
+     *      hexadecimal string that contains the hash.
+     * */
     public static String digest(String base) {
         MessageDigest digest = defaultMessageDigest();
         byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));

--- a/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/PipelineConfig.java
@@ -19,16 +19,24 @@
 
 package org.logstash.config.ir;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jruby.*;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.common.IncompleteSourceWithMetadataException;
 import org.logstash.common.SourceWithMetadata;
+import org.logstash.common.Util;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.logstash.RubyUtil.RUBY;
@@ -105,7 +113,7 @@ public final class PipelineConfig {
 
     public String configHash() {
         if (configHash == null) {
-            configHash = DigestUtils.sha1Hex(configString() + metadataString());
+            configHash = Util.digest(configString() + metadataString());
         }
         return configHash;
     }

--- a/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/AliasRegistry.java
@@ -1,8 +1,8 @@
 package org.logstash.plugins;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.logstash.common.Util;
 import org.logstash.plugins.PluginLookup.PluginType;
 import org.logstash.plugins.aliases.AliasDocumentReplace;
 import org.logstash.plugins.aliases.AliasPlugin;
@@ -109,7 +109,7 @@ public class AliasRegistry {
         }
 
         private String computeHashFromContent() {
-            return DigestUtils.sha256Hex(yamlContents);
+            return Util.digest(yamlContents);
         }
 
         @SuppressWarnings("unchecked")

--- a/logstash-core/src/main/java/org/logstash/util/EscapeHandler.java
+++ b/logstash-core/src/main/java/org/logstash/util/EscapeHandler.java
@@ -1,8 +1,5 @@
 package org.logstash.util;
 
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
-
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
   implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.1'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
-  implementation group: 'commons-codec', name: 'commons-codec', version: '1.17.0'
+  implementation group: 'commons-codec', name: 'commons-codec', version: '1.17.0' // transitively required by httpclient
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.16.1'
   implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"


### PR DESCRIPTION
## Release notes
Rationalize the usage internal hashing method and default to SHA-256


## What does this PR do?

Removes the usage fo Apache Commons Codec  MessgeDigest to use internal Util class with embodies hashing methods.

## Why is it important/What is the impact to the user?

N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Use the automatic reload config as in guide https://www.elastic.co/guide/en/logstash/current/reloading-config.html, update the pipeline definition and notice in the logs that's reloaded.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #17330
