### PR TITLE
Update tls-encryption.asciidoc

### DIFF
--- a/docs/static/security/tls-encryption.asciidoc
+++ b/docs/static/security/tls-encryption.asciidoc
@@ -3,21 +3,23 @@
 === Configuring Logstash to use TLS/SSL encryption
 
 If TLS encryption is enabled on an on premise {es} cluster, you need to
-configure the `ssl` and `cacert` options in your Logstash `.conf` file:
+configure the `ssl_enabled` and `ssl_certificate_authorities` options in your Logstash `.conf` file:
+
+NOTE: See https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html[elasticsearch output plugin documentation] for a full list of options
 
 [source,js]
 --------------------------------------------------
 output {
   elasticsearch {
     ...
-    ssl => true
-    cacert => '/path/to/cert.pem' <1>
+    ssl_enabled => true
+    ssl_certificate_authorities => '/path/to/cert.pem' <1>
   }
 }
 --------------------------------------------------
 <1> The path to the local `.pem` file that contains the Certificate
     Authority's certificate.
-    
+
 NOTE: Hosted {ess} simplifies security. This configuration step is not necessary for hosted Elasticsearch Service on Elastic Cloud.
 {ess-leadin-short} 
     


### PR DESCRIPTION
The referenced elasticsearch output plugin has deprecated the options that were specified (`ssl`, `cacert`) https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-deprecated-options

When I tried using the documented example (`ssl` option) I noticed a warning in the logstash logs:
```
[WARN ][logstash.outputs.elasticsearch] You are using a deprecated config setting "ssl" set in elasticsearch. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Set 'ssl_enabled' instead. If you have any questions about this, please visit the #logstash channel on freenode irc.
```

I have updated this document with the suggested new options to use instead.

labels:
- release version: 8.17
- doc

## Release notes
[rn:skip]

## What does this PR do?

Updates documentation to remove deprecated options with the suggested options to use instead.

## Why is it important/What is the impact to the user?

The updated documentation will help prevent new users from receiving warnings in their logs about deprecated options, or at some future date receive errors about options that are no longer valid.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The list of deprecated options can be found here (https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-deprecated-options) along with the options to replace the deprecated options with.

When I tried using the `ssl` option I noticed a warning in the logstash logs:
```
[WARN ][logstash.outputs.elasticsearch] You are using a deprecated config setting "ssl" set in elasticsearch. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Set 'ssl_enabled' instead. If you have any questions about this, please visit the #logstash channel on freenode irc.
```

Setting the newer option `ssl_enabled` prevented the warning log message, and behaved the same as when using the deprecated `ssl` option.
