### PR TITLE
Add stub workflow file to iterate on

### DIFF
--- a/.github/workflows/bump-java-version.yml
+++ b/.github/workflows/bump-java-version.yml
@@ -1,4 +1,4 @@
-name: Update JDK Version [STUB]
+name: Stub GH action for devoping new workflows [STUB]
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
This commit adds a stub GH action to be used for iterating on https://github.com/elastic/logstash/pull/17945/files this was based on a suggestion from the infra team for developing these workflows. Notably this has a pull_request trigger which will allow us to run the workflow from a PR raised from a test branch in the elastic/logstash repo.