### PR TITLE
Fix JDK matrix pipeline after configurable it split

### DIFF
--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 import os
 import sys
 import typing
+from functools import partial
 
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
@@ -257,8 +258,8 @@ ci/unit_tests.sh ruby
             retry=copy.deepcopy(ENABLED_RETRIES),
         )
 
-    def integration_test_parts(self, parts) -> list[JobRetValues]:
-        return list(map(lambda idx: integration_tests(self, idx+1, parts), range(parts))
+    def integration_test_parts(self, parts) -> list[partial[JobRetValues]]:
+        return [partial(self.integration_tests, part=idx+1, parts=parts) for idx in range(parts)]
 
     def integration_tests(self, part: int, parts: int) -> JobRetValues:
         step_name_human = f"Integration Tests - {part}/{parts}"
@@ -276,8 +277,8 @@ ci/integration_tests.sh split {part-1} {parts}
             retry=copy.deepcopy(ENABLED_RETRIES),
         )
 
-    def pq_integration_test_parts(self, parts) -> list[JobRetValues]:
-        return list(map(lambda idx: pq_integration_tests(self, idx+1, parts), range(parts))
+    def pq_integration_test_parts(self, parts) -> list[partial[JobRetValues]]:
+        return [partial(self.pq_integration_tests, part=idx+1, parts=parts) for idx in range(parts)]
 
     def pq_integration_tests(self, part: int, parts: int) -> JobRetValues:
         step_name_human = f"IT Persistent Queues - {part}/{parts}"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

PR #17219 introduced configurable split quantities for IT tests, which resulted in broken JDK matrix pipelines (e.g. as seen via the elastic internal link:
https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/444

reporting the following error

```
  File "/buildkite/builds/bk-agent-prod-k8s-1743469287077752648/elastic/logstash-linux-jdk-matrix-pipeline/.buildkite/scripts/jdk-matrix-tests/generate-steps.py", line 263
    def integration_tests(self, part: int, parts: int) -> JobRetValues:
    ^^^
SyntaxError: invalid syntax
There was a problem rendering the pipeline steps.
Exiting now.
```
)

This PR fixes the above problem.

## Why is it important/What is the impact to the user?

Restores the functionality of the JDK (Windows/Linux) matrix pipelines.

## How to test this PR locally

**Linux**

`MATRIX_OSES="ubuntu-2204" MATRIX_JDKS="adoptiomjdk_21" python3 scripts/jdk-matrix-tests/generate-steps.py | yq .`

produces:

<details><summary>Output from generate-steps for Linux</summary>

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
steps:
  - group: ubuntu-2204/adoptiomjdk_21
    key: ubuntu-2204_adoptiomjdk_21
    steps:
      - label: Initialize annotation
        key: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        command: |-
          buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 "### Group: ubuntu-2204 / adoptiomjdk_21
          | **Status** | **Test** |
          | --- | ----|
          "
      - label: Java Unit Test
        key: ubuntu-2204_adoptiomjdk_21-java-unit-test
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport ENABLE_SONARQUBE=\"false\"\nci/unit_tests.sh java\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | Java Unit Test |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | Java Unit Test |\n\"\nfi\n      "
      - label: Ruby Unit Test
        key: ubuntu-2204_adoptiomjdk_21-ruby-unit-test
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/unit_tests.sh ruby\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | Ruby Unit Test |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | Ruby Unit Test |\n\"\nfi\n      "
      - label: Integration Tests - 1/3
        key: ubuntu-2204_adoptiomjdk_21-integration-tests-1-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 0 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 1/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 1/3 |\n\"\nfi\n      "
      - label: Integration Tests - 2/3
        key: ubuntu-2204_adoptiomjdk_21-integration-tests-2-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 1 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 2/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 2/3 |\n\"\nfi\n      "
      - label: Integration Tests - 3/3
        key: ubuntu-2204_adoptiomjdk_21-integration-tests-3-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 2 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 3/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 3/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 1/3
        key: ubuntu-2204_adoptiomjdk_21-it-persistent-queues-1-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 0 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 1/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 1/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 2/3
        key: ubuntu-2204_adoptiomjdk_21-it-persistent-queues-2-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 1 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 2/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 2/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 3/3
        key: ubuntu-2204_adoptiomjdk_21-it-persistent-queues-3-of-3
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 2 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 3/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 3/3 |\n\"\nfi\n      "
      - label: x-pack unit tests
        key: ubuntu-2204_adoptiomjdk_21-x-pack-unit-test
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nx-pack/ci/unit_tests.sh\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | x-pack unit tests |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | x-pack unit tests |\n\"\nfi\n      "
      - label: x-pack integration
        key: ubuntu-2204_adoptiomjdk_21-x-pack-integration
        depends_on: ubuntu-2204-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nx-pack/ci/integration_tests.sh\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-failed: | x-pack integration |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=ubuntu-2204_adoptiomjdk_21 --append \"| :bk-status-passed: | x-pack integration |\n\"\nfi\n      "
