### PR TITLE
[chore] support markdown and asciidoc release notes

### DIFF
--- a/.github/workflows/gen_release_notes.yml
+++ b/.github/workflows/gen_release_notes.yml
@@ -6,11 +6,11 @@ on:
       branch:
         type: string
         required: true
-        default: "8.2"
+        default: "9.0"
       last_release:
         type: string
         required: true
-        default: "8.2.2"
+        default: "9.0.0"
 
 
 permissions:
@@ -35,10 +35,10 @@ jobs:
       run: |
         if [[ "${{ github.event.inputs.branch }}" =~ ^([0-8])\.[0-9]+$ ]]; then
           echo "Using Asciidoc generator"
-          SCRIPT="./tools/release/generate_release_notes_asciidoc.rb"
-        else
-          echo "Using standard generator"
           SCRIPT="./tools/release/generate_release_notes.rb"
+        else
+          echo "Using Markdown generator"
+          SCRIPT="./tools/release/generate_release_notes_md.rb"
         fi
         
         $SCRIPT "${{ github.event.inputs.branch }}" "${{ github.event.inputs.last_release }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"

--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -27,7 +27,7 @@ require 'yaml'
 require 'json'
 require 'net/http'
 
-RELEASE_NOTES_PATH = "docs/release-notes/index.md"
+RELEASE_NOTES_PATH = "docs/static/releasenotes.asciidoc"
 release_branch = ARGV[0]
 previous_release_tag = ARGV[1]
 user = ARGV[2]
@@ -37,18 +37,19 @@ report = []
 `git checkout #{release_branch}`
 
 current_release = YAML.load(IO.read("versions.yml"))["logstash"]
-current_release_no_dot = current_release.tr(".", "")
+current_release_dashes = current_release.tr(".", "-")
 
 release_notes = IO.read(RELEASE_NOTES_PATH).split("\n")
 
-coming_tag_index = release_notes.find_index {|line| line.match(/^## #{current_release} \[logstash-#{current_release_no_dot}-release-notes\]$/) }
-coming_tag_index += 1 if coming_tag_index
-release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/\[logstash-\d+-release-notes\]$/) }
+current_release_heading = "* <<logstash-#{current_release_dashes},Logstash #{current_release}>>"
+release_notes.insert(5, current_release_heading) unless release_notes[5].eql?(current_release_heading)
 
