### PR TITLE
Fix typo in Logstash docs

### DIFF
--- a/docs/reference/using-logstash-with-elastic-integrations.md
+++ b/docs/reference/using-logstash-with-elastic-integrations.md
@@ -82,6 +82,6 @@ output { <3>
 Elastic {{integrations}} are designed to work with [data streams](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-data-streams) and [ECS-compatible](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#_compatibility_with_the_elastic_common_schema_ecs) output. Be sure that these features are enabled in the [`output-elasticsearch`](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md) plugin.
 
 * Set [`data-stream`](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-data_stream) to `true`.<br> (Check out [Data streams](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-data-streams) for additional data streams settings.)
-* Set [`ecs-compatibility`](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-ecs_compatibility) to `v1` or `v8`.
+* Set [`ecs_compatibility`](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-ecs_compatibility) to `v1` or `v8`.
 
 Check out the [`output-elasticsearch` plugin](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md) docs for additional settings.


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

This PR fixes a typo in https://www.elastic.co/docs/reference/logstash/using-logstash-with-elastic-integrations

## Related issues

- Closes [#1395](https://github.com/elastic/docs-content/issues/1395)