### PR TITLE
New way of backporting to active branches using gh action

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -1,0 +1,22 @@
+name: Backport to active branches
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  backport:
+    # Only run if the PR was merged (not just closed) and has one of the backport labels
+    if: |
+      github.event.pull_request.merged == true && 
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: elastic/oblt-actions/github/backport-active@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,17 @@
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+        - sender-permission>=write
+        - sender=github-actions[bot]
+defaults:
+  actions:
+    backport:
+      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "backport"
 pull_request_rules:
 #  - name: ask to resolve conflict
 #    conditions:
@@ -127,62 +141,6 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-
-  - name: backport patches to all active minor branches for the 8 major.
-    conditions:
-      - merged
-      - label=backport-active-8
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "8.x"
-          - "8.18"
-          - "8.17"
-          - "8.16"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-
-  - name: backport patches to all active minor branches for the 9 major.
-    conditions:
-      - merged
-      - label=backport-active-9
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-
-  - name: backport patches to all active branches
-    conditions:
-      - merged
-      - label=backport-active-all
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing release branch reached EOL.
-        branches:
-          - "9.0"
-          - "8.18"
-          - "8.17"
-          - "8.16"
-          - "8.x"
-          - "7.17"
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?

Adding new github workflow for creating backports to active branches.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

