### PR TITLE
[8.x] Remove technical preview from agent driven monitoring pages.

### DIFF
--- a/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-dashboards.asciidoc
@@ -71,8 +71,8 @@ details.
 * Under **Logs**, modify the log paths to match your {ls} environment.
 
 . Configure the integration to collect metrics.
-* Make sure that **Metrics (Technical Preview)** is turned on, and **Metrics (Stack Monitoring)** is turned off.
-* Under **Metrics (Technical Preview)**, make sure the {ls} URL setting
+* Make sure that **Metrics (Elastic Agent)** is turned on (default), and **Metrics (Stack Monitoring)** is turned off.
+* Under **Metrics (Elastic Agent)**, make sure the {ls} URL setting
 points to your {ls} instance URLs. +
 By default, the integration collects {ls}
 monitoring metrics from `https://localhost:9600`. If that host and port number are not

--- a/docs/static/monitoring/monitoring-ea-serverless.asciidoc
+++ b/docs/static/monitoring/monitoring-ea-serverless.asciidoc
@@ -42,7 +42,7 @@ For more info, check out the {serverless-docs}/observability/what-is-observabili
 
 **Configure the integration to collect metrics**
 
-* Make sure that  **Metrics (Stack Monitoring)** is OFF, and that **Metrics (Technical Preview)** is ON.
+* Make sure that  **Metrics (Stack Monitoring)** is OFF, and that **Metrics (Elastic Agent)** is ON.
 * Set the {ls} URL to point to your {ls} instance. +
 By default, the integration collects {ls}
 monitoring metrics from `https://localhost:9600`. If that host and port number are not

--- a/docs/static/monitoring/monitoring-ea.asciidoc
+++ b/docs/static/monitoring/monitoring-ea.asciidoc
@@ -81,8 +81,8 @@ details about it.
 to match your {ls} environment.
 
 . Configure the integration to collect metrics
-* Make sure that **Metrics (Stack Monitoring)** is turned on, and **Metrics (Technical Preview)** is turned off, if you
-want to collect metrics from your {ls} instance
+* Make sure that **Metrics (Stack Monitoring)** is turned on, and **Metrics (Elastic Agent)** is turned off, if you
+want to collect metrics from your {ls} instance.
 * Under **Metrics (Stack Monitoring)**, make sure the hosts setting
 points to your {ls} host URLs. By default, the integration collects {ls}
 monitoring metrics from `localhost:9600`. If that host and port number are not

--- a/docs/static/monitoring/monitoring-view.asciidoc
+++ b/docs/static/monitoring/monitoring-view.asciidoc
@@ -1,9 +1,9 @@
 After you have confirmed enrollment and data is coming in,  click **View assets** to access dashboards related to the {ls} integration.
 
 For traditional Stack Monitoring UI, the dashboards marked **[Logs {ls}]** are used to visualize the logs
-produced by your {ls} instances, with those marked **[Metrics {ls}]** for the technical preview metrics
+produced by your {ls} instances, with those marked **[Metrics {ls}]** for metrics
 dashboards.
-These are populated with data only if you selected the **Metrics (Technical Preview)** checkbox.
+These are populated with data only if you selected the **Metrics (Elastic Agent)** checkbox.
 
 --
 [role="screenshot"]


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Removes technical preview label from the agent driven monitoring pages.

## Why is it important/What is the impact to the user?
Agent driven monitoring was GAed and this change updates the pages to deliver upto date info.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues
- 

## Use cases

## Screenshots

## Logs
