### PR TITLE
Add age filter fedramp

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -536,6 +536,7 @@ namespace "artifact" do
     if ENV['SKIP_PREPARE'] != "1"
       Rake::Task['bootstrap'].invoke
       Rake::Task['plugin:install-default'].invoke
+      Rake::Task['plugin:install'].invoke('logstash-filter-age')
       Rake::Task['plugin:trim-for-observabilitySRE'].invoke
       Rake::Task['artifact:clean-bundle-config'].invoke
     end

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -534,12 +534,10 @@ namespace "artifact" do
 
   task "prepare-observabilitySRE" do
     if ENV['SKIP_PREPARE'] != "1"
-      %w(
-        bootstrap
-        plugin:install-default
-        plugin:trim-for-observabilitySRE
-        artifact:clean-bundle-config
-      ).each {|task| Rake::Task[task].invoke }
+      Rake::Task['bootstrap'].invoke
+      Rake::Task['plugin:install-default'].invoke
+      Rake::Task['plugin:trim-for-observabilitySRE'].invoke
+      Rake::Task['artifact:clean-bundle-config'].invoke
     end
   end
 


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Adds `logstash-filter-age` to internal observaibilitySRE artifact

## Why is it important/What is the impact to the user?

The observaibilitySRE artifact will initially not have the plugin manager entrypoints, so we need to install this filter before packaging.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

~~~
./gradlew bootstrap artifactDockerObservabilitySRE -PfedrampHighMode=true
~~~

Observe:

~~~
[plugin:install] Installing plugin: logstash-filter-age
Installing logstash-filter-age
Installation successful
~~~

Observe that it is still present in the tarball's vendored gems:

~~~
tar -tzf build/logstash-observability-sre-8.19.0-SNAPSHOT-linux-x86_64.tar.gz | grep logstash-filter-age
~~~

Observe that it is referenced in the tarball's Gemfile:

~~~
tar -xzOf build/logstash-observability-sre-8.19.0-SNAPSHOT-linux-x86_64.tar.gz logstash-8.19.0-SNAPSHOT/Gemfile | grep 'logstash-filter-age'
~~~

Observe that it is referenced in the tarball's Gemfile.lock:
~~~
tar -xzOf build/logstash-observability-sre-8.19.0-SNAPSHOT-linux-x86_64.tar.gz logstash-8.19.0-SNAPSHOT/Gemfile.lock | grep 'logstash-filter-age'
~~~


