### PR TITLE
Bump to 9.2.0 for main

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 9.1.0
-logstash-core: 9.1.0
+logstash: 9.2.0
+logstash-core: 9.2.0
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
Having just cut a 9.1 branch, it is time to update main to the next minor

