### PR TITLE
Doc: Update installation info

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -41,3 +41,6 @@ subs:
   ilm-init:   "ILM"
   dlm:   "data lifecycle management"
   dlm-init:   "DLM"
+  stack-version: "9.0.0"
+  major-version: "9.0"
+  docker-repo: "docker.elastic.co/logstash/logstash"

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -13,19 +13,43 @@ These images are free to use under the Elastic license. They contain open source
 
 ## Pulling the image [_pulling_the_image]
 
-Obtaining Logstash for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
+Obtaining Logstash for Docker is as simple as issuing a `docker
+pull` command against the Elastic Docker registry.
 
-However, version 9.0.0 of Logstash has not yet been released, so no Docker image is currently available for this version.
+
+```sh subs=true
+docker pull {{docker-repo}}:{{stack-version}}
+```
+
+Alternatively, you can download other Docker images that contain only features
+available under the Apache 2.0 license. To download the images, go to 
+[www.docker.elastic.co](https://www.docker.elastic.co). 
 
 
 ## Verifying the image [_verifying_the_image]
 
-Although it’s optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
+Although it's optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
 
-Elastic images are signed with [Cosign](https://docs.sigstore.dev/quickstart/quickstart-cosign/) which is part of the [Sigstore](https://www.sigstore.dev/) project. Cosign supports container signing, verification, and storage in an OCI registry. Install the appropriate Cosign application for your operating system.
+Elastic images are signed with [Cosign](https://docs.sigstore.dev/cosign/) which is part of the [Sigstore](https://www.sigstore.dev/) project. 
+Cosign supports container signing, verification, and storage in an OCI registry. 
+Install the appropriate Cosign application for your operating system.
 
-Run the following commands to verify the container image signature for {{ls}} v9.0.0-beta1:
+Run the following commands to verify the container image signature for {{ls}} v{{stack-version}}:
 
-Version 9.0.0 of Logstash has not yet been released, so no Docker image is currently available for this version.
+```sh subs=true
+wget https://artifacts.elastic.co/cosign.pub <1>
+cosign verify --key cosign.pub {{docker-repo}}:{{stack-version}} <2>
+```
 
+1. Download the Elastic public key to verify container signature
+2. Verify the container against the Elastic public key
 
+The command prints the check results and the signature payload in JSON format, for example:
+
+```sh subs=true
+Verification for {{docker-repo}}:{{stack-version}} --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The signatures were verified against the specified public key
+```

--- a/docs/reference/installing-logstash.md
+++ b/docs/reference/installing-logstash.md
@@ -47,13 +47,79 @@ For testing purposes, you may still run Logstash from the command line, but you 
 
 ### APT [_apt]
 
-Version 9.0.0 of Logstash has not yet been released.
+Download and install the Public Signing Key:
+
+```
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elastic-keyring.gpg
+```
+
+You may need to install the `apt-transport-https` package on Debian before proceeding:
+
+```
+sudo apt-get install apt-transport-https
+```
+
+Save the repository definition to  /etc/apt/sources.list.d/elastic-{{major-version}}.list:
+
+```sh subs=true
+echo "deb [signed-by=/usr/share/keyrings/elastic-keyring.gpg] https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+```
+
+::::{warning}
+Use the `echo` method described above to add the Logstash repository.
+Do not use `add-apt-repository` as it will add a `deb-src` entry as well, but we do not provide a source package. 
+If you have added the `deb-src` entry, you will see an error like the following:
+
+```
+    Unable to find expected entry 'main/source/Sources' in Release file (Wrong sources.list entry or malformed file)
+```
+
+Just delete the `deb-src` entry from the `/etc/apt/sources.list` file and the
+installation should work as expected.
+::::
+
+Run `sudo apt-get update` and the repository is ready for use. You can install
+it with:
+
+```sh subs=true
+sudo apt-get update && sudo apt-get install logstash
+```
+
+Check out [Running Logstash](running-logstash.md) for details about managing Logstash as a system service.
 
 
 ### YUM [_yum]
 
-Version 9.0.0 of Logstash has not yet been released.
+Download and install the public signing key:
 
+```sh
+sudo rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
+```
+
+Add the following in your `/etc/yum.repos.d/` directory
+in a file with a `.repo` suffix, for example `logstash.repo`
+
+```sh subs=true
+[logstash-{{major-version}}]
+name=Elastic repository for {{major-version}} packages
+baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+```
+And your repository is ready for use. You can install it with:
+
+```sh
+sudo yum install logstash
+```
+
+::::{warning}
+The repositories do not work with older rpm based distributions that still use RPM v3, like CentOS5.
+::::
+
+Check out [Running Logstash](running-logstash.md)  for managing Logstash as a system service.
 
 ### Docker [_docker]
 


### PR DESCRIPTION
Install docs were migrated with unreleased config.
This work adds correct info. 

I pulled the content from pre-migration files, and compared the output to a similar page for a current release: https://www.elastic.co/guide/en/logstash/current/installing-logstash.html