### PR TITLE
Exclude plugin manager and keystore cli from observabilitySRE artifact

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -233,9 +233,13 @@ namespace "artifact" do
   task "archives_docker_observabilitySRE" => ["prepare-observabilitySRE", "generate_build_metadata"] do
     #with bundled JDKs
     @bundles_jdk = true
-    # rejection point: if `license_details` has a third entry, it is used in place of the default_exclude_paths
-    # license_details = ['ELASTIC-LICENSE','-observability-sre', default_exclude_paths]
-    license_details = ['ELASTIC-LICENSE','-observability-sre']
+    exclude_paths = default_exclude_paths + %w(
+      bin/logstash-plugin
+      bin/logstash-plugin.bat
+      bin/logstash-keystore
+      bin/logstash-keystore.bat
+    )
+    license_details = ['ELASTIC-LICENSE','-observability-sre', exclude_paths]
     %w(x86_64 arm64).each do |arch|
       create_archive_pack(license_details, arch, "linux") do |dedicated_directory_tar|
         # injection point: Use `DedicatedDirectoryTarball#write(source_file, destination_path)` to


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Excludes the `logstash-plugin` and `logstash-keystore` entrypoints from the observabilitySRE artifact

## Why is it important/What is the impact to the user?

These entrypoints cannot be invoked in a FIPS-compliant manner, so they are being excluded until a separate effort can make them so.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
