### PR TITLE
compat: add test for deserializing stringref enabled and disabled

### DIFF
--- a/logstash-core/src/test/java/org/logstash/EventTest.java
+++ b/logstash-core/src/test/java/org/logstash/EventTest.java
@@ -27,13 +27,16 @@ import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -42,6 +45,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -141,6 +145,24 @@ public final class EventTest extends RubyTestBase {
         final Event deserialized = Event.deserialize(e.serialize());
         assertEquals(bi, deserialized.getField("bi"));
         assertEquals(bd, deserialized.getField("bd"));
+    }
+
+    @Test
+    public void deserializeStringrefExtensionEnabled() throws Exception {
+        byte[] stringrefCBOR = loadAnnotatedCBORFixture("stringref-enabled.annotated-cbor.txt");
+        Event event = Event.deserialize(stringrefCBOR);
+        event.getField("[event][original]");
+        assertEquals("stringref", event.getField("test"));
+        assertEquals(true, event.getField("[extension][enabled]"));
+    }
+
+    @Test
+    public void deserializeStringrefExtensionDisabled() throws Exception {
+        byte[] stringrefCBOR = loadAnnotatedCBORFixture("stringref-disabled.annotated-cbor.txt");
+        Event event = Event.deserialize(stringrefCBOR);
+        event.getField("[event][original]");
+        assertEquals("stringref", event.getField("test"));
+        assertEquals(true, event.getField("[extension][enabled]"));
     }
 
     @Test
@@ -564,5 +586,20 @@ public final class EventTest extends RubyTestBase {
 
         assertNull(event.getField(Event.TAGS_FAILURE));
         assertEquals(event.getField("[tags]"), List.of("foo", "bar"));
+    }
+
+    static byte[] loadAnnotatedCBORFixture(String name) throws IOException {
+        try (InputStream resourceAsStream = EventTest.class.getResourceAsStream(name)) {
+            assertNotNull(resourceAsStream);
+
+            String annotated = new String(resourceAsStream.readAllBytes(), StandardCharsets.UTF_8);
+            // annotated CBOR: strip #-initiated line comments, then strip whitespace to get hex
+            String hexBytes = annotated.replaceAll("#.*(\\n|$)", "").replaceAll("\\s", "");
+
+            // result should be even number of hex digits
+            assert hexBytes.matches("(?i:[0-9a-f]{2})*");
+
+            return HexFormat.of().parseHex(hexBytes);
+        }
     }
 }

--- a/logstash-core/src/test/resources/org/logstash/stringref-disabled.annotated-cbor.txt
+++ b/logstash-core/src/test/resources/org/logstash/stringref-disabled.annotated-cbor.txt
@@ -1,0 +1,94 @@
+9f                                                               # array(*)
+   71                                                            #   text(17)
+      6a6176612e7574696c2e486173684d6170                         #     "java.util.HashMap"
+   bf                                                            #   map(*)
+      64                                                         #     text(4)
+         44415441                                                #       "DATA"
+      9f                                                         #     array(*)
+         78 19                                                   #       text(25)
+            6f72672e6c6f6773746173682e436f6e                     #         "org.logstash.Con"
+            7665727465644d6170                                   #         "vertedMap"
+         bf                                                      #       map(*)
+            64                                                   #         text(4)
+               686f7374                                          #           "host"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  68                                             #             text(8)
+                     686f73746e616d65                            #               "hostname"
+                  9f                                             #             array(*)
+                     74                                          #               text(20)
+                        6f72672e6a727562792e52756279537472696e67 #                 "org.jruby.RubyString"
+                     67                                          #               text(7)
+                        70657268617073                           #                 "perhaps"
+                     ff                                          #               break
+                  ff                                             #             break
+               ff                                                #           break
+            65                                                   #         text(5)
+               6576656e74                                        #           "event"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  68                                             #             text(8)
+                     6f726967696e616c                            #               "original"
+                  9f                                             #             array(*)
+                     74                                          #               text(20)
+                        6f72672e6a727562792e52756279537472696e67 #                 "org.jruby.RubyString"
+                     78 32                                       #               text(50)
+                        7b2274657374223a22737472696e6772         #                 "{\"test\":\"stringr"
+                        6566222c22657874656e73696f6e223a         #                 "ef\",\"extension\":"
+                        7b22656e61626c6564223a747275657d         #                 "{\"enabled\":true}"
+                        7d0a                                     #                 "}\n"
+                     ff                                          #               break
+                  ff                                             #             break
+               ff                                                #           break
+            68                                                   #         text(8)
+               4076657273696f6e                                  #           "@version"
+            61                                                   #         text(1)
+               31                                                #           "1"
+            69                                                   #         text(9)
+               657874656e73696f6e                                #           "extension"
+            9f                                                   #         array(*)
+               78 19                                             #           text(25)
+                  6f72672e6c6f6773746173682e436f6e               #             "org.logstash.Con"
+                  7665727465644d6170                             #             "vertedMap"
+               bf                                                #           map(*)
+                  67                                             #             text(7)
+                     656e61626c6564                              #               "enabled"
+                  f5                                             #             true, simple(21)
+                  ff                                             #             break
+               ff                                                #           break
+            6a                                                   #         text(10)
+               4074696d657374616d70                              #           "@timestamp"
+            9f                                                   #         array(*)
+               76                                                #           text(22)
+                  6f72672e6c6f6773746173682e54696d657374616d70   #             "org.logstash.Timestamp"
+               78 1b                                             #           text(27)
+                  323032352d30372d32385431363a3432               #             "2025-07-28T16:42"
+                  3a32342e3432313434365a                         #             ":24.421446Z"
+               ff                                                #           break
+            64                                                   #         text(4)
+               74657374                                          #           "test"
+            9f                                                   #         array(*)
+               74                                                #           text(20)
+                  6f72672e6a727562792e52756279537472696e67       #             "org.jruby.RubyString"
+               69                                                #           text(9)
+                  737472696e67726566                             #             "stringref"
+               ff                                                #           break
+            ff                                                   #         break
+         ff                                                      #       break
+      64                                                         #     text(4)
+         4d455441                                                #       "META"
+      9f                                                         #     array(*)
+         78 19                                                   #       text(25)
+            6f72672e6c6f6773746173682e436f6e                     #         "org.logstash.Con"
+            7665727465644d6170                                   #         "vertedMap"
+         bf                                                      #       map(*)
+            ff                                                   #         break
+         ff                                                      #       break
+      ff                                                         #     break
+   ff                                                            #   break

