### PR TITLE
Bump logstash version to 8.19.3

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.19.2)
+      logstash-core (= 8.19.3)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.19.2-java)
+    logstash-core (8.19.3-java)
       clamp (~> 1, >= 1.3.3)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 8.19.2
-logstash-core: 8.19.2
+logstash: 8.19.3
+logstash-core: 8.19.3
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
Update path version for logstash 8.19.3. 

Merge after 8.19.2 release. 