### PR TITLE
[chore] update ID format of release notes tool

### DIFF
--- a/tools/release/generate_release_notes_md.rb
+++ b/tools/release/generate_release_notes_md.rb
@@ -37,17 +37,16 @@ report = []
 `git checkout #{release_branch}`
 
 current_release = YAML.load(IO.read("versions.yml"))["logstash"]
-current_release_no_dot = current_release.tr(".", "")
 
 release_notes = IO.read(RELEASE_NOTES_PATH).split("\n")
 
-coming_tag_index = release_notes.find_index {|line| line.match(/^## #{current_release} \[logstash-#{current_release_no_dot}-release-notes\]$/) }
+coming_tag_index = release_notes.find_index {|line| line.match(/^## #{current_release} \[logstash-#{current_release}-release-notes\]$/) }
 coming_tag_index += 1 if coming_tag_index
 release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/\[logstash-\d+-release-notes\]$/) }
 
 unless coming_tag_index
-  report << "## #{current_release} [logstash-#{current_release_no_dot}-release-notes]\n\n"
-  report << "### Features and enhancements [logstash-#{current_release_no_dot}-features-enhancements]\n"
+  report << "## #{current_release} [logstash-#{current_release}-release-notes]\n\n"
+  report << "### Features and enhancements [logstash-#{current_release}-features-enhancements]\n"
 end
 
 plugin_changes = {}
@@ -87,7 +86,7 @@ report << "Changed plugin versions:"
 plugin_changes.each {|p, v| report << "#{p}: #{v.first} -> #{v.last}" }
 report << "---------- GENERATED CONTENT ENDS HERE ------------\n"
 
-report << "### Plugins [logstash-plugin-#{current_release_no_dot}-changes]\n"
+report << "### Plugins [logstash-plugin-#{current_release}-changes]\n"
 
 plugin_changes.each do |plugin, versions|
   _, type, name = plugin.split("-")


### PR DESCRIPTION
The new release procedure requires the ID format of release version as `-9.0.1-` instead of `-901-`.
This commit updates release note generation tool.

Relates: https://github.com/elastic/docs-content/issues/1152