### PR TITLE
security advisory message added to 8.18.1 release notes

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -90,7 +90,8 @@ This section summarizes the changes in the following releases:
 
 [IMPORTANT]
 ====
-The 8.18.1 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+The 8.18.1 release contains fixes for potential security vulnerabilities.
+Check out the https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for details.
 ====
 
 * Enhanced keystore validation to prevent the creation of secrets that fail format parsing https://github.com/elastic/logstash/pull/17351[#17351]
@@ -172,10 +173,8 @@ The 8.18.1 release contains fixes for potential security vulnerabilities. See ou
 
 [IMPORTANT]
 ====
-The 8.17.6 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
-====
-
-No user-facing changes in Logstash.
+The 8.17.6 release contains fixes for potential security vulnerabilities.
+Check out the https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for details.
 
 [[dependencies-8.17.6]]
 ==== Updates to dependencies

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -175,6 +175,7 @@ Check out the https://discuss.elastic.co/c/announcements/security-announcements/
 ====
 The 8.17.6 release contains fixes for potential security vulnerabilities.
 Check out the https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for details.
+====
 
 [[dependencies-8.17.6]]
 ==== Updates to dependencies

--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -88,6 +88,11 @@ This section summarizes the changes in the following releases:
 [[logstash-8-18-1]]
 === Logstash 8.18.1 Release Notes
 
+[IMPORTANT]
+====
+The 8.18.1 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
+
 * Enhanced keystore validation to prevent the creation of secrets that fail format parsing https://github.com/elastic/logstash/pull/17351[#17351]
 
 [[dependencies-8.18.1]]
@@ -164,6 +169,11 @@ This section summarizes the changes in the following releases:
 
 [[logstash-8-17-6]]
 === Logstash 8.17.6 Release Notes
+
+[IMPORTANT]
+====
+The 8.17.6 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
 
 No user-facing changes in Logstash.
 


### PR DESCRIPTION
Release notes updated.
@karenzone : In this case I've added the message in the release notes asciidoc file for both 8.18.1 and 8.17.6, as the file include both.

Let me know if this is correct. Thanks!