### PR TITLE
Fix deprecation warning with latest jruby/bundler

### DIFF
--- a/lib/pluginmanager/bundler/logstash_injector.rb
+++ b/lib/pluginmanager/bundler/logstash_injector.rb
@@ -96,7 +96,7 @@ module Bundler
             definition.remove_platform(specific_platform)
           end
           definition.add_platform(Gem::Platform.new('java'))
-          definition.lock(lockfile_path)
+          definition.lock
           gemfile.save
         rescue => e
           # the error should be handled elsewhere but we need to get the original file if we dont

--- a/lib/pluginmanager/bundler/logstash_uninstall.rb
+++ b/lib/pluginmanager/bundler/logstash_uninstall.rb
@@ -62,7 +62,7 @@ module Bundler
         definition = builder.to_definition(lockfile_path, {})
 
         # lock the definition and save our modified gemfile
-        definition.lock(lockfile_path)
+        definition.lock
         gemfile.save
 
         gems_to_remove.each do |gem_name|


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
[rn:skip]

## What does this PR do?

This commit updates the pluginmanager to not use a deprecated argument.

See https://github.com/rubygems/rubygems/commit/d1963bf1a6db7698f3a295dc2b4a7b04d2d318c7

## Why is it important/What is the impact to the user?

Without this patch use of the plugin manager can surface warnings that are not actionable by the logstash user. This commit fixes the underlying issue so messages are no longer surfaced. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Related issues
- https://github.com/elastic/logstash/issues/17732


## Logs

```
bash-5.1$ logstash-plugin install file:///usr/share/logstash/logstash-offline-plugins-9.1.0.zip
Using bundled JDK: /usr/share/logstash/jdk
Installing file: /usr/share/logstash/logstash-offline-plugins-9.1.0.zip
[DEPRECATED] `Definition#lock` was passed a target file argument. To fix this warning, remove it from the `Definition#lock` call.
Resolving dependencies...
Install successful
```
