### PR TITLE
health-report: link to major.minor-versioned help docs on 9.0+

### DIFF
--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -187,22 +187,49 @@ artifacts {
     }
 }
 
-task generateVersionInfoResources(type: DefaultTask) {
-    ext.outDir = layout.buildDirectory.dir("generated-resources/version-info").get()
+
+task generateHealthcheckResources(type: DefaultTask) {
+    Directory outDir = layout.buildDirectory.dir("generated-resources/main/org/logstash/health").get()
+    File outFile = outDir.file("help.url").asFile
+
+    // builds are considered "snapshot" unless the env has
+    // either `WORKFLOW_TYPE=staging` OR `RELEASE=1`
+    boolean isSnapshot = !("${System.env.WORKFLOW_TYPE}" == "staging" || "${System.env.RELEASE}" == "1")
 
     inputs.property("version-info:logstash-core", logstashCoreVersion)
-    outputs.dir(ext.outDir)
+    inputs.property("BUILD_ENV:IS_SNAPSHOT", isSnapshot)
+    outputs.dir outDir
+
+    // don't reuse outputs if they are missing
+    outputs.upToDateWhen { outFile.exists() }
 
     doLast {
-        mkdir outDir;
-        def resourceFile = outDir.file('version-info.properties').asFile
-        resourceFile.text = "logstash-core: ${logstashCoreVersion}"
+        def (majorVersion, minorVersion, patchVersion) = logstashCoreVersion.tokenize('.').subList(0,3)
+
+        String versionAnchor;
+        if (isSnapshot && patchVersion == "0") {
+            // snapshot builds on unreleased minors
+            if (majorVersion == "9") {
+                versionAnchor = "master"
+            } else {
+                versionAnchor = "${majorVersion}.x"
+            }
+        } else {
+            // otherwise we target MAJOR.MINOR
+            versionAnchor = "${majorVersion}.${minorVersion}"
+        }
+        def helpUrl = "https://www.elastic.co/guide/en/logstash/${versionAnchor}/"
+
+        mkdir outDir
+        outFile.text = helpUrl
+
+        logger.info("Health API HelpUrl base: FOR(${logstashCoreVersion}${isSnapshot ? "-SNAPSHOT" : ""}) WRITE(${helpUrl}) TO(${outFile.path})")
     }
 }
 sourceSets {
-    main { output.dir(generateVersionInfoResources.outputs.files) }
+    main { resources { output.dir(generateHealthcheckResources.outputs.files) } }
 }
-processResources.dependsOn generateVersionInfoResources
+processResources.dependsOn generateHealthcheckResources
 
 configurations {
     provided

--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -46,25 +46,6 @@ import javax.annotation.Nullable;
  */
 public final class Logstash implements Runnable, AutoCloseable {
 
-    public static final String VERSION_FULL;
-    public static final String VERSION_MAJOR;
-    public static final String VERSION_MINOR;
-    public static final String VERSION_PATCH;
-
-    static {
-        final Properties properties = new Properties();
-        try {
-            properties.load(Logstash.class.getResourceAsStream("/version-info.properties"));
-            VERSION_FULL = properties.getProperty("logstash-core");
-            final String[] versions = VERSION_FULL.split("\\.");
-            VERSION_MAJOR = versions[0];
-            VERSION_MINOR = versions[1];
-            VERSION_PATCH = versions[2];
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private static final Logger LOGGER = LogManager.getLogger(Logstash.class);
 
     /**

--- a/logstash-core/src/main/java/org/logstash/health/HelpUrl.java
+++ b/logstash-core/src/main/java/org/logstash/health/HelpUrl.java
@@ -18,20 +18,27 @@
  */
 package org.logstash.health;
 
+import com.google.common.io.Resources;
 import org.logstash.Logstash;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class HelpUrl {
     static final String BASE_URL;
     static {
-        final String versionAnchor;
-        if (Integer.parseInt(Logstash.VERSION_MAJOR) >= 9) {
-            versionAnchor = "master";
-        } else {
-            versionAnchor = String.format("%s.%s", Logstash.VERSION_MAJOR, Logstash.VERSION_MINOR);
+        try {
+            final URL url = HelpUrl.class.getResource("/help.url");
+            if (url == null) {
+                throw new IllegalStateException("Unable to locate 'help.url' resource");
+            }
+            BASE_URL = Resources.toString(url, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load help.url resource", e);
         }
-        BASE_URL = String.format("https://www.elastic.co/guide/en/logstash/%s/", versionAnchor);
     }
 
     public HelpUrl(final String page) {


### PR DESCRIPTION
## Release notes

 - fixed an issue where a diagnosis in the health report on Logstash 9.0.0 points to future-facing documentation (`master`) instead of the docs that are specific to 9.0 (`9.0`)

## What does this PR do?

 - determines the help URL base at compile-time based on a few factors:
   - snapshot builds for unreleased branches:
     - 9.x points to `master`
     - others point to `${majorVersion}.x`
   - others point to `${majorVersion}.${minorVersion}`

## Why is it important/What is the impact to the user?

When running Logstash 9.0, this makes the `help_url`-s in diagnostics correctly point to 9.0-specific guidance, instead of pointing to forward-facing guidance from the bleeding edge of `main`/`master`.

As of the time of this writing, the two are the same; but as new things are added to `main`, they will eventually diverge. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

The procedure is the same in several configurations

1. start a pipeline that will block
   ~~~
   bin/logstash -e 'input { generator { } } filter { ruby { code => "sleep 1" } } output { sink { } }'
   ~~~
2. watch the health report for ~1 minute until the status degrades:
   ~~~
   watch curl --silent 'localhost:9600/_health_report?pretty=true'
   ~~~

### Configurations:

 - snapshots:
   - unrelased main:
     - ensure versions.yml is unmodified: `git checkout -- versions.yml`
     - build logstash `./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/master/`
   - unreleased 8.19
     - emulate versions: `yq -i '(.logstash, ."logstash-core") = "8.19.0"' versions.yml` 
     - build logstash `./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/8.x/`
   - 9.0 branch
     - emulate versions: `yq -i '(.logstash, ."logstash-core") = "9.0.1"' versions.yml`
     - build logstash `./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/9.0/`
 - releases:
   - main (suppose 9.1 release):
     - emulate versions: `yq -i '(.logstash, ."logstash-core") = "9.1.0"' versions.yml` 
     - build logstash `RELEASE=1 ./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/9.1/`
   - unreleased 8.19
     - emulate versions: `yq -i '(.logstash, ."logstash-core") = "8.19.0"' versions.yml` 
     - build logstash `RELEASE=1 ./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/8.19/`
   - 9.0 branch
     - emulate versions: `yq -i '(.logstash, ."logstash-core") = "9.0.1"' versions.yml`
     - build logstash `RELEASE=1 ./gradlew installDefaultGems --info | grep HelpUrl`
     - run test
     - expect url to begin with `https://www.elastic.co/guide/en/logstash/9.0/`

