### PR TITLE
Keystore improvements.

### DIFF
--- a/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreExt.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreExt.java
@@ -31,16 +31,20 @@ public class SecretStoreExt {
 
     private static final SecretStoreFactory SECRET_STORE_FACTORY = SecretStoreFactory.fromEnvironment();
 
-    public static SecureConfig getConfig(String keystoreFile, String keystoreClassname) {
+    public static SecureConfig getConfig(final String keystoreFile, final String keystoreClassname) {
         return getSecureConfig(RubyUtil.RUBY.getENV(), keystoreFile, keystoreClassname);
     }
 
-    private static SecureConfig getSecureConfig(RubyHash env, String file, String classname) {
+    private static SecureConfig getSecureConfig(final RubyHash env, final String file, final String classname) {
         String keystorePass = (String) env.get("LOGSTASH_KEYSTORE_PASS");
         return getSecureConfig(file, keystorePass, classname);
     }
 
-    private static SecureConfig getSecureConfig(String keystoreFile, String keystorePass, String keystoreClassname) {
+    private static SecureConfig getSecureConfig(final String keystoreFile, final String keystorePass, final String keystoreClassname) {
+        if (keystoreFile == null || keystoreClassname == null) {
+            throw new IllegalArgumentException("`keystore.file` and `keystore.classname` cannot be null");
+        }
+
         SecureConfig sc = new SecureConfig();
         sc.add("keystore.file", keystoreFile.toCharArray());
         if (keystorePass != null) {
@@ -50,18 +54,18 @@ public class SecretStoreExt {
         return sc;
     }
 
-    public static boolean exists(String keystoreFile, String keystoreClassname) {
+    public static boolean exists(final String keystoreFile, final String keystoreClassname) {
         return SECRET_STORE_FACTORY.exists(getConfig(keystoreFile, keystoreClassname));
     }
 
-    public static SecretStore getIfExists(String keystoreFile, String keystoreClassname) {
+    public static SecretStore getIfExists(final String keystoreFile, final String keystoreClassname) {
         SecureConfig sc = getConfig(keystoreFile, keystoreClassname);
         return SECRET_STORE_FACTORY.exists(sc)
                 ? SECRET_STORE_FACTORY.load(sc)
                 : null;
     }
 
-    public static SecretIdentifier getStoreId(String id) {
+    public static SecretIdentifier getStoreId(final String id) {
         return new SecretIdentifier(id);
     }
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
- Require `keystore.file` and `keystore.classname` when generating a valid secure config (`SecureConfig` in `SecretStoreExt`). 
- Safely resolve keystore file and class name from the settings if available. If they both not available (explicitly set null), it might be that user intentionally turned off the keystore otherwise require both.
- Send non-null file and class name that `SecretStoreFactory#exists` validates file existency and loads.

## Why is it important/What is the impact to the user?
Improves user experience 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ] Add unit tests

## How to test this PR locally
- CLI: always requires both `keystore.file` and `keystore.classname`
  - run `bin/logstash-keystore create/add/list`
- LS run:
  - intentionally turn off keystore (set `keystore.file` and `keystore.classname` in `logstash.yml`)
  - setting `keystore.file` requires `keystore.classname` if `keystore.classname` is null, or vise-versa
  - add `MY_VAR` to keystore is available in pipeline configs with `"${MY_VAR}"`


## Related issues

## Use cases

## Screenshots

## Logs
