### PR TITLE
Update uri gem required by Logstash

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -46,3 +46,4 @@ gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "psych", "5.2.2"
 gem "cgi", "0.3.7" # Pins until a new jruby version with updated cgi is released
+gem "uri", "0.12.3" # Pins until a new jruby version with updated cgi is released


### PR DESCRIPTION
Jruby 9.4.9.0 or the latest 9.4.12.0 come with uri 0.12.2 This commit pins uri to 0.12.3