### PR TITLE
Doc: Replace reference to Elasticsearch Services with Elastic Cloud Hosted

### DIFF
--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -38,7 +38,7 @@ The Elasticsearch input, output, and filter plugins support cloud_id and cloud_a
 * [Elasticsearch output plugin](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-cloud_id)
 
 
-## Sending {{ls}} management data to {{es}} Services [cloud-id-mgmt]
+## Sending {{ls}} management data to {{ech}} [cloud-id-mgmt]
 
 These settings in the `logstash.yml` config file can help you get set up to send management data to Elastic Cloud:
 


### PR DESCRIPTION
Doc

## Release notes

[rn:skip]

## What does this PR do?

This PR replaces a reference to Elasticsearch Services with a reference to Elastic Cloud Hosted in the [Sending data to Elastic Cloud Hosted](https://www.elastic.co/docs/reference/logstash/connecting-to-cloud) doc.

## Checklist

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Relates to issue https://github.com/elastic/logstash/issues/17652
- Relates to PR https://github.com/elastic/logstash/pull/17653
