### PR TITLE
Include the prune filter for observabilitySRE image

### DIFF
--- a/x-pack/distributions/internal/observabilitySRE/plugin-allow-list.txt
+++ b/x-pack/distributions/internal/observabilitySRE/plugin-allow-list.txt
@@ -9,6 +9,7 @@ logstash-filter-fingerprint
 logstash-filter-grok
 logstash-filter-json
 logstash-filter-mutate
+logstash-filter-prune
 logstash-input-beats
 logstash-input-generator
 logstash-input-pipeline


### PR DESCRIPTION


## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The SRE team uses this filter for now. It contains no FIPS incompatible code.

## Relates to
- https://github.com/elastic/ingest-dev/issues/5973