### PR TITLE
[docs] Update `stack-version` to 9.0.1

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -12,7 +12,10 @@ toc:
   - toc: release-notes
   - toc: extend
 subs:
-  version: "9.0.0"
+  # Do NOT change `stack-version` substitution key.
+  # This may eventually be replaced with a site-wide strategy.
+  # Refer to https://github.com/elastic/docs-builder/issues/737.
+  stack-version: "9.0.1"
   logstash-ref:   "https://www.elastic.co/guide/en/logstash/current"
   ecloud:   "Elastic Cloud"
   esf:   "Elastic Serverless Forwarder"
@@ -42,7 +45,6 @@ subs:
   ilm-init:   "ILM"
   dlm:   "data lifecycle management"
   dlm-init:   "DLM"
-  stack-version: "9.0.0"
   major-version: "9.x"
   docker-repo: "docker.elastic.co/logstash/logstash"
   ess-leadin-short:   "Our hosted Elasticsearch Service is available on AWS, GCP, and Azure, and you can try it for free at https://cloud.elastic.co/registration"

--- a/docs/extend/codec-new-plugin.md
+++ b/docs/extend/codec-new-plugin.md
@@ -491,10 +491,10 @@ You should test install your plugin into a clean installation of Logstash. Downl
 
 1. Untar and cd in to the directory:
 
-    ```sh
-    curl -O https://download.elastic.co/logstash/logstash/logstash-9.0.0.tar.gz
-    tar xzvf logstash-9.0.0.tar.gz
-    cd logstash-9.0.0
+    ```sh subs=true
+    curl -O https://download.elastic.co/logstash/logstash/logstash-{{stack-version}}.tar.gz
+    tar xzvf logstash-{{stack-version}}.tar.gz
+    cd logstash-{{stack-version}}
     ```
 
 2. Using the plugin tool, we can install the gem we just built.

--- a/docs/extend/filter-new-plugin.md
+++ b/docs/extend/filter-new-plugin.md
@@ -492,10 +492,10 @@ You should test install your plugin into a clean installation of Logstash. Downl
 
 1. Untar and cd in to the directory:
 
-    ```sh
-    curl -O https://download.elastic.co/logstash/logstash/logstash-9.0.0.tar.gz
-    tar xzvf logstash-9.0.0.tar.gz
-    cd logstash-9.0.0
+    ```sh subs=true
+    curl -O https://download.elastic.co/logstash/logstash/logstash-{{stack-version}}.tar.gz
+    tar xzvf logstash-{{stack-version}}.tar.gz
+    cd logstash-{{stack-version}}
     ```
 
 2. Using the plugin tool, we can install the gem we just built.

--- a/docs/extend/input-new-plugin.md
+++ b/docs/extend/input-new-plugin.md
@@ -532,10 +532,10 @@ You should test install your plugin into a clean installation of Logstash. Downl
 
 1. Untar and cd in to the directory:
 
-    ```sh
-    curl -O https://download.elastic.co/logstash/logstash/logstash-9.0.0.tar.gz
-    tar xzvf logstash-9.0.0.tar.gz
-    cd logstash-9.0.0
+    ```sh subs=true
+    curl -O https://download.elastic.co/logstash/logstash/logstash-{{stack-version}}.tar.gz
+    tar xzvf logstash-{{stack-version}}.tar.gz
+    cd logstash-{{stack-version}}
     ```
 
 2. Using the plugin tool, we can install the gem we just built.

--- a/docs/extend/output-new-plugin.md
+++ b/docs/extend/output-new-plugin.md
@@ -449,10 +449,10 @@ You should test install your plugin into a clean installation of Logstash. Downl
 
 1. Untar and cd in to the directory:
 
-    ```sh
-    curl -O https://download.elastic.co/logstash/logstash/logstash-9.0.0.tar.gz
-    tar xzvf logstash-9.0.0.tar.gz
-    cd logstash-9.0.0
+    ```sh subs=true
+    curl -O https://download.elastic.co/logstash/logstash/logstash-{{stack-version}}.tar.gz
+    tar xzvf logstash-{{stack-version}}.tar.gz
+    cd logstash-{{stack-version}}
     ```
 
 2. Using the plugin tool, we can install the gem we just built.

--- a/docs/reference/docker-config.md
+++ b/docs/reference/docker-config.md
@@ -13,8 +13,8 @@ It is essential to place your pipeline configuration where it can be found by Lo
 
 In this example we use a bind-mounted volume to provide the configuration via the `docker run` command:
 
-```sh
-docker run --rm -it -v ~/pipeline/:/usr/share/logstash/pipeline/ docker.elastic.co/logstash/logstash:9.0.0
+```sh subs=true
+docker run --rm -it -v ~/pipeline/:/usr/share/logstash/pipeline/ docker.elastic.co/logstash/logstash:{{stack-version}}
 ```
 
 Every file in the host directory `~/pipeline/` will then be parsed by Logstash as pipeline configuration.
@@ -43,14 +43,14 @@ Settings files can also be provided through bind-mounts. Logstash expects to fin
 
 It’s possible to provide an entire directory containing all needed files:
 
-```sh
-docker run --rm -it -v ~/settings/:/usr/share/logstash/config/ docker.elastic.co/logstash/logstash:9.0.0
+```sh subs=true
+docker run --rm -it -v ~/settings/:/usr/share/logstash/config/ docker.elastic.co/logstash/logstash:{{stack-version}}
 ```
 
 Alternatively, a single file can be mounted:
 
