### PR TITLE
Update release matrix based on 9.1.0 and 8.19.0 releases

### DIFF
--- a/ci/logstash_releases.json
+++ b/ci/logstash_releases.json
@@ -1,16 +1,17 @@
 {
   "releases": {
     "7.current": "7.17.29",
-    "8.previous": "8.17.9",
-    "8.current": "8.18.4",
-    "9.current": "9.0.4"
+    "8.previous": "8.18.4",
+    "8.current": "8.19.0",
+    "9.previous": "9.0.4",
+    "9.current": "9.1.0"
   },
   "snapshots": {
     "7.current": "7.17.30-SNAPSHOT",
-    "8.previous": "8.17.10-SNAPSHOT",
-    "8.current": "8.18.5-SNAPSHOT",
-    "8.next": "8.19.0-SNAPSHOT",
-    "9.next": "9.0.5-SNAPSHOT",
-    "main": "9.1.0-SNAPSHOT"
+    "8.previous": "8.18.5-SNAPSHOT",
+    "8.current": "8.19.1-SNAPSHOT",
+    "9.previous": "9.0.5-SNAPSHOT",
+    "9.current": "9.1.1-SNAPSHOT",
+    "main": "9.2.0-SNAPSHOT"
   }
 }


### PR DESCRIPTION
This commit updates the releases matrix to point to the new minor releases.
