### PR TITLE
Pin rubocop-ast development gem due to new dep on prism

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -26,6 +26,8 @@ gem "stud", "~> 0.0.22", :group => :build
 gem "fileutils", "~> 1.7"
 
 gem "rubocop", :group => :development
+# rubocop-ast 1.43.0 carries a dep on `prism` which requires native c extensions
+gem 'rubocop-ast', '= 1.42.0', :group => :development
 gem "belzebuth", :group => :development
 gem "benchmark-ips", :group => :development
 gem "ci_reporter_rspec", "~> 1", :group => :development


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]z

## What does this PR do?

The rubocop-ast gem just introduced a new dependency on prism.
 - https://rubygems.org/gems/rubocop-ast/versions/1.43.0

In our install default gem rake task we are seeing issues trying to build native extensions. I see that in upstream jruby they are seeing a similar problem (at least it is the same failure mode https://github.com/jruby/jruby/pull/8415

This commit pins rubocop-ast to 1.42.0 which is the last version that did not have an explicit prism dependency.

## Why is it important/What is the impact to the user?

NA

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~


## Related issues
- https://github.com/jruby/jruby/pull/8415
- https://github.com/jruby/jruby/pull/8419
- https://github.com/jruby/jruby/issues/8649


## Logs
Example failure with 1.43.0
```
An error occurred while installing prism (1.4.0), and Bundler cannot continue.

In Gemfile:
  rubocop was resolved to 1.74.0, which depends on
    rubocop-ast was resolved to 1.43.0, which depends on
      prism
Error Bundler::InstallError, retrying 6/10
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/prism-1.4.0/ext/prism
/var/folders/cw/q_xjr4md1wj_w_c1xwfrnxdw0000gn/T/bin/jruby -I /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib extconf.rb

extconf failed, exit code 126

Gem files will remain installed in /Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/prism-1.4.0 for inspection.
Results logged to /Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/extensions/universal-java-21/3.1.0/prism-1.4.0/gem_make.out

  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:102:in `run'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/ext_conf_builder.rb:28:in `build'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:171:in `build_extension'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:205:in `block in build_extensions'
  org/jruby/RubyArray.java:1981:in `each'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/ext/builder.rb:202:in `build_extensions'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/installer.rb:843:in `build_extensions'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:28:in `install'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/source/rubygems.rb:207:in `install'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:54:in `install'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:62:in `apply_func'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:57:in `block in process_queue'
  org/jruby/RubyKernel.java:1725:in `loop'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:54:in `process_queue'
  /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:91:in `block in create_threads'
```