### PR TITLE
setting: enforce non-nullable (restore 8.15.x behavior)

### DIFF
--- a/logstash-core/spec/logstash/settings/string_spec.rb
+++ b/logstash-core/spec/logstash/settings/string_spec.rb
@@ -34,5 +34,10 @@ describe LogStash::Setting::SettingString do
         expect(subject.value).to eq("a")
       end
     end
+    context "when a null value is given" do
+      it "raises an ArgumentError" do
+        expect { subject.set(nil) }.to raise_error(java.lang.IllegalArgumentException)
+      end
+    end
   end
 end

--- a/logstash-core/src/main/java/org/logstash/settings/SettingString.java
+++ b/logstash-core/src/main/java/org/logstash/settings/SettingString.java
@@ -45,6 +45,9 @@ public class SettingString extends BaseSetting<String> {
 
     @Override
     public void validate(String input) throws IllegalArgumentException {
+        if (input == null) {
+            throw new IllegalArgumentException(String.format("Setting \"%s\" must be a String. Received:  (NilClass)", this.getName()));
+        }
         staticValidate(input, possibleStrings, this.getName());
     }
 

--- a/logstash-core/src/test/java/org/logstash/settings/SettingNullableStringTest.java
+++ b/logstash-core/src/test/java/org/logstash/settings/SettingNullableStringTest.java
@@ -1,0 +1,71 @@
+package org.logstash.settings;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class SettingNullableStringTest {
+
+    public static class WithValueConstraintCase{
+        private static final List<String> POSSIBLE_VALUES = List.of("a", "b", "c");
+        private SettingString sut;
+
+        @Before
+        public void setUp() throws Exception {
+            sut = new SettingNullableString("mytext", POSSIBLE_VALUES.iterator().next(), true, POSSIBLE_VALUES);
+        }
+
+        @Test
+        public void whenSetConstrainedToValueNotPresentInPossibleValuesThenThrowAHelpfulError() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+                sut.set("d");
+            });
+            assertThat(ex.getMessage(), containsString("Invalid value \"mytext: d\""));
+        }
+
+        @Test
+        public void whenSetConstrainedToValuePresentInPossibleValuesThenSetValue() {
+            sut.set("a");
+
+            assertEquals("a", sut.value());
+        }
+
+        @Test
+        public void whenSetConstrainedToNullThenSetValue() {
+            sut.set(null);
+
+            assertNull(sut.value());
+        }
+    }
+
+    public static class WithoutValueConstraintCase {
+        private SettingString sut;
+
+        @Before
+        public void setUp() throws Exception {
+            sut = new SettingNullableString("mytext", "foo", true);
+        }
+
+        @Test
+        public void whenSetUnconstrainedToNonNullValueThenSetValue() {
+            sut.set("a");
+
+            assertEquals("a", sut.value());
+        }
+
+        @Test
+        public void whenSetUnconstrainedToNullThenSetValue() {
+            sut.set(null);
+
+            assertNull(sut.value());
+        }
+    }
+}


### PR DESCRIPTION
## Release notes

 - Fixes an issue introduced in 8.16.4, 8.17.2, and 8.18.0 where null values were incorrectly accepted for non-nullable settings.

## What does this PR do?

Ensures that `SettingString` is correctly non-nullable and `SettingNullableString` is nullable.

## Why is it important/What is the impact to the user?

Improves error messages and reliability of behaviour when Logstash is misconfigured.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

With Logstash 8.15.5, set a non-nullable string setting to null in the `logstash.yml` and run Logstash, observing that it refuses to start and gives guidance about the wrong setting

~~~
(cd logstash-8.15.5 && echo 'keystore.file: null' > config/logstash.yml && bin/logstash -e 'input { generator { count => 1 } }')
~~~
> ~~~
> Your settings are invalid. Reason: Setting "keystore.file" must be a String. Received:  (NilClass)
> [2025-04-08T21:51:30,611][FATAL][org.logstash.Logstash    ] Logstash stopped processing because of an error: (SystemExit) exit
> ~~~

Repeat with Logstash 8.17.4 and observe that runtime errors that are less clear occur later
~~~
(cd logstash-8.17.4 && echo 'keystore.file: null' > config/logstash.yml && bin/logstash -e 'input { generator { count => 1 } }')
~~~
> ~~~
> [2025-04-08T22:46:34,161][ERROR][logstash.agent           ] Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"TypeError", :message=>"nil is not a string", :backtrace=>["org/logstash/execution/AbstractPipelineExt.java:293:in `initialize'", "org/logstash/execution/AbstractPipelineExt.java:227:in `initialize'", "/Users/rye/src/elastic/scratch/logstash-8.17.4/logstash-core/lib/logstash/java_pipeline.rb:47:in `initialize'", "org/jruby/RubyClass.java:949:in `new'", "/Users/rye/src/elastic/scratch/logstash-8.17.4/logstash-core/lib/logstash/pipeline_action/create.rb:50:in `execute'", "/Users/rye/src/elastic/scratch/logstash-8.17.4/logstash-core/lib/logstash/agent.rb:420:in `block in converge_state'"]}
> [2025-04-08T22:46:34,188][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600, :ssl_enabled=>false}
> [2025-04-08T22:46:34,192][INFO ][logstash.runner          ] Logstash shut down.
> [2025-04-08T22:46:34,194][FATAL][org.logstash.Logstash    ] Logstash stopped processing because of an error: (SystemExit) exit
> ~~~

Repeat with this patch, and observe the restored behaviour:

~~~
echo 'keystore.file: null' > config/logstash.yml && bin/logstash -e 'input { generator { count => 1 } }'
~~~
> ~~~
> Your settings are invalid. Reason: Setting "keystore.file" must be a String. Received:  (NilClass)
> [2025-04-08T22:49:04,092][FATAL][org.logstash.Logstash    ] Logstash stopped processing because of an error: (SystemExit) exit
> ~~~

## Related issues

Caused-By: #16576

