### PR TITLE
chmod BUILD_METADATA_FILE to allow global read permissions

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -452,6 +452,7 @@ namespace "artifact" do
 
     return if defined?(BUILD_METADATA_FILE)
     BUILD_METADATA_FILE = Tempfile.new('build.rb')
+    BUILD_METADATA_FILE.chmod(0644)
     BUILD_DATE = Time.now.iso8601
     build_info = {
       "build_date" => BUILD_DATE,


### PR DESCRIPTION
## Release notes
Allow global read permissions on BUILD_METADATA_FILE

## What does this PR do?

This PR allows for global read permissions on BUILD_METADATA_FILE (build.rb). This file is created by Ruby's `Tempfile.new` which is hardwired to set permissions to `0600` on all temporary files.

If a logstash user builds logstash and then attempts to run for example the Docker version as another system user the run will fail as only the build user has permission to read `build.rb` once it is packaged as owned by that build user with perms `0600`.

## Why is it important/What is the impact to the user?

This PR fixes #14836 which contains a complete bug report from a user experiencing this issue. The relevant excerpt is:
```
root@kind:/home/radware/git/waas/waas_backend/docker-images/logstash# docker run -u nobody:nogroup -v $PWD/data.7.17.8:/usr/share/logstash/data --rm -ti  --entrypoint bash docker.elastic.co/logstash/logstash:7.17.8

nobody@45c2639679b8:/usr/share/logstash$  ls -al ./logstash-core/lib/logstash/build.rb
-rw-rw---- 1 logstash root 156 Nov 30 16:11 ./logstash-core/lib/logstash/build.rb
```

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ] CI is passing and the build behaves as expected
- [ ] In the generated release artifacts verify that the permissions of build.rb are `0644`

## How to test this PR locally

Build all logstash packages and successfully install one or run the Docker image

## Related issues

- Fixes #14836

## Use cases

1. Build logstash
2. Run logstash as a Docker user other than yourself