### PR TITLE
cli: add hidden command-line flag for overriding settings

### DIFF
--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -65,8 +65,21 @@ module Clamp
       end
 
       def define_appender_for(option)
-        define_method(option.append_method) do |value|
-          LogStash::SETTINGS.get_value(option.attribute_name) << value
+        if option.attribute_name == "SETTINGS_PASSTHROUGH"
+          define_method(option.append_method) do |kv_pair|
+            key, value = kv_pair.split(/[:=]/, 2)
+            signal_usage_error("failed to parse setting `#{kv_pair}`") unless key && value
+            signal_usage_error("failed to apply setting `#{kv_pair}`: unknown setting `#{key}`") unless LogStash::SETTINGS.registered?(key)
+            if value.empty?
+              LogStash::SETTINGS.get_setting(key).reset rescue signal_usage_error("failed to reset setting `#{kv_pair}`: #{$!.message}")
+            else
+              LogStash::SETTINGS.set_value(key, value) rescue signal_usage_error("failed to apply setting `#{kv_pair}`: #{$!.message}")
+            end
+          end
+        else
+          define_method(option.append_method) do |value|
+            LogStash::SETTINGS.get_value(option.attribute_name) << value
+          end
         end
       end
 

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -211,6 +211,12 @@ class LogStash::Runner < Clamp::StrictCommand
     :attribute_name => "path.settings",
     :default => LogStash::SETTINGS.get_default("path.settings")
 
+  option(['--setting', '-S'], "KEY=VALUE",
+         "individual setting",
+         :attribute_name => "SETTINGS_PASSTHROUGH",
+         :multivalued => true,
+         :hidden => true)
+
   ### DEPRECATED FLAGS ###
   deprecated_option ["--verbose"], :flag,
     I18n.t("logstash.runner.flag.verbose"),


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

[rn: skip]

## What does this PR do?

When invoking Logstash in test, it is often necessary to override a setting, but cumbersome to provide a whole `logstash.yml` (or to append specific overrides to a fixture-provided one) when there is no provided command-line option paired with the setting.

This feature adds a _hidden_ `--setting` option with an `-S` shortname, whose value is a colon- or equals-separated key-value pair.

 - long-form single arg: `--setting=queue.type:persisted`
 - long-form arg-pair: `--setting node.name:myname`
 - short-form: `-Squeue.type=persisted`

## Why is it important/What is the impact to the user?

No user impact; improved testability.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

 - Invoke logstash with any setting in any of the supported formats and observe that the modified setting value is in the debug output:
   
   - short-form `-Skey=value`:
     ~~~
     bin/logstash --log.level=debug -Snode.name=banana | grep 'node.name'
     ~~~
     > ~~~
     > [2025-04-23T16:39:57,851][DEBUG][logstash.runner          ] *node.name: banana (default: perhaps)
     > ~~~
   
   - long-form arg pair `--setting key:value`:
     ~~~
     bin/logstash --log.level=debug --setting node.name:orange | grep 'node.name'
     ~~~
     > ~~~
     > [2025-04-23T16:40:01,001][DEBUG][logstash.runner          ] *node.name: orange (default: perhaps)
     > ~~~
   
   - long-form single arg `--setting=key:value`:
     ~~~
     bin/logstash --log.level=debug --setting=node.name:grape | grep 'node.name'
     ~~~
     > ~~~
     > [2025-04-23T16:40:04,571][DEBUG][logstash.runner          ] *node.name: grape (default: perhaps)
     > ~~~

 - Invoke with a non-coercible value to observe a helpful error message:
   ~~~
   bin/logstash --log.level=debug -Sapi.enabled=banana
   ~~~
   > ~~~
   > ERROR: failed to apply setting `api.enabled=banana`: Cannot coerce `banana` to boolean (api.enabled)
   > ~~~

 - Invoke with an unregistered setting name to observe a helpful error message:

   ~~~
   bin/logstash --log.level=debug -Sfruit.favorite=banana
   ~~~
   > ~~~
   > ERROR: failed to apply setting `fruit.favorite=banana`: unknown setting `fruit.favorite`
   > ~~~

## Use cases

Simplifies testing by allowing integration test invocation to include _any_ setting without needing to override the settings.yml that may or may not be provided by a fixture.

## Logs

~~~
      arbitrary settings
        --setting=key:value formatted options
          when specifying `--setting=node.name:my-fancy-node-name --setting=api.enabled:false`
            overrides setting `node.name` to `my-fancy-node-name`
            overrides setting `api.enabled` to `false`
          when specifying `--setting=api.enabled:false`
            overrides setting `api.enabled` to `false`
          when specifying uncoercible `--setting=api.enabled:yellow`
            raises a helpful usage error about failed coercion
          when specifying unregistered `--setting=banana:yellow`
            raises a helpful usage error about the unknown setting
          when specifying `--setting=node.name:my-fancy-node-name`
            overrides setting `node.name` to `my-fancy-node-name`
        -Skey=value formatted options
          when specifying unregistered `-Sbanana=yellow`
            raises a helpful usage error about the unknown setting
          when specifying `-Snode.name=my-fancy-node-name -Sapi.enabled=false`
            overrides setting `node.name` to `my-fancy-node-name`
            overrides setting `api.enabled` to `false`
          when specifying uncoercible `-Sapi.enabled=yellow`
            raises a helpful usage error about failed coercion
          when specifying `-Snode.name=my-fancy-node-name`
            overrides setting `node.name` to `my-fancy-node-name`
          when specifying `-Sapi.enabled=false`
            overrides setting `api.enabled` to `false`
        --setting key:value formatted options
          when specifying `--setting api.enabled:false`
            overrides setting `api.enabled` to `false`
          when specifying `--setting node.name:my-fancy-node-name --setting api.enabled:false`
            overrides setting `api.enabled` to `false`
            overrides setting `node.name` to `my-fancy-node-name`
          when specifying unregistered `--setting banana:yellow`
            raises a helpful usage error about the unknown setting
          when specifying `--setting node.name:my-fancy-node-name`
            overrides setting `node.name` to `my-fancy-node-name`
          when specifying uncoercible `--setting api.enabled:yellow`
            raises a helpful usage error about failed coercion
~~~