### PR TITLE
Ensure observabilitySRE image is pushed on DRA staging

### DIFF
--- a/.buildkite/scripts/dra/build-and-push-observability-sre.sh
+++ b/.buildkite/scripts/dra/build-and-push-observability-sre.sh
@@ -17,7 +17,12 @@ echo "Pushing ObservabilitySRE container to Docker repository"
 docker_login
 
 # Get qualified version without SHA (this is what the gradle task will produce)
+# Note that the gradle task always produces a version with -SNAPSHOT so if the
+# workflow type is staging we need to append -SNAPSHOT to the version.
 QUALIFIED_VERSION="$(.buildkite/scripts/common/qualified-version.sh)"
+if [[ "${WORKFLOW_TYPE:-}" == "staging" && "${QUALIFIED_VERSION}" != *-SNAPSHOT ]]; then
+  QUALIFIED_VERSION="${QUALIFIED_VERSION}-SNAPSHOT"
+fi
 
 # Set environment variable to include SHA and get version with SHA
 QUALIFIED_VERSION_WITH_SHA="$(INCLUDE_COMMIT_ID=1 .buildkite/scripts/common/qualified-version.sh)"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The `artifactDockerObservabilitySRE` gradle task *always* produces a tag with a `SNAPSHOT` postfix. In the staging pipeline we use the shared `qualified-version` script for determining the LS version. That script correctly handles conditionally adding a `SNAPSHOT` postfix which is important for the tagging scheme for pushing to our container registry. Given the intermediate tag produced by the gradle task is never pushed anywhere we can update the build script to ensure the "local" artifact is always referenced with the `SNAPSHOT` postfix.

## Why is it important/What is the impact to the user?
N/A
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
-~ [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

