### PR TITLE
Log *what* components trigger a grype scan

### DIFF
--- a/.github/workflows/critical_vulnerability_scan.yml
+++ b/.github/workflows/critical_vulnerability_scan.yml
@@ -22,3 +22,4 @@ jobs:
           path: "./scan"
           fail-build: true
           severity-cutoff: critical
+          output-format: table


### PR DESCRIPTION
This commit updates the grype action to log what components it is scanning (including any that are critical which will cause the action to fail). Previously the default sarif file was generated and nothing was logged. Without this commit it is impossible to tell from a failed action *what* is causing the failure.


See https://github.com/anchore/scan-action?tab=readme-ov-file#action-inputs which indicates this option should do what we want. 