### PR TITLE
Increment logstash patch version for 7.19

### DIFF
--- a/Gemfile.jruby-2.5.lock.release
+++ b/Gemfile.jruby-2.5.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 7.17.29)
+      logstash-core (= 7.17.30)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (7.17.29-java)
+    logstash-core (7.17.30-java)
       chronic_duration (~> 0.10)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 7.17.29
-logstash-core: 7.17.29
+logstash: 7.17.30
+logstash-core: 7.17.30
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
Do not merge until 7.17.29 is released