### PR TITLE
Added missed 9.current definition in CI releases inventory

### DIFF
--- a/ci/logstash_releases.json
+++ b/ci/logstash_releases.json
@@ -2,7 +2,8 @@
   "releases": {
     "7.current": "7.17.28",
     "8.previous": "8.17.6",
-    "8.current": "8.18.1"
+    "8.current": "8.18.1",
+    "9.current": "9.0.1"
   },
   "snapshots": {
     "7.current": "7.17.29-SNAPSHOT",


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?

Adds definition for `9.current` in CI inventory.