### PR TITLE
Fix allow_superuser comment

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -288,7 +288,7 @@
 #
 # ------------ Other Settings --------------
 #
-# Allow or block running Logstash as superuser (default: true). Windows are excluded from the checking
+# Allow or block running Logstash as superuser (default: false). Windows are excluded from the checking
 # allow_superuser: false
 #
 # Where to find custom plugins


### PR DESCRIPTION
This commit fixes the comment of `allow_superuser` in `logstash.yml`.
The default value should be `false`.

relates: https://github.com/elastic/logstash/pull/16558