### PR TITLE
Update monkey patch for clamp to 1.3.3

### DIFF
--- a/logstash-core/lib/logstash/patches/clamp.rb
+++ b/logstash-core/lib/logstash/patches/clamp.rb
@@ -106,8 +106,9 @@ module Clamp
       # --long.flag.name=false => sets flag to false
       def extract_value(switch, arguments)
         if flag? && (arguments.first.nil? || arguments.first.match("^-"))
-          flag_value(switch)
+          flag_set?(switch)
         else
+          raise ArgumentError, Clamp.message(:no_value_provided) if arguments.empty?
           arguments.shift
         end
       end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "pry", "~> 0.12"  #(Ruby license)
   gem.add_runtime_dependency "stud", "~> 0.0.19" #(Apache 2.0 license)
-  gem.add_runtime_dependency "clamp", "~> 1" #(MIT license) for command line args/flags
+  gem.add_runtime_dependency "clamp", "~> 1", ">= 1.3.3" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "~> 0.2" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 1"  #(MIT license)
   gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956


### PR DESCRIPTION
The 1.3.3 release of the `clamp` gem contains some commits that invalidate our monkey patch (listed below). This commit updates our patch and ensures our gemspec requires a version of clamp that matches the target of the patch.

- https://github.com/mdub/clamp/commit/db61e39656a5c8c96319d24f38ee404b9e9ccf15
- https://github.com/mdub/clamp/commit/c6b28b6719717c28fefee08d8a4681e9ae03ccfc
