### PR TITLE
8.19 release notes rendering fix

### DIFF
--- a/docs/static/releasenotes.asciidoc
+++ b/docs/static/releasenotes.asciidoc
@@ -2,6 +2,7 @@
 == Release Notes
 
 This section summarizes the changes in the following releases:
+
 * <<logstash-8-19-1,Logstash 8.19.1>>
 * <<logstash-8-19-0,Logstash 8.19.0>>
 * <<logstash-8-18-4,Logstash 8.18.4>>


### PR DESCRIPTION
I think we are missing a blank line to fix this rendering problem:

<img width="902" height="668" alt="image" src="https://github.com/user-attachments/assets/d79c9385-6ed0-4592-b4e1-32f29de09b56" />


cc: @andsel & @jsvd 