### PR TITLE
Start all exhastive tests in parallel

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
     structure = {"steps": []}
 
     structure["steps"].append({
-        "group": "Testing Phase",
+        "group": "Pull request suite",
         "key": "testing-phase",
         **testing_phase_steps(),
     })
@@ -210,35 +210,30 @@ if __name__ == "__main__":
     structure["steps"].append({
             "group": "Compatibility / Linux",
             "key": "compatibility-linux",
-            "depends_on": "testing-phase",
             "steps": compat_linux_steps,
     })
 
     structure["steps"].append({
             "group": "Compatibility / Windows",
             "key": "compatibility-windows",
-            "depends_on": "testing-phase",
             "steps": [compat_windows_step(imagesuffix=windows_test_os)],
     })
 
     structure["steps"].append({
             "group": "Acceptance / Packaging",
             "key": "acceptance-packaging",
-            "depends_on": ["testing-phase"],
             "steps": acceptance_linux_steps(),
     })
 
     structure["steps"].append({
             "group": "Acceptance / Docker",
             "key": "acceptance-docker",
-            "depends_on": ["testing-phase"],
             "steps": acceptance_docker_steps(),
     })
 
     structure["steps"].append({
         "group": "Observability SRE Acceptance Tests",
         "key": "acceptance-observability-sre",
-        "depends_on": ["testing-phase"],
         "steps": [fips_test_runner_step()],
     })
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Previously the package based tests would be blocked on the pull request suite. Given those tests MUST have be run to even get code in to a branch this results in the exhaustive test suite taking roughly 30 mins to even start the unique tests. In practice when we want to reproduce or test a failure in the exhaustive suite we DONT want to be blocked on seeing the PR tests. This commit removes the depends-on condition for the package based tests on the pull request tests. It does not seem like any protection from doing unncessary package based tests if a pull request test fails is worth the extra wall time in practice. This should significantly decrease the total time needed for the exhaustive test pipeline.

## Related issues

- https://github.com/elastic/ingest-dev/issues/5579