### PR TITLE
[8.17] update jruby-openssl to 0.15.4

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.4.2'
   gem.add_runtime_dependency 'ruby-maven-libs', '~> 3', '>= 3.8.9'
   gem.add_runtime_dependency "jar-dependencies",'= 0.4.1' # Pin to `0.4.1` until https://github.com/jruby/jruby/issues/7262 is resolved
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.15.4"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION
backport of https://github.com/elastic/logstash/pull/17646