### PR TITLE
Test PR to measure accuracy and performance of Event size computation

### DIFF
--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -86,7 +86,7 @@ tasks.register("jmh", JavaExec) {
   doFirst {
     args = [
             "-Djava.io.tmpdir=${buildDir.absolutePath}",
-            "-XX:+HeapDumpOnOutOfMemoryError", "-Xms2g", "-Xmx2g",
+            "-XX:+HeapDumpOnOutOfMemoryError", "-Xms8g", "-Xmx8g",
             shadowJar.archiveFile.get().asFile,
             include
     ]

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSizeEstimationBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/EventSizeEstimationBenchmark.java
@@ -1,0 +1,108 @@
+package org.logstash.benchmark;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.jruby.java.proxies.ConcreteJavaProxy;
+import org.logstash.Event;
+import org.logstash.RubyUtil;
+import org.logstash.Timestamp;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/*
+* ./gradlew jmh -Pinclude="org.logstash.benchmark.EventSizeEstimationBenchmark.*"
+* */
+
+@Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class EventSizeEstimationBenchmark {
+
+    // 512 bytes
+    public static final String MEDIUM_FILLING_STRING = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum Excepteur sint occaecat cupidatat non proident, sunt in culpa quioe";
+
+    //2048 bytes
+    public static final String LONG_FILLING_STRING = MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING;
+    private Event mediumEvent;
+    private Event longEvent;
+    private Event longEvent_1_nestingLevel;
+
+    @Setup(Level.Invocation)
+    public void setUp() {
+        mediumEvent = createNestedEvent(10, 5, MEDIUM_FILLING_STRING);
+        longEvent = createNestedEvent(10, 5, LONG_FILLING_STRING);
+        longEvent_1_nestingLevel = createNestedEvent(10, 1, LONG_FILLING_STRING);
+    }
+
+    @Benchmark
+    public final void deepConvertedMapNavigation(Blackhole blackhole) {
+        long size = mediumEvent.estimateMemory();
+        blackhole.consume(size);
+    }
+
+    @Benchmark
+    public final void cborSerializationEstimate(Blackhole blackhole) throws JsonProcessingException {
+        byte[] cborSerialized = mediumEvent.serialize();
+        blackhole.consume(cborSerialized);
+    }
+
+    @Benchmark
+    public final void deepConvertedMapNavigation_longValues_2KB(Blackhole blackhole) {
+        long size = longEvent.estimateMemory();
+        blackhole.consume(size);
+    }
+
+    @Benchmark
+    public final void cborSerializationEstimate_longValues_2KB(Blackhole blackhole) throws JsonProcessingException {
+        byte[] cborSerialized = longEvent.serialize();
+        blackhole.consume(cborSerialized);
+    }
+
+//    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Benchmark
+    public final void deepConvertedMapNavigation_longValues_2KB_noDeepNesting(Blackhole blackhole) {
+        long size = longEvent_1_nestingLevel.estimateMemory();
+        blackhole.consume(size);
+    }
+
+//    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Benchmark
+    public final void cborSerializationEstimate_longValues_2KB_noDeepNesting(Blackhole blackhole) throws JsonProcessingException {
+        byte[] cborSerialized = longEvent_1_nestingLevel.serialize();
+        blackhole.consume(cborSerialized);
+    }
+
+    private static Event createNestedEvent(int elementsPerLayer, int layer, String fillingString) {
+        double totalElements = Math.pow(elementsPerLayer, layer);
+        System.out.println("Total elements: " + totalElements);
+
+        // TODO fill with nested layers
+        Event event = new Event();
+        event.setField("timestamp", new ConcreteJavaProxy(RubyUtil.RUBY,
+                RubyUtil.RUBY_TIMESTAMP_CLASS, new Timestamp()
+        ));
+
+
+        Map<String, Object> map = createSubdocument(elementsPerLayer, layer, fillingString);
+        event.setField("custom_data", map);
+        return event;
+    }
+
+    private static Map<String, Object> createSubdocument(int elementsPerLayer, int layer, String fillingString) {
+        Map<String, Object> map = new HashMap<>(elementsPerLayer);
+        for (int i = 0; i < elementsPerLayer; i++) {
+            if (layer == 0) {
+                map.put(String.format("field_%d", i), fillingString);
+            } else {
+                map.put(String.format("field_%d", i), createSubdocument(elementsPerLayer, layer - 1, fillingString));
+            }
+        }
+        return map;
+    }
+}

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -145,9 +145,11 @@ javaTests.finalizedBy(jacocoTestReport)
 
 tasks.register("rubyTests", Test) {
     dependsOn compileTestJava
+    maxHeapSize = "8g"
     inputs.files fileTree("${projectDir}/lib")
     inputs.files fileTree("${projectDir}/spec")
     systemProperty 'logstash.root.dir', projectDir.parent
+    systemProperty 'jol.magicFieldOffset', true
     include '/org/logstash/RSpecTests.class'
     include '/org/logstash/config/ir/ConfigCompilerTest.class'
     include '/org/logstash/config/ir/CompiledPipelineTest.class'
@@ -159,6 +161,7 @@ tasks.register("rubyTests", Test) {
     include '/org/logstash/plugins/CounterMetricImplTest.class'
     include '/org/logstash/plugins/factory/PluginFactoryExtTest.class'
     include '/org/logstash/execution/ObservedExecutionTest.class'
+    include '/org/logstash/EventSizeCalculationTest.class'
 }
 
 test {
@@ -262,6 +265,7 @@ dependencies {
     testImplementation 'org.elasticsearch:securemock:1.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.openjdk.jol:jol-core:0.17'
 
     api group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
     api group: 'commons-codec', name: 'commons-codec', version: '1.17.0'

--- a/logstash-core/src/main/java/org/logstash/ConvertedMap.java
+++ b/logstash-core/src/main/java/org/logstash/ConvertedMap.java
@@ -21,14 +21,19 @@
 package org.logstash;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.jruby.RubyHash;
-import org.jruby.RubyString;
+
+import org.jruby.*;
+import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.ext.JrubyTimestampExtLibrary;
 
 /**
  * <p>This class is an internal API and behaves very different from a standard {@link Map}.</p>
@@ -156,5 +161,97 @@ public final class ConvertedMap extends IdentityHashMap<String, Object> {
      */
     private static String convertKey(final RubyString key) {
         return internStringForUseAsKey(key.asJavaString());
+    }
+
+    public long estimateMemory() {
+        return values().stream()
+                .map(this::estimateMemory)
+                .mapToLong(Long::longValue)
+                .sum();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private long estimateMemory(Object o) {
+        if (o instanceof Boolean) {
+            return 1;
+        }
+        if (o instanceof Byte) {
+            return Byte.SIZE;
+        }
+        if (o instanceof Short) {
+            return Short.SIZE;
+        }
+        if (o instanceof Integer) {
+            return Integer.SIZE;
+        }
+        if (o instanceof Long) {
+            return Long.SIZE;
+        }
+        if (o instanceof Float) {
+            return Float.SIZE;
+        }
+        if (o instanceof Double) {
+            return Double.SIZE;
+        }
+        if (o instanceof Character) {
+            return Character.SIZE;
+        }
+        if (o instanceof String) {
+            return ((String) o).getBytes().length;
+        }
+        if (o instanceof RubyString) {
+            return ((RubyString) o).getBytes().length;
+        }
+
+
+        if (o instanceof Collection) {
+            Collection c = (Collection) o;
+            long memory = 0L;
+            for (Object v : c) {
+                memory += estimateMemory(v);
+            }
+            return memory;
+        }
+
+        if (o instanceof ConvertedMap) {
+            ConvertedMap c = (ConvertedMap) o;
+            return c.estimateMemory();
+        }
+
+        if (o instanceof Map) {
+            // this case shouldn't happen because all Map are converted to ConvertedMap
+            Map<String, Object> m = (Map<String, Object>) o;
+            long memory = 0L;
+            for (Map.Entry e : m.entrySet()) {
+                memory += estimateMemory(e.getKey());
+                memory += estimateMemory(e.getValue());
+            }
+            return memory;
+        }
+        if (o instanceof JrubyTimestampExtLibrary.RubyTimestamp) {
+            // wraps an java.time.Instant which is made of long and int
+            return 8 + 4;
+        }
+        if (o instanceof BigInteger) {
+            return ((BigInteger) o).toByteArray().length;
+        }
+        if (o instanceof BigDecimal) {
+            // BigInteger has 4 fields, one reference 2 ints (scale and precision) and a long.
+            return 8 + 2 * 4 + 8;
+        }
+        if (o instanceof RubyBignum) {
+            RubyBignum rbn = (RubyBignum) o;
+            return ((RubyFixnum) rbn.size()).getLongValue();
+        }
+        if (o instanceof RubyBigDecimal) {
+            RubyBigDecimal rbd = (RubyBigDecimal) o;
+            // wraps a Java BigDecimal so we can return the size of that:
+            return estimateMemory(rbd.getValue());
+        }
+
+        // TODO primitive type arrays?
+        // TODO object arrays?
+
+        throw new RuntimeException("Unsupported type: " + o.getClass());
     }
 }

--- a/logstash-core/src/main/java/org/logstash/Event.java
+++ b/logstash-core/src/main/java/org/logstash/Event.java
@@ -567,4 +567,16 @@ public final class Event implements Cloneable, Queueable, co.elastic.logstash.ap
             return path.stream().collect(Collectors.joining("][", "[", "]"));
         }
     }
+
+    /**
+     * @return a byte size estimation of the event, based on the payloads carried by nested data structures,
+     * without considering the space needed by the JVM to represent the object itself.
+     *
+     * */
+    public long estimateMemory() {
+        long total = 0;
+        total += data.estimateMemory();
+        total += metadata.estimateMemory();
+        return total;
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/EventSizeCalculationTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventSizeCalculationTest.java
@@ -104,7 +104,7 @@ public final class EventSizeCalculationTest extends RubyTestBase {
     }
 
 
-    private Event createNestedEvent(int elementsPerLayer, int layer, String fillingString) {
+    private static Event createNestedEvent(int elementsPerLayer, int layer, String fillingString) {
         double totalElements = Math.pow(elementsPerLayer, layer);
         System.out.println("Total elements: " + totalElements);
 

--- a/logstash-core/src/test/java/org/logstash/EventSizeCalculationTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventSizeCalculationTest.java
@@ -1,0 +1,142 @@
+package org.logstash;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import org.jruby.java.proxies.ConcreteJavaProxy;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+* Run with: ./gradlew :logstash-core:rubyTests --tests "org.logstash.EventSizeCalculationTest.compareDeeplyNestedEventSizeComputation" -Dorg.gradle.jvmargs=-Xmx4g
+* */
+
+public final class EventSizeCalculationTest extends RubyTestBase {
+
+    public static final String SHORT_FILLING_STRING = "Test string";
+    // 512 bytes
+    public static final String MEDIUM_FILLING_STRING = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum Excepteur sint occaecat cupidatat non proident, sunt in culpa quioe";
+
+    //2048 bytes
+    public static final String LONG_FILLING_STRING = MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING + MEDIUM_FILLING_STRING;
+
+    private final static class EventAndSize {
+        final Event event;
+        final long size;
+
+        private EventAndSize(Event event, long size) {
+            this.event = event;
+            this.size = size;
+        }
+    }
+
+    @Test
+    public void compareDeeplyNestedEventSizeComputation() throws Exception {
+//        final Event e = createTestEvent();
+
+//        ClassLayout classLayout = ClassLayout.parseInstance(e);
+//        System.out.println("Calculated object size: " + classLayout.instanceSize() + " bytes, CBOR size: " + cborSerialized.length);
+//        System.out.println(ClassLayout.parseInstance(e).toPrintable());
+//        long roughBytesEstimatedSize = eventWithSize.size;
+//        System.out.println("System -Djol.magicFieldOffset: " + System.getProperty("jol.magicFieldOffset"));
+//        System.out.println("System -Djdk.attach.allowAttachSelf: " + System.getProperty("jdk.attach.allowAttachSelf"));
+//        System.setProperty("jol.magicFieldOffset", "true");
+
+        long maxHeapBytes = Runtime.getRuntime().maxMemory();
+        long maxHeapMB = maxHeapBytes / (1024 * 1024);
+
+        System.out.printf("Max Heap Size: %d MB%n", maxHeapMB);
+
+        System.out.println("Short string filling");
+        Event event = createNestedEvent(10, 5, SHORT_FILLING_STRING);
+        captureHeapDump("event_with_short_string.hprof");
+//        ClassLayout classLayout = ClassLayout.parseInstance(event).instanceSize();
+//        String footprint = GraphLayout.parseInstance(event).toFootprint();
+//        System.out.println(footprint);
+//        System.out.println(GraphLayout.parseInstance(event).toPrintable());
+        reportSizes(event);
+
+        System.out.println("Medium string filling");
+        event = createNestedEvent(10, 5, MEDIUM_FILLING_STRING);
+        captureHeapDump("event_with_medium_string.hprof");
+        reportSizes(event);
+
+        System.out.println("Long string filling");
+        event = createNestedEvent(10, 5, LONG_FILLING_STRING);
+        captureHeapDump("event_with_long_string.hprof");
+        reportSizes(event);
+    }
+
+    private static void reportSizes(Event e) throws JsonProcessingException {
+        byte[] cborSerialized = e.serialize();
+        long roughBytesEstimatedSize = e.estimateMemory();
+
+        System.out.println("Calculated object size: " + roughBytesEstimatedSize + " bytes, CBOR size: " + cborSerialized.length);
+    }
+
+    private Event createTestEvent() {
+        // TODO fill with nested layers
+        Event event = new Event();
+
+        event.setField("timestamp", new ConcreteJavaProxy(RubyUtil.RUBY,
+                RubyUtil.RUBY_TIMESTAMP_CLASS, new Timestamp()
+        ));
+
+        event.setField("[@metadata][foo]", Collections.emptyMap());
+        event.setField("[@metadata][bar]", Collections.singletonList("hello"));
+
+        // non ASCII
+        event.setField("foo", "bör");
+
+        final BigInteger bi = new BigInteger("9223372036854776000");
+        final BigDecimal bd =  new BigDecimal("9223372036854776001.99");
+        event.setField("bi", bi);
+        event.setField("bd", bd);
+
+        return event;
+    }
+
+
+    private Event createNestedEvent(int elementsPerLayer, int layer, String fillingString) {
+        double totalElements = Math.pow(elementsPerLayer, layer);
+        System.out.println("Total elements: " + totalElements);
+
+        // TODO fill with nested layers
+        Event event = new Event();
+        event.setField("timestamp", new ConcreteJavaProxy(RubyUtil.RUBY,
+                RubyUtil.RUBY_TIMESTAMP_CLASS, new Timestamp()
+        ));
+
+
+        Map<String, Object> map = createSubdocument(elementsPerLayer, layer, fillingString);
+        event.setField("custom_data", map);
+        return event;
+    }
+
+    private static Map<String, Object> createSubdocument(int elementsPerLayer, int layer, String fillingString) {
+        Map<String, Object> map = new HashMap<>(elementsPerLayer);
+        for (int i = 0; i < elementsPerLayer; i++) {
+            if (layer == 0) {
+                map.put(String.format("field_%d", i), fillingString);
+            } else {
+                map.put(String.format("field_%d", i), createSubdocument(elementsPerLayer, layer - 1, fillingString));
+            }
+        }
+        return map;
+    }
+
+
+    private void captureHeapDump(String dumpPath) throws IOException {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        HotSpotDiagnosticMXBean mxBean = ManagementFactory.newPlatformMXBeanProxy(
+                server, "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
+        mxBean.dumpHeap(dumpPath, true);
+    }
+}


### PR DESCRIPTION
## Summary
This PR is used to verify how Event memory estimation kinds varies, respect to accuracy and performance.
All should be compared against a byte-perfect measure, ideally considering object hears and all the details about memory layout alignment covered by [JOL library](https://github.com/openjdk/jol). However, the JOL library has problems in navigating JRuby related objects, so all the measurements are relative to each other and not against byte-perfect one.

