### PR TITLE
release notes 9.0.1 updated with security advisor

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -24,7 +24,8 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ## 9.0.1 [logstash-9.0.1-release-notes]
 
 ::::{important}
-The 9.0.1 release contains fixes for potential security vulnerabilities. See our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+The 9.0.1 release contains fixes for potential security vulnerabilities. 
+Check out the [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for details.
 ::::
 
 ### Features and enhancements [logstash-9.0.1-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -23,6 +23,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.0.1 [logstash-9.0.1-release-notes]
 
+::::{important}
+The 9.0.1 release contains fixes for potential security vulnerabilities. See our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+::::
+
 ### Features and enhancements [logstash-9.0.1-features-enhancements]
 
 * Enhanced keystore validation to prevent the creation of secrets in an invalid format [#17351](https://github.com/elastic/logstash/pull/17351)


### PR DESCRIPTION
Release notes for 9.0.1 updated to main branch.

@karenzone : I'm not totally sure if this is the right branch for this release notes in docs V3, and how to publish this after the change is made.