```
</details>

**Windows**

`MATRIX_OSES="windows-2025" MATRIX_JDKS="adoptiomjdk_21" python3 scripts/jdk-matrix-tests/generate-steps.py | yq .`

<details><summary>Output from generate-steps for Windows</summary>

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
steps:
  - group: windows-2025/adoptiomjdk_21
    key: windows-2025_adoptiomjdk_21
    steps:
      - label: Initialize annotation
        key: windows-2025-adoptiomjdk_21-initialize-annotation
        command: |-
          buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 "### Group: windows-2025 / adoptiomjdk_21
          | **Status** | **Test** |
          | --- | ----|
          "
      - label: Java Unit Test
        key: windows-2025_adoptiomjdk_21-java-unit-test
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport ENABLE_SONARQUBE=\"false\"\nci/unit_tests.sh java\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | Java Unit Test |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | Java Unit Test |\n\"\nfi\n      "
      - label: Ruby Unit Test
        key: windows-2025_adoptiomjdk_21-ruby-unit-test
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/unit_tests.sh ruby\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | Ruby Unit Test |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | Ruby Unit Test |\n\"\nfi\n      "
      - label: Integration Tests - 1/3
        key: windows-2025_adoptiomjdk_21-integration-tests-1-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 0 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 1/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 1/3 |\n\"\nfi\n      "
      - label: Integration Tests - 2/3
        key: windows-2025_adoptiomjdk_21-integration-tests-2-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 1 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 2/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 2/3 |\n\"\nfi\n      "
      - label: Integration Tests - 3/3
        key: windows-2025_adoptiomjdk_21-integration-tests-3-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nci/integration_tests.sh split 2 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | Integration Tests - 3/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | Integration Tests - 3/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 1/3
        key: windows-2025_adoptiomjdk_21-it-persistent-queues-1-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 0 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 1/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 1/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 2/3
        key: windows-2025_adoptiomjdk_21-it-persistent-queues-2-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 1 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 2/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 2/3 |\n\"\nfi\n      "
      - label: IT Persistent Queues - 3/3
        key: windows-2025_adoptiomjdk_21-it-persistent-queues-3-of-3
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nexport FEATURE_FLAG=persistent_queues\nci/integration_tests.sh split 2 3\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | IT Persistent Queues - 3/3 |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | IT Persistent Queues - 3/3 |\n\"\nfi\n      "
      - label: x-pack unit tests
        key: windows-2025_adoptiomjdk_21-x-pack-unit-test
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nx-pack/ci/unit_tests.sh\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | x-pack unit tests |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | x-pack unit tests |\n\"\nfi\n      "
      - label: x-pack integration
        key: windows-2025_adoptiomjdk_21-x-pack-integration
        depends_on: windows-2025-adoptiomjdk_21-initialize-annotation
        agents:
          provider: gcp
          imageProject: elastic-images-prod
          image: family/platform-ingest-logstash-multi-jdk-windows-2025
          machineType: n2-standard-4
          diskSizeGb: 200
          diskType: pd-ssd
        retry:
          automatic:
            - limit: 3
        command: "\n#!/usr/bin/env bash\nset -euo pipefail\n\n# unset generic JAVA_HOME\nunset JAVA_HOME\n\n# LS env vars for JDK matrix tests\nexport BUILD_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport RUNTIME_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\nexport LS_JAVA_HOME=/opt/buildkite-agent/.java/adoptiomjdk_21\n\nexport PATH=\"/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH\"\neval \"$(rbenv init -)\"\n\n# temporarily disable immediate failure on errors, so that we can update the BK annotation\nset +eo pipefail\n\nx-pack/ci/integration_tests.sh\n        \nif [[ $$? -ne 0 ]]; then\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-failed: | x-pack integration |\n\"\n  exit 1\nelse\n    buildkite-agent annotate --style=info --context=windows-2025_adoptiomjdk_21 --append \"| :bk-status-passed: | x-pack integration |\n\"\nfi\n      "
```
</details>

## Related issues

PR #17219