--- a/logstash-core/src/test/resources/org/logstash/stringref-enabled.annotated-cbor.txt
+++ b/logstash-core/src/test/resources/org/logstash/stringref-enabled.annotated-cbor.txt
@@ -1,0 +1,91 @@
+d9 0100                                                           # tag(256)
+   9f                                                             #   array(*)
+      71                                                          #     text(17)
+         6a6176612e7574696c2e486173684d6170                       #       "java.util.HashMap"
+      bf                                                          #     map(*)
+         64                                                       #       text(4)
+            44415441                                              #         "DATA"
+         9f                                                       #       array(*)
+            78 19                                                 #         text(25)
+               6f72672e6c6f6773746173682e436f6e                   #           "org.logstash.Con"
+               7665727465644d6170                                 #           "vertedMap"
+            bf                                                    #         map(*)
+               64                                                 #           text(4)
+                  74657374                                        #             "test"
+               9f                                                 #           array(*)
+                  74                                              #             text(20)
+                     6f72672e6a727562792e52756279537472696e67     #               "org.jruby.RubyString"
+                  69                                              #             text(9)
+                     737472696e67726566                           #               "stringref"
+                  ff                                              #             break
+               68                                                 #           text(8)
+                  4076657273696f6e                                #             "@version"
+               61                                                 #           text(1)
+                  31                                              #             "1"
+               69                                                 #           text(9)
+                  657874656e73696f6e                              #             "extension"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     67                                           #               text(7)
+                        656e61626c6564                            #                 "enabled"
+                     f5                                           #               true, simple(21)
+                     ff                                           #               break
+                  ff                                              #             break
+               6a                                                 #           text(10)
+                  4074696d657374616d70                            #             "@timestamp"
+               9f                                                 #           array(*)
+                  76                                              #             text(22)
+                     6f72672e6c6f6773746173682e54696d657374616d70 #               "org.logstash.Timestamp"
+                  78 1b                                           #             text(27)
+                     323032352d30372d32385431353a3433             #               "2025-07-28T15:43"
+                     3a35332e3334303537325a                       #               ":53.340572Z"
+                  ff                                              #             break
+               65                                                 #           text(5)
+                  6576656e74                                      #             "event"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     68                                           #               text(8)
+                        6f726967696e616c                          #                 "original"
+                     9f                                           #               array(*)
+                        d8 19                                     #                 tag(25)
+                           04                                     #                   unsigned(4)
+                        78 32                                     #                 text(50)
+                           7b2274657374223a22737472696e6772       #                   "{\"test\":\"stringr"
+                           6566222c22657874656e73696f6e223a       #                   "ef\",\"extension\":"
+                           7b22656e61626c6564223a747275657d       #                   "{\"enabled\":true}"
+                           7d0a                                   #                   "}\n"
+                        ff                                        #                 break
+                     ff                                           #               break
+                  ff                                              #             break
+               64                                                 #           text(4)
+                  686f7374                                        #             "host"
+               9f                                                 #           array(*)
+                  d8 19                                           #             tag(25)
+                     02                                           #               unsigned(2)
+                  bf                                              #             map(*)
+                     68                                           #               text(8)
+                        686f73746e616d65                          #                 "hostname"
+                     9f                                           #               array(*)
+                        d8 19                                     #                 tag(25)
+                           04                                     #                   unsigned(4)
+                        67                                        #                 text(7)
+                           70657268617073                         #                   "perhaps"
+                        ff                                        #                 break
+                     ff                                           #               break
+                  ff                                              #             break
+               ff                                                 #           break
+            ff                                                    #         break
+         64                                                       #       text(4)
+            4d455441                                              #         "META"
+         9f                                                       #       array(*)
+            d8 19                                                 #         tag(25)
+               02                                                 #           unsigned(2)
+            bf                                                    #         map(*)
+               ff                                                 #           break
+            ff                                                    #         break
+         ff                                                       #       break
+      ff                                                          #     break


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?

Adds tests to prove that enabling the CBOR stringref extension in https://github.com/elastic/logstash/pull/17849 does not create a rollback barrier.

## Why is it important/What is the impact to the user?

We want to ensure that a user who has begun using LS 9.x (in which we plan to activate the CBOR stringref extension) can safely roll back to LS 9.1, even if stringref-enabled events are left behind in the PQ.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

 - Dependency of: https://github.com/elastic/logstash/pull/17849 (tests must pass on 9.1 without modification of code)
