### PR TITLE
Build artifacts only for those that match host arch

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -157,6 +157,7 @@ steps:
     command: |
       set -euo pipefail
       source .buildkite/scripts/common/vm-agent.sh
+      export ARCH="x86_64"
       ./ci/observabilitySREsmoke_tests.sh
 
   - label: ":lab_coat: Integration Tests - FIPS mode / part 1-of-6"

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -28,6 +28,7 @@ def package_x86_step(branch, workflow_type):
   command: |
     export WORKFLOW_TYPE="{workflow_type}"
     export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+    export ARCH="x86_64"
     eval "$(rbenv init -)"
     .buildkite/scripts/dra/build_packages.sh
   artifact_paths:

--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -17,8 +17,8 @@ def to_bk_key_friendly_string(key):
 
 def package_x86_step(branch, workflow_type):
     step = f'''
-- label: ":package: Build packages / {branch}-{workflow_type.upper()} DRA artifacts"
-  key: "logstash_build_packages_dra"
+- label: ":package: Build x86 packages / {branch}-{workflow_type.upper()} DRA artifacts"
+  key: "logstash_build_x86_packages_dra"
   agents:
     provider: gcp
     imageProject: elastic-images-prod
@@ -34,7 +34,31 @@ def package_x86_step(branch, workflow_type):
   artifact_paths:
     - "**/*.hprof"
 '''
+    return step
 
+def package_arm_step(branch, workflow_type):
+  # Note: this is currently using an x86 host. We can use a true arm host later 
+  # if we want. System packages dont rely on matching host arch to target artifact arch
+  # This just parallelizes the packaging for each across different build hosts for shorter
+  # total time
+    step = f'''
+- label: ":package: Build arm packages / {branch}-{workflow_type.upper()} DRA artifacts"
+  key: "logstash_build_arm_packages_dra"
+  agents:
+    provider: gcp
+    imageProject: elastic-images-prod
+    image: family/platform-ingest-logstash-ubuntu-2204
+    machineType: "n2-standard-16"
+    diskSizeGb: 200
+  command: |
+    export WORKFLOW_TYPE="{workflow_type}"
+    export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
+    ARCH="aarch64"
+    eval "$(rbenv init -)"
+    .buildkite/scripts/dra/build_packages.sh
+  artifact_paths:
+    - "**/*.hprof"
+'''
     return step
 
 def package_x86_docker_step(branch, workflow_type):
@@ -158,6 +182,7 @@ def publish_dra_step(branch, workflow_type, depends_on):
 def build_steps_to_yaml(branch, workflow_type):
     steps = []
     steps.extend(yaml.safe_load(package_x86_step(branch, workflow_type)))
+    steps.extend(yaml.safe_load(package_arm_step(branch, workflow_type)))
     steps.extend(yaml.safe_load(package_x86_docker_step(branch, workflow_type)))
     steps.extend(yaml.safe_load(package_aarch64_docker_step(branch, workflow_type)))
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Previously when doing platform specific builds (x86_64, arm) BOTH sets of artifacts were produced regarless of host. This increases CI run times and is needless resource consumption. This commit makes the rake tasks compile artifacts for only the host arch it is being run on.


## Why is it important/What is the impact to the user?
N/A
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/elastic/ingest-dev/issues/5994
- https://github.com/elastic/ingest-dev/issues/5579
