### PR TITLE
upgrade jdk to 21.0.7+6

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -7,8 +7,8 @@ logstash-core-plugin-api: 2.1.16
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptium"
-  revision: 21.0.6
-  build: 7
+  revision: 21.0.7
+  build: 6
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
Fixes: https://github.com/elastic/logstash/issues/17590
CI failed: https://buildkite.com/elastic/logstash-jdk-availability-check-pipeline/builds/51#01965613-71ec-4c14-8b5a-cd12cb7c4ce7