### PR TITLE
[docs] Add `applies_to` labels for 9.1.0

### DIFF
--- a/docs/reference/keystore.md
+++ b/docs/reference/keystore.md
@@ -136,7 +136,10 @@ bin/logstash-keystore add ES_USER ES_PWD
 When prompted, enter a value for each key.
 
 ::::{note}
-Key values are limited to ASCII letters (`a`-`z`, `A`-`Z`), numbers (`0`-`9`), underscores (`_`), and dots (`.`); they must be at least one character long and cannot begin with a number.
+Key values are limited to:
+
+* {applies_to}`stack: ga 9.0.0` ASCII characters including digits, letters, and a few special symbols.
+* {applies_to}`stack: ga 9.1.0` ASCII letters (`a`-`z`, `A`-`Z`), numbers (`0`-`9`), underscores (`_`), and dots (`.`); they must be at least one character long and cannot begin with a number.
 ::::
 
 

--- a/docs/reference/persistent-queues.md
+++ b/docs/reference/persistent-queues.md
@@ -81,7 +81,8 @@ If you want to define values for a specific pipeline, use [`pipelines.yml`](/ref
 
     To avoid losing data in the persistent queue, you can set `queue.checkpoint.writes: 1` to force a checkpoint after each event is written. Keep in mind that disk writes have a resource cost. Setting this value to `1` ensures maximum durability, but can severely impact performance. See [Controlling durability](#durability-persistent-queues) to better understand the trade-offs.
 
-
+`queue.checkpoint.interval` {applies_to}`stack: deprecated 9.1`
+:   Sets the interval in milliseconds when a checkpoint is forced on the head page. Default is `1000`. Set to `0` to eliminate periodic checkpoints.
 
 ## Configuration notes [pq-config-notes]
 


### PR DESCRIPTION
Closes https://github.com/elastic/docs-content-internal/issues/69

## Context

Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

## Updates

I reviewed all commits since the 9.0.0 release that touched the `docs` directory and looked through the proposed 9.1.0 release notes in https://github.com/elastic/logstash/pull/17822. I only found two items that required `applies_to` badges:

* https://github.com/elastic/logstash/pull/17351
* https://github.com/elastic/logstash/pull/17759