-```sh
-docker run --rm -it -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml docker.elastic.co/logstash/logstash:9.0.0
+```sh subs=true
+docker run --rm -it -v ~/settings/logstash.yml:/usr/share/logstash/config/logstash.yml docker.elastic.co/logstash/logstash:{{stack-version}}
 ```
 
 ::::{note}
@@ -63,8 +63,8 @@ Bind-mounted configuration files will retain the same permissions and ownership 
 
 Bind-mounted configuration is not the only option, naturally. If you prefer the *Immutable Infrastructure* approach, you can prepare a custom image containing your configuration by using a `Dockerfile` like this one:
 
-```dockerfile
-FROM docker.elastic.co/logstash/logstash:9.0.0
+```dockerfile subs=true
+FROM docker.elastic.co/logstash/logstash:{{stack-version}}
 RUN rm -f /usr/share/logstash/pipeline/logstash.conf
 COPY pipeline/ /usr/share/logstash/pipeline/
 COPY config/ /usr/share/logstash/config/

--- a/docs/reference/first-event.md
+++ b/docs/reference/first-event.md
@@ -15,15 +15,15 @@ To test your Logstash installation, run the most basic Logstash pipeline.
 
 **MacOS, Linux**
 
-```sh
-cd logstash-9.0.0
+```sh subs=true
+cd logstash-{{stack-version}}
 bin/logstash -e 'input { stdin { } } output { stdout {} }'
 ```
 
 **Windows**
 
-```sh
-cd logstash-9.0.0
+```sh subs=true
+cd logstash-{{stack-version}}
 .\bin\logstash.bat -e "input { stdin { } } output { stdout {} }"
 ```
 
@@ -37,16 +37,16 @@ The location of the `bin` directory varies by platform. See [Directory layout](/
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of {{stack-version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{stack-version}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{stack-version}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).

--- a/docs/reference/offline-plugins.md
+++ b/docs/reference/offline-plugins.md
@@ -25,7 +25,7 @@ To build an offline plugin pack:
 
     where:
 
-    * `OUTPUT` specifies the zip file where the compressed plugin pack will be written. The default file is `/LOGSTASH_HOME/logstash-offline-plugins-9.0.0.zip`. If you are using 5.2.x and 5.3.0, this location should be a zip file whose contents will be overwritten.
+    * `OUTPUT` specifies the zip file where the compressed plugin pack will be written. The default file is _/LOGSTASH_HOME/logstash-offline-plugins-{{stack-version}}.zip_. If you are using 5.2.x and 5.3.0, this location should be a zip file whose contents will be overwritten.
     * `[PLUGINS]` specifies one or more plugins that you want to include in the pack.
     * `--overwrite` specifies if you want to override an existing file at the location
 
@@ -56,12 +56,12 @@ To install an offline plugin pack:
 1. Move the compressed bundle to the machine where you want to install the plugins.
 2. Run the `bin/logstash-plugin install` subcommand and pass in the file URI of the offline plugin pack.
 
-    ```sh
-    bin/logstash-plugin install file:///c:/path/to/logstash-offline-plugins-9.0.0.zip
+    ```sh subs=true
+    bin/logstash-plugin install file:///c:/path/to/logstash-offline-plugins-{{stack-version}}.zip
     ```
 
-    ```sh
-    bin/logstash-plugin install file:///path/to/logstash-offline-plugins-9.0.0.zip
+    ```sh subs=true
+    bin/logstash-plugin install file:///path/to/logstash-offline-plugins-{{stack-version}}.zip
     ```
 
     This command expects a file URI, so make sure you use forward slashes and specify the full path to the pack.

--- a/docs/reference/running-logstash-command-line.md
+++ b/docs/reference/running-logstash-command-line.md
@@ -8,16 +8,16 @@ mapped_pages:
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of the {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of the {{stack-version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{stack-version}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{stack-version}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).

--- a/docs/reference/running-logstash-windows.md
+++ b/docs/reference/running-logstash-windows.md
@@ -67,7 +67,7 @@ After installing a [supported JVM](https://www.elastic.co/support/matrix#matrix_
 Once you have [*Setting Up and Running Logstash*](/reference/setting-up-running-logstash.md) and validated JVM pre-requisites, you may proceed.
 
 ::::{note}
-For the examples listed below, we are running Windows Server 2016, Java 11.0.3, have extracted the [Logstash ZIP package](https://www.elastic.co/downloads/logstash) to `C:\logstash-9.0.0\`, and using the example `syslog.conf` file shown below (stored in `C:\logstash-9.0.0\config\`).
+For the examples listed below, we are running Windows Server 2016, Java 11.0.3, have extracted the [Logstash ZIP package](https://www.elastic.co/downloads/logstash) to _C:\logstash-{{stack-version}}\\_, and using the example `syslog.conf` file shown below (stored in _C:\logstash-{{stack-version}}\config\\_).
 ::::
 
 
@@ -77,9 +77,9 @@ For the examples listed below, we are running Windows Server 2016, Java 11.0.3, 
 
 Logstash can be run manually using [PowerShell](https://docs.microsoft.com/en-us/powershell/).  Open an Administrative [PowerShell](https://docs.microsoft.com/en-us/powershell/) session, then run the following commands:
 
-```sh
-PS C:\Windows\system32> cd C:\logstash-9.0.0\
-PS C:\logstash-9.0.0> .\bin\logstash.bat -f .\config\syslog.conf
+```sh subs=true
+PS C:\Windows\system32> cd C:\logstash-{{stack-version}}\
+PS C:\logstash-{{stack-version}}> .\bin\logstash.bat -f .\config\syslog.conf
 ```
 
 ::::{note}
