### PR TITLE
Release notes for 9.0.5

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -52,7 +52,6 @@ No user-facing changes in Logstash core.
 **Elasticsearch Output - 12.0.6**
 
 * Add headers reporting uncompressed size and doc count for bulk requests [#1217](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1217)
-
 * [DOC] Fix link to Logstash DLQ docs [#1214](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1214)
 
 ## 9.0.4 [logstash-9.0.4-release-notes]


### PR DESCRIPTION
Supercedes #17948, which placed the notes out of order.

I have filed https://github.com/elastic/logstash/issues/17952 to address the ordering issue.
