### PR TITLE
Update docset.yml to distinguish between major version and major.minor

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -41,6 +41,7 @@ subs:
   ilm-init:   "ILM"
   dlm:   "data lifecycle management"
   dlm-init:   "DLM"
+  major-version: "9.x"
+  major-minor-version: "9.0"
   stack-version: "9.0.0"
-  major-version: "9.0"
   docker-repo: "docker.elastic.co/logstash/logstash"


### PR DESCRIPTION
it is the start of a fix to https://github.com/elastic/logstash/issues/17561

but requires documentation refactoring after these attributes are changed.