### PR TITLE
Start observabilitySRE container builds immediately on DRA

### DIFF
--- a/.buildkite/scripts/dra/generatesteps.py
+++ b/.buildkite/scripts/dra/generatesteps.py
@@ -83,7 +83,6 @@ def ship_observability_sre_image_steps(branch, workflow_type):
     step = f'''
 - label: ":package: Build & Ship aarch64 ObservabilitySRE container / {branch}-{workflow_type.upper()}"
   key: "logstash_build_and_ship_observability_sre_aarch64"
-  depends_on: logstash_publish_dra
   agents:
     provider: aws
     imagePrefix: platform-ingest-logstash-ubuntu-2204-aarch64
@@ -99,7 +98,6 @@ def ship_observability_sre_image_steps(branch, workflow_type):
     .buildkite/scripts/dra/build-and-push-observability-sre.sh
 - label: ":package: Build & Ship x86_64 ObservabilitySRE container / {branch}-{workflow_type.upper()}"
   key: "logstash_build_and_ship_observability_sre_x86_64"
-  depends_on: logstash_publish_dra
   agents:
     provider: gcp
     imageProject: elastic-images-prod


### PR DESCRIPTION
Previously as the pipeline for publishing observabilitySRE artifacts was being developed that part of the pipeline only executed after the rest of the DRA artifacts had been prepared. This sacrificed build time for ensuring that failures did not disrupt the rest of the DRA process. Now that the workflow has been stabilized it is no longer necessary to wait. This commit removes the deps for the DRA build to complete before starting the observabilitySRE artifact creation. This should decrease the total time for the DRA pipeline to complete.
