### PR TITLE
Add helper method to wait for log message to be observed

### DIFF
--- a/qa/docker/shared_examples/container_options.rb
+++ b/qa/docker/shared_examples/container_options.rb
@@ -88,8 +88,7 @@ shared_examples_for 'it applies settings correctly' do |flavor|
       expect(output_plugins[0].dig('name')).to eql('elasticsearch')
 
       # check if logs contain the ES request with the resolved ${USER}
-      container_logs = @container.logs(stdout: true)
-      expect(container_logs.include?('https://kimchy:xxxxxx@es:9200')).to be true
+      wait_for_log_message(@container, 'https://kimchy:xxxxxx@es:9200')
     end
   end
 end

--- a/qa/docker/shared_examples/xpack.rb
+++ b/qa/docker/shared_examples/xpack.rb
@@ -48,14 +48,11 @@ shared_examples_for 'a container with xpack features' do |flavor|
         expect(settings['xpack.management.pipeline.id']).to eq("${XPACK_MANAGEMENT_PIPELINE_ID}")
         expect(settings['xpack.management.elasticsearch.hosts']).to eq("${XPACK_MANAGEMENT_ELASTICSEARCH_HOSTS}")
 
-        # get container logs
-        container_logs = container.logs(stdout: true)
-
         # check if logs contain node3 & node4 values actually resolved and used
-        expect(container_logs.include?('pipeline_id=>["*"]')).to be true
+        wait_for_log_message(container, 'pipeline_id=>["*"]', :stdout)
         # note that, we are not spinning up ES nodes, so values can be in errors or in pool update logs
-        expect(container_logs.include?('http://node3:9200')).to be true
-        expect(container_logs.include?('http://node4:9200')).to be true
+        wait_for_log_message(container, 'http://node3:9200', :stdout)
+        wait_for_log_message(container, 'http://node4:9200', :stdout)
       end
     end
   end

--- a/qa/docker/spec/spec_helper.rb
+++ b/qa/docker/spec/spec_helper.rb
@@ -51,7 +51,7 @@ end
 
 def wait_for_log_message(container, search_string, stream = :stdout)
   Stud.try(40.times, [NoMethodError, Docker::Error::ConflictError, RSpec::Expectations::ExpectationNotMetError, TypeError]) do
-    container_logs = @container.logs(stream => true)
+    container_logs = container.logs(stream => true)
     expect(container_logs.include?(search_string)).to be true
   end
 end

--- a/qa/docker/spec/spec_helper.rb
+++ b/qa/docker/spec/spec_helper.rb
@@ -49,6 +49,13 @@ def wait_for_pipeline(container, pipeline = 'main')
   end
 end
 
+def wait_for_log_message(container, search_string, stream = :stdout)
+  Stud.try(40.times, [NoMethodError, Docker::Error::ConflictError, RSpec::Expectations::ExpectationNotMetError, TypeError]) do
+    container_logs = @container.logs(stream => true)
+    expect(container_logs.include?(search_string)).to be true
+  end
+end
+
 def cleanup_container(container)
   unless container.nil?
     begin


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

There appears to be a race condition in tests whereby log messages are not observed with a single interogation of the container logs. This commit adds a helper method to wait for log messages. This should make the tests more resilient when there is a delay in log messages being captured.

## Why is it important/What is the impact to the user?
NA

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist


## How to test this PR locally

```
➜  logstash git:(more-resilient-log-assertion) ✗ ci/docker_acceptance_tests.sh oss

```


## Logs
Example failure:
https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/1776#_

```
2025-04-23 23:45:53 PDT | Failures:
-- | --
  | 2025-04-23 23:45:53 PDT |  
  | 2025-04-23 23:45:53 PDT | 1) A container running the oss image behaves like it applies settings correctly when setting config.string persists ${CONFIG_STRING} key in logstash.yml, resolves when running and spins up without issue
  | 2025-04-23 23:45:53 PDT | Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { \|failure, _opts\| raise failure }
  | 2025-04-23 23:45:53 PDT |  
  | 2025-04-23 23:45:53 PDT | expected true
  | 2025-04-23 23:45:53 PDT | got false
  | 2025-04-23 23:45:53 PDT | Shared Example Group: "it applies settings correctly" called from ./docker/spec/oss/container_spec.rb:8
  | 2025-04-23 23:45:53 PDT | # ./docker/shared_examples/container_options.rb:92:in `block in <main>'
  | 2025-04-23 23:45:53 PDT |  
  | 2025-04-23 23:45:53 PDT | Finished in 8 minutes 24 seconds (files took 2.74 seconds to load)
```

