### PR TITLE
Add Mergify rule for forwardporting documentation changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -125,10 +125,10 @@ pull_request_rules:
     conditions:
       - merged
       - label=docs
-      - files~=^docs/ 
-      - head~=^\d+\.
+      - files~=^docs/
+      - base~=^\d+\.
     actions:
       backport:
         branches:
           - main
-        title: "[{{ destination_branch }}](forwardport #{{ number }}) {{ title }}"
+        title: "[{{ destination_branch }}] (forwardport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -120,3 +120,15 @@ pull_request_rules:
       backport:
         branches:
           - "9.1"
+
+  - name: forwardport docs changes to main
+    conditions:
+      - merged
+      - label=docs
+      - files~=^docs/ 
+      - head~=^\d+\.
+    actions:
+      backport:
+        branches:
+          - main
+        title: "[{{ destination_branch }}](forwardport #{{ number }}) {{ title }}"


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

This change is part of https://github.com/elastic/docs-builder/issues/1433.

In order to make the porting of documentation changes to `main` more straightforward, a new rule specific to changes inside the `docs` folder is being added.

## Why is it important/What is the impact to the user?

Documentation writers will have a smoother workflow with automated forwardporting, and code owners can then decide whether to merge the changes or not.

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] ˜˜I have commented my code, particularly in hard-to-understand areas˜˜
- [ ] ˜˜I have made corresponding changes to the documentation˜˜
- [ ] ˜˜I have made corresponding change to the default configuration files (and/or docker env variables)˜˜
- [ ] ˜˜I have added tests that prove my fix is effective or that my feature works˜˜