### PR TITLE
[docs] Use centrally maintained version variables

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -14,7 +14,6 @@ toc:
   - toc: release-notes
   - toc: extend
 subs:
-  version: "9.0.0"
   logstash-ref:   "https://www.elastic.co/guide/en/logstash/current"
   ecloud:   "Elastic Cloud"
   ech:   "Elastic Cloud Hosted"
@@ -45,8 +44,6 @@ subs:
   ilm-init:   "ILM"
   dlm:   "data lifecycle management"
   dlm-init:   "DLM"
-  stack-version: "9.0.0"
-  major-version: "9.x"
   docker-repo: "docker.elastic.co/logstash/logstash"
   ess-leadin-short:   "Elastic Cloud Hosted is available on AWS, GCP, and Azure, and you can try it for free at https://cloud.elastic.co/registration."
   ess-leadin: "You can run Elasticsearch on your own hardware or use Elastic Cloud Hosted, available on AWS, GCP, and Azure. Try Elastic Cloud Hosted for free: https://cloud.elastic.co/registration."

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -18,27 +18,27 @@ pull` command against the Elastic Docker registry.
 
 
 ```sh subs=true
-docker pull {{docker-repo}}:{{stack-version}}
+docker pull {{docker-repo}}:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features
-available under the Apache 2.0 license. To download the images, go to 
-[www.docker.elastic.co](https://www.docker.elastic.co). 
+available under the Apache 2.0 license. To download the images, go to
+[www.docker.elastic.co](https://www.docker.elastic.co).
 
 
 ## Verifying the image [_verifying_the_image]
 
 Although it's optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
 
-Elastic images are signed with [Cosign](https://docs.sigstore.dev/cosign/) which is part of the [Sigstore](https://www.sigstore.dev/) project. 
-Cosign supports container signing, verification, and storage in an OCI registry. 
+Elastic images are signed with [Cosign](https://docs.sigstore.dev/cosign/) which is part of the [Sigstore](https://www.sigstore.dev/) project.
+Cosign supports container signing, verification, and storage in an OCI registry.
 Install the appropriate Cosign application for your operating system.
 
-Run the following commands to verify the container image signature for {{ls}} v{{stack-version}}:
+Run the following commands to verify the container image signature for {{ls}} v{{version.stack}}:
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub <1>
-cosign verify --key cosign.pub {{docker-repo}}:{{stack-version}} <2>
+cosign verify --key cosign.pub {{docker-repo}}:{{version.stack}} <2>
 ```
 
 1. Download the Elastic public key to verify container signature
@@ -47,7 +47,7 @@ cosign verify --key cosign.pub {{docker-repo}}:{{stack-version}} <2>
 The command prints the check results and the signature payload in JSON format, for example:
 
 ```sh subs=true
-Verification for {{docker-repo}}:{{stack-version}} --
+Verification for {{docker-repo}}:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline

--- a/docs/reference/first-event.md
+++ b/docs/reference/first-event.md
@@ -37,16 +37,16 @@ The location of the `bin` directory varies by platform. See [Directory layout](/
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of {{version.stack}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{version.stack}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{version.stack}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).

--- a/docs/reference/installing-logstash.md
+++ b/docs/reference/installing-logstash.md
@@ -59,15 +59,15 @@ You may need to install the `apt-transport-https` package on Debian before proce
 sudo apt-get install apt-transport-https
 ```
 
-Save the repository definition to  /etc/apt/sources.list.d/elastic-{{major-version}}.list:
+Save the repository definition to  /etc/apt/sources.list.d/elastic-{{version.stack | M.x}}.list:
 
 ```sh subs=true
-echo "deb [signed-by=/usr/share/keyrings/elastic-keyring.gpg] https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+echo "deb [signed-by=/usr/share/keyrings/elastic-keyring.gpg] https://artifacts.elastic.co/packages/{{version.stack | M.x}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{version.stack | M.x}}.list
 ```
 
 ::::{warning}
 Use the `echo` method described above to add the Logstash repository.
-Do not use `add-apt-repository` as it will add a `deb-src` entry as well, but we do not provide a source package. 
+Do not use `add-apt-repository` as it will add a `deb-src` entry as well, but we do not provide a source package.
 If you have added the `deb-src` entry, you will see an error like the following:
 
 ```
@@ -100,9 +100,9 @@ Add the following in your `/etc/yum.repos.d/` directory
 in a file with a `.repo` suffix, for example `logstash.repo`
 
 ```sh subs=true
-[logstash-{{major-version}}]
-name=Elastic repository for {{major-version}} packages
-baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+[logstash-{{version.stack | M.x}}]
+name=Elastic repository for {{version.stack | M.x}} packages
+baseurl=https://artifacts.elastic.co/packages/{{version.stack | M.x}}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/docs/reference/running-logstash-command-line.md
+++ b/docs/reference/running-logstash-command-line.md
@@ -8,16 +8,16 @@ mapped_pages:
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of the {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of the {{version.stack}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}} that interrupts it, you will need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{version.stack}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{version.stack}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).

--- a/docs/reference/working-with-plugins.md
+++ b/docs/reference/working-with-plugins.md
@@ -8,16 +8,16 @@ mapped_pages:
 ::::{admonition} macOS Gatekeeper warnings
 :class: important
 
-Apple’s rollout of stricter notarization requirements affected the notarization of the {{version}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}}, you need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
+Apple’s rollout of stricter notarization requirements affected the notarization of the {{version.stack}} {{ls}} artifacts. If macOS Catalina displays a dialog when you first run {{ls}}, you need to take an action to allow it to run. To prevent Gatekeeper checks on the {{ls}} files, run the following command on the downloaded `.tar.gz` archive or the directory to which was extracted:
 
 ```sh
 xattr -d -r com.apple.quarantine <archive-or-directory>
 ```
 
-For example, if the `.tar.gz` file was extracted to the default logstash-{{version}} directory, the command is:
+For example, if the `.tar.gz` file was extracted to the default logstash-{{version.stack}} directory, the command is:
 
 ```sh subs=true
-xattr -d -r com.apple.quarantine logstash-{{version}}
+xattr -d -r com.apple.quarantine logstash-{{version.stack}}
 ```
 
 Alternatively, you can add a security override if a Gatekeeper popup appears by following the instructions in the *How to open an app that hasn’t been notarized or is from an unidentified developer* section of [Safely open apps on your Mac](https://support.apple.com/en-us/HT202491).


### PR DESCRIPTION
Related to https://github.com/elastic/docs-projects/issues/519

Update the docs to use centrally-managed [version variables](https://elastic.github.io/docs-builder/syntax/version-variables/) from docs-builder's [`version.yml` configuration file](https://github.com/elastic/docs-builder/blob/main/config/versions.yml). The Docs team is responsible for updating these version numbers for each release. These version variables will replace `docset`-level version-related `subs` so we don't have to update those values in this repo for every release.

