### PR TITLE
make sure versions.yml is only read once into gradle.ext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@
 
 buildscript {
     ext {
-        snakeYamlVersion = '2.2'
         shadowGradlePluginVersion = '8.1.1'
     }
 
@@ -28,9 +27,6 @@ buildscript {
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
-    }
-    dependencies {
-        classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
     }
 }
 
@@ -44,7 +40,6 @@ apply from: "${projectDir}/x-pack/distributions/internal/observabilitySRE/build-
 apply plugin: 'de.undercouch.download'
 apply from: "rubyUtils.gradle"
 
-import org.yaml.snakeyaml.Yaml
 import de.undercouch.gradle.tasks.download.Download
 import groovy.json.JsonSlurper
 import org.logstash.gradle.tooling.ListProjectDependencies
@@ -710,10 +705,10 @@ class JDKDetails {
     final String unpackedJdkName
     private String arch
 
-    JDKDetails(versionYml, osName, jdkArch) {
-        revision = versionYml.bundled_jdk.revision
-        build = versionYml.bundled_jdk.build
-        vendor = versionYml.bundled_jdk.vendor
+    JDKDetails(bundledJdk, osName, jdkArch) {
+        revision = bundledJdk.revision
+        build = bundledJdk.build
+        vendor = bundledJdk.vendor
         major = revision.split('\\.').first() as int
         this.osName = osName
 
@@ -829,9 +824,9 @@ tasks.register("downloadJdk", Download) {
     project.ext.set("versionFound", true)
     String osName = selectOsType()
 
-    def versionYml = new Yaml().load(new File("$projectDir/versions.yml").text)
     String jdkArch = selectArch()
-    def jdkDetails = new JDKDetails(versionYml, osName, jdkArch)
+
+    def jdkDetails = new JDKDetails(gradle.ext.versions.bundled_jdk, osName, jdkArch)
 
     description "Download JDK ${jdkDetails.major}, OS: ${osName}"
 
@@ -860,10 +855,8 @@ tasks.register("downloadJdk", Download) {
 }
 
 tasks.register("checkNewJdkVersion") {
-    def versionYml = new Yaml().load(new File("$projectDir/versions.yml").text)
-
     // use Linux x86_64 as canary platform
-    def jdkDetails = new JDKDetails(versionYml, "linux", "x86_64")
+    def jdkDetails = new JDKDetails(gradle.ext.versions.bundled_jdk, "linux", "x86_64")
     // throws Gradle exception if local and remote doesn't match
     jdkDetails.checkLocalVersionMatchingLatest()
 }

--- a/logstash-core/benchmarks/build.gradle
+++ b/logstash-core/benchmarks/build.gradle
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-import org.yaml.snakeyaml.Yaml
-
-// fetch version from Logstash's main versions.yml file
-def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
+def versionMap = gradle.ext.versions
 
 description = """Logstash Core Java Benchmarks"""
 version = versionMap['logstash-core']
@@ -36,7 +33,6 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
     classpath "com.github.johnrengelman:shadow:${shadowGradlePluginVersion}"
   }
 }

--- a/logstash-core/build.gradle
+++ b/logstash-core/build.gradle
@@ -19,12 +19,6 @@
 
 
 buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
-    }
 }
 
 plugins {
@@ -50,10 +44,7 @@ jacoco {
 }
 
 
-import org.yaml.snakeyaml.Yaml
-
-// fetch version from Logstash's main versions.yml file
-def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../versions.yml").text)
+def versionMap = gradle.ext.versions
 
 description = """Logstash Core Java"""
 

--- a/rubyUtils.gradle
+++ b/rubyUtils.gradle
@@ -23,15 +23,13 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
         classpath "de.undercouch:gradle-download-task:4.0.4"
-        classpath "org.jruby:jruby-core:9.4.13.0"
+        classpath "org.jruby:jruby-core:${gradle.ext.versions.jruby.version}"
     }
 }
 
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
-import org.yaml.snakeyaml.Yaml
 
 
 import org.jruby.Ruby
@@ -217,7 +215,7 @@ Object executeJruby(File projectDir, File buildDir, Closure<?> /* Object*/ block
 //===============================================================================
 
 def versionsPath = project.hasProperty("LOGSTASH_CORE_PATH") ? LOGSTASH_CORE_PATH + "/../versions.yml" : "${projectDir}/versions.yml"
-versionMap = (Map) (new Yaml()).load(new File("${versionsPath}").text)
+versionMap = gradle.ext.versions
 
 String jRubyURL
 String jRubyVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,18 @@ if (!oss) {
   include ':logstash-xpack'
   project(':logstash-xpack').projectDir = new File('./x-pack')
 }
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath "org.yaml:snakeyaml:2.2"
+  }
+}
+
+// load versions of jdk and jruby asap so we can use them anywhere else in the scripts
+import org.yaml.snakeyaml.Yaml
+def versionsFile = file("$rootDir/versions.yml")
+gradle.ext.versions = new Yaml().load(versionsFile.text)

--- a/tools/benchmark-cli/build.gradle
+++ b/tools/benchmark-cli/build.gradle
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.yaml.snakeyaml.Yaml
 
-// fetch version from Logstash's main versions.yml file
-def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
+def versionMap = gradle.ext.versions
 
 description = """Logstash End to End Benchmarking Utility"""
 version = versionMap['logstash-core']
@@ -36,7 +34,6 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath group: 'org.yaml', name: 'snakeyaml', version: "${snakeYamlVersion}"
     classpath "com.github.johnrengelman:shadow:${shadowGradlePluginVersion}"
   }
 }

--- a/tools/dependencies-report/build.gradle
+++ b/tools/dependencies-report/build.gradle
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-import org.yaml.snakeyaml.Yaml
-
-// fetch version from Logstash's main versions.yml file
-def versionMap = (Map) (new Yaml()).load(new File("$projectDir/../../versions.yml").text)
+def versionMap = gradle.ext.versions
 
 description = """Logstash Dependency Reporting Utility"""
 version = versionMap['logstash-core']
@@ -36,7 +33,6 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath "org.yaml:snakeyaml:${snakeYamlVersion}"
     classpath "com.github.johnrengelman:shadow:${shadowGradlePluginVersion}"
   }
 }


### PR DESCRIPTION
this removes the need to re-read the yaml file in so many places, and also avoids having to state the jruby version an extra time in the rubyUtils.gradle

It uses `gradle.ext`, computed in settings.gradle, as a place to store the versions. This is important to load the versions before any other `buildscript {}` block runs. From what I can gleam this isn't an anti-pattern, but happy to be convinced otherwise.

Exhaustive test suite: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/2179/steps/canvas