### PR TITLE
Restore code review changes

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -165,6 +165,8 @@ steps:
       # Run the smoke tests on the PR code
       docker tag docker.elastic.co/logstash/logstash-observability-sre:$${QUALIFIED_VERSION} \
         pr-built-observability-sre-image
+      # observabilitySREsmokeTests orchestrates FIPS-mode docker images
+      # and validates assertions separately, so it does not need FIPS flag.
       ./gradlew observabilitySREsmokeTests --stacktrace
 
   - label: ":lab_coat: Integration Tests - FIPS mode / part 1-of-3"

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -89,7 +89,7 @@ tasks.register("observabilitySREsmokeTests", Test) {
         }
         def result = exec {
             workingDir file("distributions/internal/observabilitySRE/qa/smoke/docker")
-            commandLine 'docker-compose', 'up', '-d'
+            commandLine 'docker-compose', 'up', '--detach'
             ignoreExitValue = true
         }
         if (result.exitValue != 0) {
@@ -107,7 +107,7 @@ tasks.register("observabilitySREsmokeTests", Test) {
     doLast {
         exec {
             workingDir file("distributions/internal/observabilitySRE/qa/smoke/docker")
-            commandLine 'docker-compose', 'down', '-v'
+            commandLine 'docker-compose', 'down', '--volumes'
             ignoreExitValue = true
         }
         // Clean up the generated certificates

--- a/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/logstash/pipeline/logstash.conf
+++ b/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/logstash/pipeline/logstash.conf
@@ -38,7 +38,7 @@ filter {
   
   if [log_content] =~ /json=/ {
     grok {
-      match => { "log_content" => ".*json=%{GREEDYDATA:json_string}.*" }
+      match => { "log_content" => "json=%{GREEDYDATA:json_string}" }
     }
     json {
       source => "json_string"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Some code review comments from https://github.com/elastic/logstash/pull/17486 were committed via the github UI but when locally rebased they were excluded due to a missed sync. This PR restores them. 

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
N/A
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## Related Issues
- Relates to https://github.com/elastic/logstash/pull/17486 