### PR TITLE
Add fips config to jvm.options for observabilitySRE

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -115,6 +115,15 @@ RUN mkdir -p /usr/share/logstash/config/security
 RUN cp /usr/share/logstash/x-pack/distributions/internal/observabilitySRE/config/security/java.security /usr/share/logstash/config/security/ && \
     chown --recursive logstash:root /usr/share/logstash/config/security/
 
+# Copy additional JVM options and append to existing jvm.options
+RUN cp /usr/share/logstash/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options /tmp/fips-jvm.options && \
+    chown logstash:root /tmp/fips-jvm.options
+# echos are for ensuring that the file ends with a newline
+RUN echo "" >> /usr/share/logstash/config/jvm.options && \
+    echo "" >> /usr/share/logstash/config/jvm.options && \
+    cat /tmp/fips-jvm.options >> /usr/share/logstash/config/jvm.options && \
+    rm /tmp/fips-jvm.options
+
 # list the classes provided by the fips BC
 RUN find /usr/share/logstash -name *.jar | grep lib
 

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -141,17 +141,6 @@ RUN /usr/share/logstash/jdk/bin/keytool -importkeystore \
     -deststorepass changeit \
     -srcstorepass changeit \
     -noprompt
-
-# Set Java security properties through LS_JAVA_OPTS
-ENV LS_JAVA_OPTS="\
-    -Djava.security.properties=/usr/share/logstash/config/security/java.security \
-    -Djavax.net.ssl.trustStore=/usr/share/logstash/config/security/cacerts.bcfks \
-    -Djavax.net.ssl.trustStoreType=BCFKS \
-    -Djavax.net.ssl.trustStoreProvider=BCFIPS \
-    -Djavax.net.ssl.trustStorePassword=changeit \
-    -Dssl.KeyManagerFactory.algorithm=PKIX \
-    -Dssl.TrustManagerFactory.algorithm=PKIX \
-    -Dorg.bouncycastle.fips.approved_only=true"
 <% end -%>
 
 WORKDIR /usr/share/logstash

--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -119,9 +119,10 @@ RUN cp /usr/share/logstash/x-pack/distributions/internal/observabilitySRE/config
 RUN cp /usr/share/logstash/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options /tmp/fips-jvm.options && \
     chown logstash:root /tmp/fips-jvm.options
 # echos are for ensuring that the file ends with a newline
-RUN echo "" >> /usr/share/logstash/config/jvm.options && \
-    echo "" >> /usr/share/logstash/config/jvm.options && \
-    cat /tmp/fips-jvm.options >> /usr/share/logstash/config/jvm.options && \
+RUN ( \
+      echo ""; echo ""; \
+      cat /tmp/fips-jvm.options \
+    ) >> /usr/share/logstash/config/jvm.options && \
     rm /tmp/fips-jvm.options
 
 # list the classes provided by the fips BC

--- a/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options
+++ b/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options
@@ -1,0 +1,9 @@
+# FIPS config to be appended to /usr/share/logstash/config/jvm.options
+-Djava.security.properties=/usr/share/logstash/config/security/java.security
+-Djavax.net.ssl.trustStore=/usr/share/logstash/config/security/cacerts.bcfks
+-Djavax.net.ssl.trustStoreType=BCFKS
+-Djavax.net.ssl.trustStoreProvider=BCFIPS
+-Djavax.net.ssl.trustStorePassword=changeit
+-Dssl.KeyManagerFactory.algorithm=PKIX
+-Dssl.TrustManagerFactory.algorithm=PKIX
+-Dorg.bouncycastle.fips.approved_only=true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

In addition to setting `LS_JAVA_OPTS` we now include the fips config java options in the `/usr/share/logstash/config/jvm.options` file. This ensures that if consumers of the image overwrite `LS_JAVA_OPTS` the fips config is still respected from `jvm.options`.

## Related Issues
- https://github.com/elastic/ingest-dev/issues/5972