-unless coming_tag_index
-  report << "## #{current_release} [logstash-#{current_release_no_dot}-release-notes]\n\n"
-  report << "###  Features and enhancements [logstash-#{current_release_no_dot}-features-enhancements]\n"
-end
+coming_tag_index = release_notes.find_index {|line| line.match(/^coming\[#{current_release}\]/) }
+coming_tag_index += 1 if coming_tag_index
+release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/^\[\[logstash/) }
+
+report << "[[logstash-#{current_release_dashes}]]" unless release_notes.any? { |line| line&.match(/^\[\[logstash-#{current_release_dashes}/) }
+report << "=== Logstash #{current_release} Release Notes\n" unless release_notes.any? { |line| line&.match(/^=== Logstash #{current_release}/)}
 
 plugin_changes = {}
 
@@ -87,11 +88,11 @@ report << "Changed plugin versions:"
 plugin_changes.each {|p, v| report << "#{p}: #{v.first} -> #{v.last}" }
 report << "---------- GENERATED CONTENT ENDS HERE ------------\n"
 
-report << "### Plugins [logstash-plugin-#{current_release_no_dot}-changes]\n"
+report << "==== Plugins\n"
 
 plugin_changes.each do |plugin, versions|
   _, type, name = plugin.split("-")
-  header = "**#{name.capitalize} #{type.capitalize} - #{versions.last}**"
+  header = "*#{name.capitalize} #{type.capitalize} - #{versions.last}*"
   start_changelog_file = Tempfile.new(plugin + 'start')
   end_changelog_file = Tempfile.new(plugin + 'end')
   changelog = `curl https://raw.githubusercontent.com/logstash-plugins/#{plugin}/v#{versions.last}/CHANGELOG.md`.split("\n")
@@ -117,7 +118,7 @@ IO.write(RELEASE_NOTES_PATH, release_notes.join("\n"))
 puts "Creating commit.."
 branch_name = "update_release_notes_#{Time.now.to_i}"
 `git checkout -b #{branch_name}`
-`git commit #{RELEASE_NOTES_PATH} -m "Update release notes for #{current_release}"`
+`git commit docs/static/releasenotes.asciidoc -m "Update release notes for #{current_release}"`
 
 puts "Pushing commit.."
 `git remote set-url origin https://x-access-token:#{token}@github.com/elastic/logstash.git`

--- a/tools/release/generate_release_notes_md.rb
+++ b/tools/release/generate_release_notes_md.rb
@@ -27,7 +27,7 @@ require 'yaml'
 require 'json'
 require 'net/http'
 
-RELEASE_NOTES_PATH = "docs/static/releasenotes.asciidoc"
+RELEASE_NOTES_PATH = "docs/release-notes/index.md"
 release_branch = ARGV[0]
 previous_release_tag = ARGV[1]
 user = ARGV[2]
@@ -37,19 +37,18 @@ report = []
 `git checkout #{release_branch}`
 
 current_release = YAML.load(IO.read("versions.yml"))["logstash"]
-current_release_dashes = current_release.tr(".", "-")
+current_release_no_dot = current_release.tr(".", "")
 
 release_notes = IO.read(RELEASE_NOTES_PATH).split("\n")
 
-current_release_heading = "* <<logstash-#{current_release_dashes},Logstash #{current_release}>>"
-release_notes.insert(5, current_release_heading) unless release_notes[5].eql?(current_release_heading)
-
-coming_tag_index = release_notes.find_index {|line| line.match(/^coming\[#{current_release}\]/) }
+coming_tag_index = release_notes.find_index {|line| line.match(/^## #{current_release} \[logstash-#{current_release_no_dot}-release-notes\]$/) }
 coming_tag_index += 1 if coming_tag_index
-release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/^\[\[logstash/) }
+release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/\[logstash-\d+-release-notes\]$/) }
 
-report << "[[logstash-#{current_release_dashes}]]" unless release_notes.any? { |line| line&.match(/^\[\[logstash-#{current_release_dashes}/) }
-report << "=== Logstash #{current_release} Release Notes\n" unless release_notes.any? { |line| line&.match(/^=== Logstash #{current_release}/)}
+unless coming_tag_index
+  report << "## #{current_release} [logstash-#{current_release_no_dot}-release-notes]\n\n"
+  report << "###  Features and enhancements [logstash-#{current_release_no_dot}-features-enhancements]\n"
+end
 
 plugin_changes = {}
 
@@ -88,11 +87,11 @@ report << "Changed plugin versions:"
 plugin_changes.each {|p, v| report << "#{p}: #{v.first} -> #{v.last}" }
 report << "---------- GENERATED CONTENT ENDS HERE ------------\n"
 
-report << "==== Plugins\n"
+report << "### Plugins [logstash-plugin-#{current_release_no_dot}-changes]\n"
 
 plugin_changes.each do |plugin, versions|
   _, type, name = plugin.split("-")
-  header = "*#{name.capitalize} #{type.capitalize} - #{versions.last}*"
+  header = "**#{name.capitalize} #{type.capitalize} - #{versions.last}**"
   start_changelog_file = Tempfile.new(plugin + 'start')
   end_changelog_file = Tempfile.new(plugin + 'end')
   changelog = `curl https://raw.githubusercontent.com/logstash-plugins/#{plugin}/v#{versions.last}/CHANGELOG.md`.split("\n")
@@ -118,7 +117,7 @@ IO.write(RELEASE_NOTES_PATH, release_notes.join("\n"))
 puts "Creating commit.."
 branch_name = "update_release_notes_#{Time.now.to_i}"
 `git checkout -b #{branch_name}`
-`git commit docs/static/releasenotes.asciidoc -m "Update release notes for #{current_release}"`
+`git commit #{RELEASE_NOTES_PATH} -m "Update release notes for #{current_release}"`
 
 puts "Pushing commit.."
 `git remote set-url origin https://x-access-token:#{token}@github.com/elastic/logstash.git`


### PR DESCRIPTION
This commit preserves asciidoc release note generator to`generate_release_notes.rb` for v7 backward compatibility.
Markdown generator moves to `generate_release_notes_md.rb`.

Prior to this change, in case v7 needs a release, the workflow runs `generate_release_notes_asciidoc.rb` in `main` and the script checkouts `7.17` branch. However, v7 only does not have the new `generate_release_notes_asciidoc.rb`. So, it is better to keep the asciidoc generation to `generate_release_notes.rb`

Follow-up of #17613
Fixes: #16853