### PR TITLE
update dockerfile template based on feedback from dockerhub

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -74,7 +74,9 @@ RUN addgroup -g 1000 logstash && \
   --no-create-home \
   logstash && \
 <% end -%>
+<% if image_flavor == 'full' || image_flavor == 'oss' -%>
   arch="$(rpm --query --queryformat='%{ARCH}' rpm)" && \
+<% end -%>
   curl -f -Lo logstash.tar.gz <%= url_root %>/<%= tarball %> && \
   tar -zxf logstash.tar.gz -C /usr/share && \
   rm logstash.tar.gz && \


### PR DESCRIPTION
apply feedback from https://github.com/docker-library/official-images/pull/18983#issuecomment-2855576120

- remove manual retries
- decompress tarball without piping
- determine architecture from within docker before downloading tarball
    - this is required for dockerhub
    - for wolfi based image keep the current injection of ARCH from the environment 
