### PR TITLE
[CI] Remove UBI docker acceptance test

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -155,7 +155,7 @@ ci/acceptance_tests.sh"""),
 
 def acceptance_docker_steps()-> list[typing.Any]:
     steps = []
-    for flavor in ["full", "oss", "ubi", "wolfi"]:
+    for flavor in ["full", "oss", "wolfi"]:
         steps.append({
             "label": f":docker: {flavor} flavor acceptance",
             "agents": gcp_agent(vm_name="ubuntu-2204", image_prefix="family/platform-ingest-logstash"),

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -44,8 +44,6 @@ namespace "plugin" do
       # STDOUT pollution removal needed until 8.19 and 9.1
       # https://github.com/elastic/logstash/pull/17125
       next false if line.match?(/^Using (system java|bundled JDK|LS_JAVA_HOME defined java)/)
-
-      next false if line.match?(/pass JVM parameters via LS_JAVA_OPTS/)
       
       # post-execution filtration is needed until 8.19 and 9.1
       # when list --[no-]expand flag is supported, use it instead

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -45,7 +45,7 @@ namespace "plugin" do
       # https://github.com/elastic/logstash/pull/17125
       next false if line.match?(/^Using (system java|bundled JDK|LS_JAVA_HOME defined java)/)
 
-      next false if line.match?(/^pass JVM parameters via LS_JAVA_OPTS/)
+      next false if line.match?(/pass JVM parameters via LS_JAVA_OPTS/)
       
       # post-execution filtration is needed until 8.19 and 9.1
       # when list --[no-]expand flag is supported, use it instead

--- a/rakelib/plugin.rake
+++ b/rakelib/plugin.rake
@@ -44,6 +44,8 @@ namespace "plugin" do
       # STDOUT pollution removal needed until 8.19 and 9.1
       # https://github.com/elastic/logstash/pull/17125
       next false if line.match?(/^Using (system java|bundled JDK|LS_JAVA_HOME defined java)/)
+
+      next false if line.match?(/^pass JVM parameters via LS_JAVA_OPTS/)
       
       # post-execution filtration is needed until 8.19 and 9.1
       # when list --[no-]expand flag is supported, use it instead


### PR DESCRIPTION
This commit removes the UBI acceptance test. 
The default base image is UBI. Full flavour test has covered UBI flavour

Fixes: #17830

~This commit removes the unwanted warning which pollutes the plugins list~

~[installed_plugins](https://github.com/elastic/logstash/blob/main/rakelib/plugin.rake#L118) is polluted with  ["pass JVM parameters via LS_JAVA_OPTS", "logstash-codec-avro", "logstash-codec-cef", ... ]~