### PR TITLE
Remove tech preview from agent driven LS monitoring pages.

### DIFF
--- a/docs/reference/dashboard-monitoring-with-elastic-agent.md
+++ b/docs/reference/dashboard-monitoring-with-elastic-agent.md
@@ -85,8 +85,8 @@ Check out [Installing {{agent}}](docs-content://reference/fleet/install-elastic-
 
 6. Configure the integration to collect metrics.
 
-    * Make sure that **Metrics (Technical Preview)** is turned on, and **Metrics (Stack Monitoring)** is turned off.
-    * Under **Metrics (Technical Preview)**, make sure the {{ls}} URL setting points to your {{ls}} instance URLs.<br> By default, the integration collects {{ls}} monitoring metrics from `https://localhost:9600`. If that host and port number are not correct, update the `Logstash URL` setting. If you configured {{ls}} to use encrypted communications and/or a username and password, you must access it via HTTPS, and expand the **Advanced Settings** options, and fill in with the appropriate values for your {{ls}} instance.
+    * Make sure that **Metrics (Elastic Agent)** is enabled (default), and **Metrics (Stack Monitoring)** is turned off.
+    * Under **Metrics (Elastic Agent)**, make sure the {{ls}} URL setting points to your {{ls}} instance URLs.<br> By default, the integration collects {{ls}} monitoring metrics from `https://localhost:9600`. If that host and port number are not correct, update the `Logstash URL` setting. If you configured {{ls}} to use encrypted communications and/or a username and password, you must access it via HTTPS, and expand the **Advanced Settings** options, and fill in with the appropriate values for your {{ls}} instance.
 
 7. Click **Save and continue**.<br> This step takes a minute or two to complete. When it’s done, you’ll have an agent policy that contains a system integration policy for the configuration you just specified.
 8. In the popup, click **Add {{agent}} to your hosts** to open the **Add agent** flyout.
@@ -129,7 +129,7 @@ It takes about a minute for {{agent}} to enroll in {{fleet}}, download the confi
 
 After you have confirmed enrollment and data is coming in,  click **View assets** to access dashboards related to the {{ls}} integration.
 
-For traditional Stack Monitoring UI, the dashboards marked **[Logs {{ls}}]** are used to visualize the logs produced by your {{ls}} instances, with those marked **[Metrics {{ls}}]** for the technical preview metrics dashboards. These are populated with data only if you selected the **Metrics (Technical Preview)** checkbox.
+For traditional Stack Monitoring UI, the dashboards marked **[Logs {{ls}}]** are used to visualize the logs produced by your {{ls}} instances, with those marked **[Metrics {{ls}}]** for metrics dashboards. These are populated with data only if you selected the **Metrics (Elastic Agent)** checkbox.
 
 :::{image} images/integration-assets-dashboards.png
 :alt: Integration assets

--- a/docs/reference/dashboard-monitoring-with-elastic-agent.md
+++ b/docs/reference/dashboard-monitoring-with-elastic-agent.md
@@ -85,7 +85,7 @@ Check out [Installing {{agent}}](docs-content://reference/fleet/install-elastic-
 
 6. Configure the integration to collect metrics.
 
-    * Make sure that **Metrics (Elastic Agent)** is enabled (default), and **Metrics (Stack Monitoring)** is turned off.
+    * Make sure that **Metrics (Elastic Agent)** is turned on (default), and **Metrics (Stack Monitoring)** is turned off.
     * Under **Metrics (Elastic Agent)**, make sure the {{ls}} URL setting points to your {{ls}} instance URLs.<br> By default, the integration collects {{ls}} monitoring metrics from `https://localhost:9600`. If that host and port number are not correct, update the `Logstash URL` setting. If you configured {{ls}} to use encrypted communications and/or a username and password, you must access it via HTTPS, and expand the **Advanced Settings** options, and fill in with the appropriate values for your {{ls}} instance.
 
 7. Click **Save and continue**.<br> This step takes a minute or two to complete. When it’s done, you’ll have an agent policy that contains a system integration policy for the configuration you just specified.

--- a/docs/reference/monitoring-with-elastic-agent.md
+++ b/docs/reference/monitoring-with-elastic-agent.md
@@ -92,7 +92,7 @@ Check out [Installing {{agent}}](docs-content://reference/fleet/install-elastic-
 
 6. Configure the integration to collect metrics
 
-    * Make sure that **Metrics (Stack Monitoring)** is turned on, and **Metrics (Technical Preview)** is turned off, if you want to collect metrics from your {{ls}} instance
+    * Make sure that **Metrics (Stack Monitoring)** is turned on, and **Metrics (Elastic Agent)** is turned off, if you want to collect metrics from your {{ls}} instance.
     * Under **Metrics (Stack Monitoring)**, make sure the hosts setting points to your {{ls}} host URLs. By default, the integration collects {{ls}} monitoring metrics from `localhost:9600`. If that host and port number are not correct, update the `hosts` setting. If you configured {{ls}} to use encrypted communications, you must access it via HTTPS. For example, use a `hosts` setting like `https://localhost:9600`.
 
 7. Choose where to add the integration policy.<br> Click **New hosts** to add it to new agent policy or **Existing hosts** to add it to an existing agent policy.
@@ -136,7 +136,7 @@ It takes about a minute for {{agent}} to enroll in {{fleet}}, download the confi
 
 After you have confirmed enrollment and data is coming in,  click **View assets** to access dashboards related to the {{ls}} integration.
 
-For traditional Stack Monitoring UI, the dashboards marked **[Logs {{ls}}]** are used to visualize the logs produced by your {{ls}} instances, with those marked **[Metrics {{ls}}]** for the technical preview metrics dashboards. These are populated with data only if you selected the **Metrics (Technical Preview)** checkbox.
+For traditional Stack Monitoring UI, the dashboards marked **[Logs {{ls}}]** are used to visualize the logs produced by your {{ls}} instances, with those marked **[Metrics {{ls}}]** for metrics dashboards. These are populated with data only if you selected the **Metrics (Elastic Agent)** checkbox.
 
 :::{image} images/integration-assets-dashboards.png
 :alt: Integration assets

--- a/docs/reference/serverless-monitoring-with-elastic-agent.md
+++ b/docs/reference/serverless-monitoring-with-elastic-agent.md
@@ -46,7 +46,7 @@ For more info, check out the [Elastic Observability](docs-content://solutions/ob
 
 **Configure the integration to collect metrics**
 
-* Make sure that  **Metrics (Stack Monitoring)** is OFF, and that **Metrics (Technical Preview)** is ON.
+* Make sure that **Metrics (Elastic Agent)** is enabled (default), and **Metrics (Stack Monitoring)** is turned off.
 * Set the {{ls}} URL to point to your {{ls}} instance.<br> By default, the integration collects {{ls}} monitoring metrics from `https://localhost:9600`. If that host and port number are not correct, update the `Logstash URL` setting. If you configured {{ls}} to use encrypted communications and/or a username and password, you must access it using HTTPS. Expand the **Advanced Settings** options, and fill in the appropriate values for your {{ls}} instance.
 
 

--- a/docs/reference/serverless-monitoring-with-elastic-agent.md
+++ b/docs/reference/serverless-monitoring-with-elastic-agent.md
@@ -46,7 +46,7 @@ For more info, check out the [Elastic Observability](docs-content://solutions/ob
 
 **Configure the integration to collect metrics**
 
-* Make sure that **Metrics (Elastic Agent)** is enabled (default), and **Metrics (Stack Monitoring)** is turned off.
+* Make sure that **Metrics (Elastic Agent)** is turned on (default), and **Metrics (Stack Monitoring)** is turned off.
 * Set the {{ls}} URL to point to your {{ls}} instance.<br> By default, the integration collects {{ls}} monitoring metrics from `https://localhost:9600`. If that host and port number are not correct, update the `Logstash URL` setting. If you configured {{ls}} to use encrypted communications and/or a username and password, you must access it using HTTPS. Expand the **Advanced Settings** options, and fill in the appropriate values for your {{ls}} instance.
 
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Removes the tech preview from the agent driven LS monitoring pages.

## Why is it important/What is the impact to the user?
This feature is GAed and corresponding pages need to be updated not to confuse users.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- 

## Use cases


## Screenshots


## Logs
