### PR TITLE
[health-report ci] Put back the full start requirement.

### DIFF
--- a/.buildkite/scripts/health-report-tests/bootstrap.py
+++ b/.buildkite/scripts/health-report-tests/bootstrap.py
@@ -84,7 +84,9 @@ class Bootstrap:
         for stdout_line in iter(process.stdout.readline, ""):
             print(stdout_line.strip())
             # we don't wait for Logstash fully start as we also test slow pipeline start scenarios
-            if "Pipeline started" in stdout_line:
+            if full_start_required is False and "Starting pipeline" in stdout_line:
+                break
+            if full_start_required is True and "Pipeline started" in stdout_line:
                 break
             if "Logstash shut down" in stdout_line or "Logstash stopped" in stdout_line:
                 print(f"Logstash couldn't spin up.")


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Places back the full start requirement flag `full_start_required` which can be controlled by a driver. For the scenarios such as slow start this can be not required as it needs to confirm pipeline start taking longer. And for other backpressure test cases it is required to check full pipeline start

## Why is it important/What is the impact to the user?
N/A

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- 

## Use cases


## Screenshots

## Logs