@@ -89,8 +89,8 @@ In a production environment, we recommend that you use [logstash.yml](/reference
 
 Wait for the following messages to appear, to confirm Logstash has started successfully:
 
-```sh
-[logstash.runner          ] Starting Logstash {"logstash.version"=>"9.0.0"}
+```sh subs=true
+[logstash.runner          ] Starting Logstash {"logstash.version"=>"{{stack-version}}"}
 [logstash.inputs.udp      ] Starting UDP listener {:address=>"0.0.0.0:514"}
 [logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
 ```
@@ -103,20 +103,20 @@ It is recommended to validate your configuration works by running Logstash manua
 ::::
 
 
-Download [NSSM](https://nssm.cc/), then extract `nssm.exe` from `nssm-<version.number>\win64\nssm.exe` to `C:\logstash-9.0.0\bin\`. Then open an Administrative [PowerShell](https://docs.microsoft.com/en-us/powershell/) session, then run the following commands:
+Download [NSSM](https://nssm.cc/), then extract `nssm.exe` from `nssm-<version.number>\win64\nssm.exe` to _C:\logstash-{{stack-version}}\bin\\_. Then open an Administrative [PowerShell](https://docs.microsoft.com/en-us/powershell/) session, then run the following commands:
 
-```sh
-PS C:\Windows\system32> cd C:\logstash-9.0.0\
-PS C:\logstash-9.0.0> .\bin\nssm.exe install logstash
+```sh subs=true
+PS C:\Windows\system32> cd C:\logstash-{{stack-version}}\
+PS C:\logstash-{{stack-version}}> .\bin\nssm.exe install logstash
 ```
 
 Once the `NSSM service installer` window appears, specify the following parameters in the `Application` tab:
 
 * In the `Application` tab:
 
-    * Path: Path to `logstash.bat`: `C:\logstash-9.0.0\bin\logstash.bat`
-    * Startup Directory: Path to the `bin` directory: `C:\logstash-9.0.0\bin`
-    * Arguments: For this example to start Logstash: `-f C:\logstash-9.0.0\config\syslog.conf`
+    * Path: Path to `logstash.bat`: _C:\logstash-{{stack-version}}\bin\logstash.bat_
+    * Startup Directory: Path to the `bin` directory: _C:\logstash-{{stack-version}}\bin_
+    * Arguments: For this example to start Logstash: _-f C:\logstash-{{stack-version}}\config\syslog.conf_
 
         ::::{note}
         In a production environment, we recommend that you use [logstash.yml](/reference/logstash-settings-file.md) to control Logstash execution.
@@ -156,9 +156,9 @@ Open the Windows [Task Scheduler](https://docs.microsoft.com/en-us/windows/deskt
 
     * Click `New`, then specify the following:
     * Action: `Start a program`
-    * Program/script: `C:\logstash-9.0.0\bin\logstash.bat`
-    * Add arguments: `-f C:\logstash-9.0.0\config\syslog.conf`
-    * Start in: `C:\logstash-9.0.0\bin\`
+    * Program/script: _C:\logstash-{{stack-version}}\bin\logstash.bat_
+    * Add arguments: _-f C:\logstash-{{stack-version}}\config\syslog.conf_
+    * Start in: _C:\logstash-{{stack-version}}\bin\\_
 
         ::::{note}
         In a production environment, we recommend that you use [logstash.yml](/reference/logstash-settings-file.md) to control Logstash execution.

--- a/docs/reference/working-with-plugins.md
+++ b/docs/reference/working-with-plugins.md
@@ -8,16 +8,16 @@ mapped_pages:
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of the {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}}, you need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of the {{stack-version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}}, you need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{stack-version}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{stack-version}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).


### PR DESCRIPTION
This is a temporary solution until we have a solution for https://github.com/elastic/docs-builder/issues/737. I used the substitution key `stack-version` so we can easily search and replace across repos until there's a permanent, centralized solution. 