### PR TITLE
Add lockfile for newly created 9.1 branch

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -1,0 +1,986 @@
+PATH
+  remote: logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 9.1.0)
+
+PATH
+  remote: logstash-core
+  specs:
+    logstash-core (9.1.0-java)
+      clamp (~> 1)
+      concurrent-ruby (~> 1, < 1.1.10)
+      down (~> 5.2.0)
+      elasticsearch (~> 8)
+      filesize (~> 0.2)
+      gems (~> 1)
+      i18n (~> 1)
+      jrjackson (= 0.4.20)
+      manticore (~> 0.6)
+      minitar (~> 1)
+      pry (~> 0.12)
+      puma (~> 6.3, >= 6.4.2)
+      rack (~> 3)
+      rubyzip (~> 1)
+      sinatra (~> 4)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.6)
+      thwait
+      treetop (~> 1)
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    amazing_print (1.8.1)
+    arr-pm (0.0.12)
+    ast (2.4.3)
+    atomic (1.1.101-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    avro (1.10.2)
+      multi_json (~> 1)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1120.0)
+    aws-sdk-cloudfront (1.119.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-cloudwatch (1.116.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-core (3.226.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.105.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-resourcegroups (1.83.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.191.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sns (1.100.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.96.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    back_pressure (1.0.0)
+    backports (3.25.1)
+    base64 (0.3.0)
+    belzebuth (0.2.3)
+      childprocess
+    benchmark-ips (2.14.0)
+    bigdecimal (3.2.2-java)
+    bindata (2.5.1)
+    buftok (0.2.0)
+    builder (3.3.0)
+    cabin (0.9.0)
+    childprocess (4.1.0)
+    ci_reporter (2.1.0)
+      builder (>= 2.1.2)
+      rexml
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (1.3.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    dalli (3.2.8)
+    date (3.3.3-java)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    domain_name (0.6.20240107)
+    dotenv (3.1.8)
+    down (5.2.4)
+      addressable (~> 2.8)
+    e2mmap (0.1.0)
+    edn (1.1.1)
+    elastic-transport (8.4.0)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.18.0)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.18.0)
+    elasticsearch-api (8.18.0)
+      multi_json
+    equalizer (0.0.11)
+    et-orbi (1.2.11)
+      tzinfo
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    ffi (1.17.2-java)
+    filesize (0.2.0)
+    fileutils (1.7.3)
+    fivemat (1.3.7)
+    flores (0.0.8)
+    fpm (1.16.0)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (>= 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
+    gelfd2 (0.4.1)
+    gem_publisher (1.5.0)
+    gems (1.3.0)
+    gene_pool (1.5.0)
+      concurrent-ruby (>= 1.0)
+    hashdiff (1.2.0)
+    hitimes (1.3.1-java)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0-java)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    insist (1.0.0)
+    jar-dependencies (0.5.5)
+    jls-grok (0.11.5)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.6.2)
+    jrjackson (0.4.20-java)
+    jruby-jms (1.3.0-java)
+      gene_pool
+      semantic_logger
+    jruby-openssl (0.15.4-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (2.12.2-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    logstash-codec-avro (3.4.1-java)
+      avro (~> 1.10.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-cef (6.2.8-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-collectd (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.1.0)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-edn_lines (3.1.0)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-es_bulk (3.1.0)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-fluent (3.4.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-json (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-json_lines (3.2.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-line (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-msgpack (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.1.2)
+      concurrent-ruby
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-patterns-core
+    logstash-codec-netflow (4.3.2)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-plain (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-rubydebug (3.1.0)
+      amazing_print (~> 1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (2.6.2-java)
+      fivemat
+      gem_publisher
+      kramdown (~> 2)
+      logstash-codec-plain
+      logstash-core (>= 6.3)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.10.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-cidr (3.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (4.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-csv (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-date (3.1.15)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.2.5)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elastic_integration (9.0.0-java)
+      logstash-core (>= 8.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (4.2.0)
+      elasticsearch (>= 7.14.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+    logstash-filter-fingerprint (3.4.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-geoip (7.3.1-java)
+      logstash-core (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.3)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-patterns-core (>= 4.3.0, < 5)
+      stud (~> 0.0.22)
+    logstash-filter-http (2.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-json (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-kv (4.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-memcached (1.2.0)
+      dalli (~> 3)
+      logstash-core-plugin-api (~> 2.0)
+    logstash-filter-metrics (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.5.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-prune (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-sleep (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.4.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      psych (>= 5.1.0)
+    logstash-filter-truncate (1.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.3.5-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-uuid (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.3.1)
+      logstash-core (>= 8.15.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri (>= 1.18.8)
+      xml-simple
+    logstash-input-azure_event_hubs (1.5.1)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      stud (>= 0.0.22)
+    logstash-input-beats (7.0.2-java)
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.6)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (2.0.1)
+      logstash-codec-plain
+      logstash-core (>= 8.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elastic_serverless_forwarder (2.0.0-java)
+      logstash-codec-json_lines
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-http (>= 3.7.2)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-plugin_factory_support
+    logstash-input-elasticsearch (5.2.0)
+      elasticsearch (>= 7.17.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+      tzinfo
+      tzinfo-data
+    logstash-input-exec (3.6.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-scheduler (~> 1.0)
+      stud (~> 0.0.22)
+    logstash-input-file (4.4.6)
+      addressable
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-ganglia (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.3.2)
+      gelfd2 (= 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-generator (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-graphite (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-event_support (~> 1.0)
+      stud
+    logstash-input-http (4.1.2-java)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+    logstash-input-http_poller (6.0.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-input-jms (3.3.0-java)
+      jruby-jms (>= 1.2.0)
+      logstash-codec-json (~> 3.0)
+      logstash-codec-plain (~> 3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      semantic_logger (< 4.0.0)
+    logstash-input-pipe (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      stud (~> 0.0.22)
+    logstash-input-redis (3.7.1)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (>= 4.0.1, < 5)
+    logstash-input-stdin (3.4.0)
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-syslog (3.7.1)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok (>= 4.4.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-tcp (7.0.2-java)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-twitter (4.1.1)
+      http-form_data (~> 2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      public_suffix (> 4, < 6)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 6.2.0)
+    logstash-input-udp (3.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.1.2)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-integration-aws (7.2.1-java)
+      aws-sdk-cloudfront
+      aws-sdk-cloudwatch
+      aws-sdk-core (~> 3)
+      aws-sdk-resourcegroups
+      aws-sdk-s3
+      aws-sdk-sns
+      aws-sdk-sqs
+      concurrent-ruby
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      rexml
+      rufus-scheduler (>= 3.0.9)
+      stud (~> 0.0.22)
+    logstash-integration-jdbc (5.6.0)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      lru_redux
+      sequel (>= 5.74.0)
+      tzinfo
+      tzinfo-data
+    logstash-integration-kafka (11.6.3-java)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core (>= 8.3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-logstash (1.0.4-java)
+      logstash-codec-json_lines (~> 3.1)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-input-http (>= 3.7.0)
+      logstash-mixin-http_client (~> 7.3)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.1)
+      stud
+    logstash-integration-rabbitmq (7.4.0-java)
+      back_pressure (~> 1.0)
+      logstash-codec-json
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      march_hare (~> 4.0)
+      stud (~> 0.0.22)
+    logstash-integration-snmp (4.0.6-java)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-mixin-ca_trusted_fingerprint_support (1.0.1-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-deprecation_logger_support (1.0.0-java)
+      logstash-core (>= 5.0.0)
+    logstash-mixin-ecs_compatibility_support (1.3.0-java)
+      logstash-core (>= 6.0.0)
+    logstash-mixin-event_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-mixin-http_client (7.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+    logstash-mixin-normalize_config_support (1.0.0-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-plugin_factory_support (1.0.0-java)
+      logstash-core (>= 7.13.0)
+    logstash-mixin-scheduler (1.0.1-java)
+      logstash-core (>= 7.16)
+      rufus-scheduler (>= 3.0.9)
+    logstash-mixin-validator_support (1.1.1-java)
+      logstash-core (>= 6.8)
+    logstash-output-csv (3.0.10)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-output-file
+    logstash-output-elasticsearch (12.0.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.8)
+      mustache (>= 0.99.8)
+    logstash-output-file (4.3.0)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (6.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+    logstash-output-lumberjack (3.1.9)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-redis (5.2.0)
+      logstash-core (>= 6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 4)
+      stud
+    logstash-output-stdout (3.1.4)
+      logstash-codec-rubydebug
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (7.0.1)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.2.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      webhdfs
+    logstash-patterns-core (4.3.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    manticore (0.9.1-java)
+      openssl_pkcs8_pure
+    march_hare (4.7.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (1.1.0)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mini_mime (1.1.5)
+    minitar (1.0.2)
+    msgpack (1.8.0-java)
+    multi_json (1.15.0)
+    multipart-post (2.4.1)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    naught (1.1.0)
+    net-http (0.6.0)
+      uri
+    net-imap (0.5.9)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.4-java)
+    nokogiri (1.18.8-java)
+      racc (~> 1.4)
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    openssl_pkcs8_pure (0.0.0.2)
+    paquet (0.2.1)
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.15.2-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    psych (5.2.6-java)
+      date
+      jar-dependencies (>= 0.1.7)
+    public_suffix (5.1.1)
+    puma (6.6.0-java)
+      nio4r (~> 2.0)
+    raabro (1.4.0)
+    racc (1.8.1-java)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    redis (4.8.1)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rspec-wait (1.0.1)
+      rspec (>= 3.4)
+    rubocop (1.74.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.42.0)
+      parser (>= 3.3.7.2)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (1.3.0)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    semantic_logger (3.4.1)
+      concurrent-ruby (~> 1.0)
+    sequel (5.93.0)
+      bigdecimal
+    simple_oauth (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov-json (0.2.3)
+      json
+      simplecov
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.6.0)
+    timeout (0.4.3)
+    treetop (1.6.14)
+      polyglot (~> 0.3)
+    twitter (6.2.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.3)
+    webhdfs (0.11.0)
+      addressable
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.9)
+      rexml
+
+PLATFORMS
+  java
+  universal-java-21
+
+DEPENDENCIES
+  belzebuth
+  benchmark-ips
+  bigdecimal (~> 3.1)
+  childprocess (~> 4)
+  ci_reporter_rspec (~> 1)
+  date (= 3.3.3)
+  fileutils (~> 1.7)
+  flores (~> 0.0.8)
+  fpm (~> 1, >= 1.14.1)
+  gems (~> 1)
+  json-schema (~> 2)
+  logstash-codec-avro
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (~> 2.6.0)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elastic_integration
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-http
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-memcached
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-prune
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-azure_event_hubs
+  logstash-input-beats
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elastic_serverless_forwarder
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-jms
+  logstash-input-pipe
+  logstash-input-redis
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-integration-aws
+  logstash-integration-jdbc
+  logstash-integration-kafka
+  logstash-integration-logstash
+  logstash-integration-rabbitmq
+  logstash-integration-snmp
+  logstash-output-csv
+  logstash-output-elasticsearch (>= 11.14.0)
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pipe
+  logstash-output-redis
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  minitar (~> 1)
+  murmurhash3 (= 0.1.6)
+  octokit (~> 4.25)
+  paquet (~> 0.2)
+  pleaserun (~> 0.0.28)
+  polyglot
+  rack-test
+  rake (~> 13)
+  rspec (~> 3.5)
+  rubocop
+  rubocop-ast (= 1.42.0)
+  ruby-progressbar (~> 1)
+  rubyzip (~> 1)
+  simplecov (~> 0.22.0)
+  simplecov-json
+  stud (~> 0.0.22)
+  thwait
+  treetop
+  webmock (~> 3)
+
+BUNDLED WITH
+   2.6.3


### PR DESCRIPTION
9.1 was cut from main and is now ready for managing the lockfile in source.

NOTE: this file was generated with:

```
git checkout upstream/8.19
./gradlew clean installDefaultGems
./vendor/jruby/bin/jruby -S bundle update --all --patch --strict
cp  Gemfile.lock Gemfile.jruby-3.1.lock.release
```