### PR TITLE
Make sure FIPS comments belong in the platform-sre Dockerfile

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -184,8 +184,8 @@ WORKDIR /usr/share/logstash
 ENV ELASTIC_CONTAINER true
 ENV PATH=/usr/share/logstash/bin:$PATH
 
-# Add FIPS configuration for observability-sre image flavor
 <% if image_flavor == 'observability-sre' -%>
+# Add FIPS configuration for observability-sre image flavor
 
 RUN mkdir -p /usr/share/logstash/config/security
 


### PR DESCRIPTION
Without this change the FIPS related comment is sneaking into the other Dockerfiles:

https://github.com/elastic/dockerfiles/blob/8.19/logstash/Dockerfile#L45