### PR TITLE
pq: activate stringref extension for more-compact PQ representation

### DIFF
--- a/logstash-core/src/main/java/org/logstash/ObjectMappers.java
+++ b/logstash-core/src/main/java/org/logstash/ObjectMappers.java
@@ -116,6 +116,7 @@ public final class ObjectMappers {
 
     public static final ObjectMapper CBOR_MAPPER = new ObjectMapper(
         new CBORFactory().configure(CBORGenerator.Feature.WRITE_MINIMAL_INTS, false)
+                         .configure(CBORGenerator.Feature.STRINGREF, true)
     ).registerModules(RUBY_SERIALIZERS, CBOR_DESERIALIZERS)
             .activateDefaultTyping(TYPE_VALIDATOR, ObjectMapper.DefaultTyping.NON_FINAL);
 

--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -27,13 +27,16 @@ import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -42,6 +45,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -141,6 +145,24 @@ public final class EventTest extends RubyTestBase {
         final Event deserialized = Event.deserialize(e.serialize());
         assertEquals(bi, deserialized.getField("bi"));
         assertEquals(bd, deserialized.getField("bd"));
+    }
+
+    @Test
+    public void deserializeStringrefExtensionEnabled() throws Exception {
+        byte[] stringrefCBOR = loadAnnotatedCBORFixture("stringref-enabled.annotated-cbor.txt");
+        Event event = Event.deserialize(stringrefCBOR);
+        event.getField("[event][original]");
+        assertEquals("stringref", event.getField("test"));
+        assertEquals(true, event.getField("[extension][enabled]"));
+    }
+
+    @Test
+    public void deserializeStringrefExtensionDisabled() throws Exception {
+        byte[] stringrefCBOR = loadAnnotatedCBORFixture("stringref-disabled.annotated-cbor.txt");
+        Event event = Event.deserialize(stringrefCBOR);
+        event.getField("[event][original]");
+        assertEquals("stringref", event.getField("test"));
+        assertEquals(true, event.getField("[extension][enabled]"));
     }
 
     @Test
@@ -564,5 +586,20 @@ public final class EventTest extends RubyTestBase {
 
         assertNull(event.getField(Event.TAGS_FAILURE));
         assertEquals(event.getField("[tags]"), List.of("foo", "bar"));
+    }
+
+    static byte[] loadAnnotatedCBORFixture(String name) throws IOException {
+        try (InputStream resourceAsStream = EventTest.class.getResourceAsStream(name)) {
+            assertNotNull(resourceAsStream);
+
+            String annotated = new String(resourceAsStream.readAllBytes(), StandardCharsets.UTF_8);
+            // annotated CBOR: strip #-initiated line comments, then strip whitespace to get hex
+            String hexBytes = annotated.replaceAll("#.*(\\n|$)", "").replaceAll("\\s", "");
+
+            // result should be even number of hex digits
+            assert hexBytes.matches("(?i:[0-9a-f]{2})*");
+
+            return HexFormat.of().parseHex(hexBytes);
+        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -72,7 +72,7 @@ public class DeadLetterQueueReaderTest {
     private Path dir;
     private int defaultDlqSize = 100_000_000; // 100mb
 
-    private static final int PAD_FOR_BLOCK_SIZE_EVENT = 32490;
+    private static final int PAD_FOR_BLOCK_SIZE_EVENT = 32511;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -240,7 +240,7 @@ public class DeadLetterQueueReaderTest {
     // This test tests for a single event that ends on a block boundary
     @Test
     public void testBlockBoundary() throws Exception {
-        final int PAD_FOR_BLOCK_SIZE_EVENT = 32490;
+        final int PAD_FOR_BLOCK_SIZE_EVENT = 32511;
         Event event = createEventWithConstantSerializationOverhead();
         char[] field = new char[PAD_FOR_BLOCK_SIZE_EVENT];
         Arrays.fill(field, 'e');
@@ -267,7 +267,7 @@ public class DeadLetterQueueReaderTest {
     @Test
     public void testBlockBoundaryMultiple() throws Exception {
         Event event = createEventWithConstantSerializationOverhead();
-        char[] field = new char[7929];
+        char[] field = new char[7950];
         Arrays.fill(field, 'x');
         event.setField("message", new String(field));
         long startTime = System.currentTimeMillis();
@@ -935,7 +935,7 @@ public class DeadLetterQueueReaderTest {
 
     private int prepareFilledSegmentFiles(int segments, long start) throws IOException {
         final Event event = createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", generateMessageContent(32479));
+        event.setField("message", generateMessageContent(32500));
 
         DLQEntry entry = new DLQEntry(event, "", "", String.format("%05d", 1), constantSerializationLengthTimestamp(start));
         assertEquals("Serialized dlq entry + header MUST be 32Kb (size of a block)", BLOCK_SIZE, entry.serialize().length + 13);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -105,7 +105,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     @Test
     public void testRemovesOlderSegmentsWhenWriteOnReopenedDLQContainingExpiredSegments() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
 
         final Clock pointInTimeFixedClock = Clock.fixed(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
         final ForwardableClock fakeClock = new ForwardableClock(pointInTimeFixedClock);
@@ -160,7 +160,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     @Test
     public void testRemovesOlderSegmentsWhenWritesIntoDLQContainingExpiredSegments() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
 
         long startTime = fakeClock.instant().toEpochMilli();
         int messageSize = 0;
@@ -203,7 +203,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
     @Test
     public void testRemoveMultipleOldestSegmentsWhenRetainedAgeIsExceeded() throws IOException {
         final Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
 
         long startTime = fakeClock.instant().toEpochMilli();
         int messageSize = 0;

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -251,7 +251,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testRemoveOldestSegmentWhenRetainedSizeIsExceededAndDropOlderModeIsEnabled() throws IOException {
         Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
         long startTime = System.currentTimeMillis();
 
         int messageSize = 0;
@@ -488,7 +488,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testDropEventCountCorrectlyNotEnqueuedEvents() throws IOException, InterruptedException {
         Event blockAlmostFullEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        int serializationHeader = 286;
+        int serializationHeader = 265;
         int notEnoughHeaderSpace = 5;
         blockAlmostFullEvent.setField("message", DeadLetterQueueReaderTest.generateMessageContent(BLOCK_SIZE - serializationHeader - RECORD_HEADER_SIZE + notEnoughHeaderSpace));
 
@@ -501,7 +501,7 @@ public class DeadLetterQueueWriterTest {
             // enqueue a record with size smaller than BLOCK_SIZE
             DLQEntry entry = new DLQEntry(blockAlmostFullEvent, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
             assertEquals("Serialized plus header must not leave enough space for another record header ",
-                    entry.serialize().length, BLOCK_SIZE - RECORD_HEADER_SIZE - notEnoughHeaderSpace);
+                    BLOCK_SIZE - RECORD_HEADER_SIZE - notEnoughHeaderSpace, entry.serialize().length);
             writeManager.writeEntry(entry);
 
             // enqueue a record bigger than BLOCK_SIZE
@@ -512,7 +512,7 @@ public class DeadLetterQueueWriterTest {
 
         // fill the queue to push out the segment with the 2 previous events
         Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
-        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32479));
+        event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
                 .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
                 .storageType(QueueStorageType.DROP_NEWER)

--- a/logstash-core/src/test/resources/org/logstash/stringref-disabled.annotated-cbor.txt
+++ b/logstash-core/src/test/resources/org/logstash/stringref-disabled.annotated-cbor.txt
@@ -1,0 +1,94 @@
+9f                                                               # array(*)
+   71                                                            #   text(17)
+      6a6176612e7574696c2e486173684d6170                         #     "java.util.HashMap"
+   bf                                                            #   map(*)
+      64                                                         #     text(4)
+         44415441                                                #       "DATA"
+      9f                                                         #     array(*)
+         78 19                                                   #       text(25)
+            6f72672e6c6f6773746173682e436f6e                     #         "org.logstash.Con"
+            7665727465644d6170                                   #         "vertedMap"
+         bf                                                      #       map(*)
+            64                                                   #         text(4)
+               686f7374                                          #           "host"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  68                                             #             text(8)
+                     686f73746e616d65                            #               "hostname"
+                  9f                                             #             array(*)
+                     74                                          #               text(20)
+                        6f72672e6a727562792e52756279537472696e67 #                 "org.jruby.RubyString"
+                     67                                          #               text(7)
+                        70657268617073                           #                 "perhaps"
+                     ff                                          #               break
+                  ff                                             #             break
+               ff                                                #           break
+            65                                                   #         text(5)
+               6576656e74                                        #           "event"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  68                                             #             text(8)
+                     6f726967696e616c                            #               "original"
+                  9f                                             #             array(*)
+                     74                                          #               text(20)
+                        6f72672e6a727562792e52756279537472696e67 #                 "org.jruby.RubyString"
+                     78 32                                       #               text(50)
+                        7b2274657374223a22737472696e6772         #                 "{\"test\":\"stringr"
+                        6566222c22657874656e73696f6e223a         #                 "ef\",\"extension\":"
+                        7b22656e61626c6564223a747275657d         #                 "{\"enabled\":true}"
+                        7d0a                                     #                 "}\n"
+                     ff                                          #               break
+                  ff                                             #             break
+               ff                                                #           break
+            68                                                   #         text(8)
+               4076657273696f6e                                  #           "@version"
+            61                                                   #         text(1)
+               31                                                #           "1"
+            69                                                   #         text(9)
+               657874656e73696f6e                                #           "extension"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  67                                             #             text(7)
+                     656e61626c6564                              #               "enabled"
+                  f5                                             #             true, simple(21)
+                  ff                                             #             break
+               ff                                                #           break
+            6a                                                   #         text(10)
+               4074696d657374616d70                              #           "@timestamp"
+            9f                                                   #         array(*)
+               76                                                #           text(22)
+                  6f72672e6c6f6773746173682e54696d657374616d70   #             "org.logstash.Timestamp"
+               78 1b                                             #           text(27)
+                  323032352d30372d32385431363a3432               #             "2025-07-28T16:42"
+                  3a32342e3432313434365a                         #             ":24.421446Z"
+               ff                                                #           break
+            64                                                   #         text(4)
+               74657374                                          #           "test"
+            9f                                                   #         array(*)
+               74                                                #           text(20)
+                  6f72672e6a727562792e52756279537472696e67       #             "org.jruby.RubyString"
+               69                                                #           text(9)
+                  737472696e67726566                             #             "stringref"
+               ff                                                #           break
+            ff                                                   #         break
+         ff                                                      #       break
+      64                                                         #     text(4)
+         4d455441                                                #       "META"
+      9f                                                         #     array(*)
+         78 19                                                   #       text(25)
+            6f72672e6c6f6773746173682e436f6e                     #         "org.logstash.Con"
+            7665727465644d6170                                   #         "vertedMap"
+         bf                                                      #       map(*)
+            ff                                                   #         break
+         ff                                                      #       break
+      ff                                                         #     break
+   ff                                                            #   break

--- a/logstash-core/src/test/resources/org/logstash/stringref-enabled.annotated-cbor.txt
+++ b/logstash-core/src/test/resources/org/logstash/stringref-enabled.annotated-cbor.txt
@@ -1,0 +1,91 @@
+d9 0100                                                           # tag(256)
+   9f                                                             #   array(*)
+      71                                                          #     text(17)
+         6a6176612e7574696c2e486173684d6170                       #       "java.util.HashMap"
+      bf                                                          #     map(*)
+         64                                                       #       text(4)
+            44415441                                              #         "DATA"
+         9f                                                       #       array(*)
+            78 19                                                 #         text(25)
+               6f72672e6c6f6773746173682e436f6e                   #           "org.logstash.Con"
+               7665727465644d6170                                 #           "vertedMap"
+            bf                                                    #         map(*)
+               64                                                 #           text(4)
+                  74657374                                        #             "test"
+               9f                                                 #           array(*)
+                  74                                              #             text(20)
+                     6f72672e6a727562792e52756279537472696e67     #               "org.jruby.RubyString"
+                  69                                              #             text(9)
+                     737472696e67726566                           #               "stringref"
+                  ff                                              #             break
+               68                                                 #           text(8)
+                  4076657273696f6e                                #             "@version"
+               61                                                 #           text(1)
+                  31                                              #             "1"
+               69                                                 #           text(9)
+                  657874656e73696f6e                              #             "extension"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     67                                           #               text(7)
+                        656e61626c6564                            #                 "enabled"
+                     f5                                           #               true, simple(21)
+                     ff                                           #               break
+                  ff                                              #             break
+               6a                                                 #           text(10)
+                  4074696d657374616d70                            #             "@timestamp"
+               9f                                                 #           array(*)
+                  76                                              #             text(22)
+                     6f72672e6c6f6773746173682e54696d657374616d70 #               "org.logstash.Timestamp"
+                  78 1b                                           #             text(27)
+                     323032352d30372d32385431353a3433             #               "2025-07-28T15:43"
+                     3a35332e3334303537325a                       #               ":53.340572Z"
+                  ff                                              #             break
+               65                                                 #           text(5)
+                  6576656e74                                      #             "event"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     68                                           #               text(8)
+                        6f726967696e616c                          #                 "original"
+                     9f                                           #               array(*)
+                        d8 19                                     #                 tag(25)
+                           04                                     #                   unsigned(4)
+                        78 32                                     #                 text(50)
+                           7b2274657374223a22737472696e6772       #                   "{\"test\":\"stringr"
+                           6566222c22657874656e73696f6e223a       #                   "ef\",\"extension\":"
+                           7b22656e61626c6564223a747275657d       #                   "{\"enabled\":true}"
+                           7d0a                                   #                   "}\n"
+                        ff                                        #                 break
+                     ff                                           #               break
+                  ff                                              #             break
+               64                                                 #           text(4)
+                  686f7374                                        #             "host"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     68                                           #               text(8)
+                        686f73746e616d65                          #                 "hostname"
+                     9f                                           #               array(*)
+                        d8 19                                     #                 tag(25)
+                           04                                     #                   unsigned(4)
+                        67                                        #                 text(7)
+                           70657268617073                         #                   "perhaps"
+                        ff                                        #                 break
+                     ff                                           #               break
+                  ff                                              #             break
+               ff                                                 #           break
+            ff                                                    #         break
+         64                                                       #       text(4)
+            4d455441                                              #         "META"
+         9f                                                       #       array(*)
+            d8 19                                                 #         tag(25)
+               02                                                 #           unsigned(2)
+            bf                                                    #         map(*)
+               ff                                                 #           break
+            ff                                                    #         break
+         ff                                                       #       break
+      ff                                                          #     break


### PR DESCRIPTION
## Release notes

 - Persisted Queue: improved serialization to be more compact by default

## What does this PR do?

When serializing a non-primitive value, CBOR encodes a two-element tuple containing the class name and the class-specific serialized value, which results in a significant amount of overhead in the form of frequently-repeated strings.

Jackson CBOR supports the [stringref][] extension, which allows it to avoid repeating the actual bytes of a string, and instead keeps track of the strings it has encountered and _referencing_ those strings by the index in which they occur.

For example, the first `org.jruby.RubyString` looks like:

~~~
74                                            # text(20)
   6f72672e6a727562792e52756279537472696e67   #   "org.jruby.RubyString"
~~~

While each subsequent string looks like:

~~~
d8 19                                         # tag(25)
   05                                         #   unsigned(5)
~~~

Enabling this extension allows us to save:
 - ~18 bytes from each secondary `org.jruby.RubyString`
 - ~23 bytes from each secondary `org.logstash.ConvertedMap`
 - ~24 bytes from each secondary `org.logstash.ConvertedList`
 - ...etc.

Practical example: a 9183-byte complex JSON that contains an `event.original`, consumed through the stdin input with json codec (adding fields like `@timestamp`, `@version` per normal) resulted in a 22% reduction in serialized size:

| CBOR unpatched   | CBOR patched    | 
| ---------------- | --------------- |
| 11218 bytes      | 8728 bytes      | 

The CBOR implementation in Jackson _appears_ to support reading stringrefs regardless of whether this feature is enabled for serializing, which means that this change is not a rollback-barrier.

[stringref]: https://cbor.schmorp.de/stringref

## Why is it important/What is the impact to the user?

Reduces size-on-disk for PQ, enabling more events to fit on each page and reducing disk IO

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

 - remove your queue data dir
   > ~~~
   > rm -rf "${LOGSTASH_HOME?:}/data/queue"
   > ~~~
 - run _unpatched_ LS to inject 100 events into the queue
   > ~~~
   > git checkout main && git pull && ./gradlew clean assemble installDefaultGems
   > bin/logstash -Squeue.type=persisted -e 'input { generator { count => 100 } } output { stdout { codec => json_lines } }'
   > ~~~
 - after process stops, [inspect page files](https://gist.github.com/yaauie/c7350c91bd84b824e749d118762f6143) to events tagged as `CBOR(known)` (indicating that they start with the `9F716A` sequence that events have historically started with)
 - run _patched_ LS to inject 100 more events
   > ~~~
   > git fetch yaauie && git checkout yaauie/pq-activate-cbor-stringref-extension && ./gradlew clean assemble installDefaultGems
   > bin/logstash -Squeue.type=persisted -e 'input { generator { count => 1000 } } output { stdout { codec => json_lines } }'
   > ~~~
 - after process stops, [inspect page files](https://gist.github.com/yaauie/c7350c91bd84b824e749d118762f6143) to see additional events tagged as `CBOR(stringref)` (indicating that they start with the stringref tag `D90100`)

## Related issues

 - Anti-Rollback Barriers
  - [ ] 9.1 - https://github.com/elastic/logstash/pull/17988
  - [ ] 9.0 - https://github.com/elastic/logstash/pull/17989 
  - [ ] 8.19 - https://github.com/elastic/logstash/pull/17990

## Use cases

 - Constrained or metered IO
