### PR TITLE
update ubi9 in ironbank images to 9.6

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -15,7 +15,7 @@ RUN go build
 <%# Start image_flavor 'ironbank' %>
 ARG BASE_REGISTRY=registry1.dso.mil
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.5
+ARG BASE_TAG=9.6
 ARG LOGSTASH_VERSION=<%= elastic_version %>
 ARG GOLANG_VERSION=1.21.8
 

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -14,7 +14,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "9.5"
+  BASE_TAG: "9.6"
   LOGSTASH_VERSION: "<%= elastic_version %>"
   GOLANG_VERSION: "1.21.8"
 


### PR DESCRIPTION
manual backport of https://github.com/elastic/logstash/pull/17802 to 8.19 and other 8.x branches