### PR TITLE
Update cgi to 0.3.7

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -45,3 +45,4 @@ gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "psych", "5.2.2"
+gem "cgi", "0.3.7" # Pins until a new jruby version with updated cgi is released


### PR DESCRIPTION
Jruby 9.4.9.0 or the latest 9.4.12.0 come with cgi 0.3.6. This commit pins cgi to 0.3.7