### PR TITLE
Use dedicated elasticsearch image for observabilitySRE smoke testing

### DIFF
--- a/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
+++ b/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-fips:8.19.0-SNAPSHOT
+    image: docker.elastic.co/cloud-release/elasticsearch-cloud-ess-fips:8.19.0-SNAPSHOT
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=true

--- a/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
+++ b/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=/usr/share/elasticsearch/config/certs/ca.crt
     ports:
       - "9200:9200"
-    entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
-    command: ["eswrapper"]
     volumes:
       - ./certs:/usr/share/elasticsearch/config/certs
     networks:

--- a/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
+++ b/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=/usr/share/elasticsearch/config/certs/ca.crt
     ports:
       - "9200:9200"
+    entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
+    command: ["eswrapper"]
     volumes:
       - ./certs:/usr/share/elasticsearch/config/certs
     networks:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The ES team has started publishing a purpose built image for the fedramp high project. Update our smoke test stack to use this container.

## Why is it important/What is the impact to the user?

N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

