### PR TITLE
Limit memory consumption in test on overflow

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -124,6 +124,7 @@ tasks.register("javaTests", Test) {
     exclude '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     exclude '/org/logstash/execution/ObservedExecutionTest.class'
 
+    // 10GB is needed by the BufferedTokenizerExtWithSizeLimitTest.givenTooLongInputExtractDoesntOverflow test
     maxHeapSize = "10g"
 
     jacoco {

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -125,7 +125,6 @@ tasks.register("javaTests", Test) {
     exclude '/org/logstash/execution/ObservedExecutionTest.class'
 
     maxHeapSize = "10g"
-    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError'
 
     jacoco {
         enabled = true

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -124,7 +124,8 @@ tasks.register("javaTests", Test) {
     exclude '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     exclude '/org/logstash/execution/ObservedExecutionTest.class'
 
-    maxHeapSize = "12g"
+    maxHeapSize = "10g"
+    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError'
 
     jacoco {
         enabled = true

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -31,6 +31,7 @@ public class JavaVersion implements Comparable<JavaVersion> {
 
     public static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
     public static final JavaVersion JAVA_17 = parse("17");
+    public static final JavaVersion JAVA_21 = parse("21");
 
     private final List<Integer> version;
 

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
@@ -136,6 +136,7 @@ public final class BufferedTokenizerExtWithSizeLimitTest extends RubyTestBase {
 
         assumeThat("Expect at least JDK 21", JavaVersion.CURRENT, Matchers.greaterThanOrEqualTo(JavaVersion.JAVA_21));
         long expectedNeedHeapMemory = 10L * GB;
+        // To understand the motivation of 10GB heap please read https://github.com/elastic/logstash/pull/17373#issuecomment-2750378212
         assumeTrue("Skip the test because VM hasn't enough physical memory", hasEnoughPhysicalMemory(expectedNeedHeapMemory));
 
         assertEquals("Xmx must equals to what's defined in the Gradle's javaTests task",

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
@@ -37,8 +37,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.logstash.RubyUtil.RUBY;
 
@@ -122,7 +122,7 @@ public final class BufferedTokenizerExtWithSizeLimitTest extends RubyTestBase {
     }
 
     @Test
-    public void givenMaliciousInputExtractDoesntOverflow() {
+    public void givenTooLongInputExtractDoesntOverflow() {
         long expectedNeedHeapMemory = 10L * GB;
         assumeTrue("Skip the test because VM hasn't enough physical memory", hasEnoughPhysicalMemory(expectedNeedHeapMemory));
 

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
@@ -19,6 +19,7 @@
 
 package org.logstash.common;
 
+import org.hamcrest.Matchers;
 import org.jruby.RubyArray;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
@@ -27,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.logstash.RubyTestBase;
 import org.logstash.RubyUtil;
+import org.logstash.util.JavaVersion;
 
 import javax.management.Attribute;
 import javax.management.InstanceNotFoundException;
@@ -39,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 import static org.logstash.RubyUtil.RUBY;
 
@@ -123,6 +126,15 @@ public final class BufferedTokenizerExtWithSizeLimitTest extends RubyTestBase {
 
     @Test
     public void givenTooLongInputExtractDoesntOverflow() {
+        // This test has proven to go OOM on JDK 11 and JDK 17, also if physical memory is 16GB.
+        // JDK 21 successfully executes the test due to internal changes or efficiency of G1GC (the default GC).
+        // Tested also others GC on JDK 11 without any success:
+        // - ZGC
+        // - Parallel GC
+        // - CMS
+        // remove this code when the minimal JDK version for Logstash is JDK 21 or greater.
+
+        assumeThat("Expect at least JDK 21", JavaVersion.CURRENT, Matchers.greaterThanOrEqualTo(JavaVersion.JAVA_21));
         long expectedNeedHeapMemory = 10L * GB;
         assumeTrue("Skip the test because VM hasn't enough physical memory", hasEnoughPhysicalMemory(expectedNeedHeapMemory));
 

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
@@ -160,6 +160,7 @@ public final class BufferedTokenizerExtWithSizeLimitTest extends RubyTestBase {
             System.out.println(e.getMessage());
             return false;
         }
+        System.out.println("Physical memory on the VM is: " + physicalMemory + " bytes");
         return physicalMemory > requiredPhysicalMemory;
     }
 

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerExtWithSizeLimitTest.java
@@ -117,25 +117,25 @@ public final class BufferedTokenizerExtWithSizeLimitTest extends RubyTestBase {
     @Test
     public void givenMaliciousInputExtractDoesntOverflow() {
         assertEquals("Xmx must equals to what's defined in the Gradle's javaTests task",
-                12L * GB, Runtime.getRuntime().maxMemory());
+                10L * GB, Runtime.getRuntime().maxMemory());
 
         // re-init the tokenizer with big sizeLimit
         initSUTWithSizeLimit((int) (2L * GB) - 3);
         // Integer.MAX_VALUE is 2 * GB
-        String bigFirstPiece = generateString("a", Integer.MAX_VALUE - 1024);
-        sut.extract(context, RubyUtil.RUBY.newString(bigFirstPiece));
+        RubyString bigFirstPiece = generateString("a", Integer.MAX_VALUE - 1024);
+        sut.extract(context, bigFirstPiece);
 
         // add another small fragment to trigger int overflow
         // sizeLimit is (2^32-1)-3 first segment length is (2^32-1) - 1024 second is 1024 +2
-        // so the combined length of first and second is > sizeLimit and should throw an expection
+        // so the combined length of first and second is > sizeLimit and should throw an exception
         // but because of overflow it's negative and happens to be < sizeLimit
         Exception thrownException = assertThrows(IllegalStateException.class, () -> {
-            sut.extract(context, RubyUtil.RUBY.newString(generateString("a", 1024 + 2)));
+            sut.extract(context, generateString("a", 1024 + 2));
         });
         assertThat(thrownException.getMessage(), containsString("input buffer full"));
     }
 
-    private String generateString(String fill, int size) {
-        return fill.repeat(size);
+    private RubyString generateString(String fill, int size) {
+        return RubyUtil.RUBY.newString(fill.repeat(size));
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Updates only test code to be able to run a test that consumes big memory if:
- the physical memory is bigger than the requested Java heap
- JDK version is greater than or equal to 21.

The reason to limit the JDK version is that on 16GB machine the G1GC is more efficient than the one on previous JDKs and so let complete the test with 10GB heap, while in JDK 17 it consistently fails with OOM error.

## Why is it important/What is the impact to the user?

N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] tested on ubuntu 2024 16GB RAM VM with JDK 11, 17 and 21

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- failing exhaustive: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1564
- success exhaustive: ~~https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1569~~ https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1594

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #17353
