### PR TITLE
Preserve coerce behavior from Ruby Integer/PositiveInteger Settings impl

### DIFF
--- a/logstash-core/src/main/java/org/logstash/settings/SettingInteger.java
+++ b/logstash-core/src/main/java/org/logstash/settings/SettingInteger.java
@@ -32,7 +32,7 @@ public class SettingInteger extends Coercible<Integer> {
         } else {
             // try to parse string to int
             try {
-                return Integer.parseInt(obj.toString());
+                return Integer.parseInt(obj.toString().trim());
             } catch (NumberFormatException e) {
                 // ugly flow control
             }

--- a/logstash-core/src/test/java/org/logstash/settings/SettingIntegerTest.java
+++ b/logstash-core/src/test/java/org/logstash/settings/SettingIntegerTest.java
@@ -41,6 +41,11 @@ public class SettingIntegerTest {
         assertEquals(Integer.valueOf(100), sut.coerce(100L));
     }
 
+    @Test
+    public void givenWhitespaceStringWithIntegerCoerceCastIntoInteger() {
+        assertEquals(Integer.valueOf(100), sut.coerce(" 100 "));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void givenDoubleInstanceThenCoerceThrowsException() {
         sut.coerce(1.1);


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Recently https://github.com/elastic/logstash/pull/17460 the implementation for integer/postive integer settings was moved from jruby to pure java. The ruby implementation was leinient with whitespace in string values. This commit updates the java implementation to replicate this by stripping whitespace from string values before trying to parse them as int.

