### PR TITLE
[DOCS] Fix nullable type linting error in OpenAPI document

### DIFF
--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -1748,11 +1748,9 @@ components:
           type: string
           description: A unique identifier for the ephemeral session of the Logstash instance.
         snapshot:
-          type: boolean
-          nullable: true
+          type: [boolean, 'null']
         status:
           $ref: '#/components/schemas/Status'
-
     PipelineSettings:
       type: object
       properties:
@@ -2263,19 +2261,16 @@ components:
           type: object
           properties:
             last_error:
-              type: string
-              nullable: true
+              type: [ string, 'null']
             successes:
               type: integer
               format: int64
             last_success_timestamp:
-              type: string
+              type: [ string, 'null']
               format: date-time
-              nullable: true
             last_failure_timestamp:
-              type: string
+              type: [ string, 'null']
               format: date-time
-              nullable: true
             failures:
               type: integer
               format: int64

--- a/docs/static/spec/openapi/redocly.yaml
+++ b/docs/static/spec/openapi/redocly.yaml
@@ -26,15 +26,10 @@ rules:
  # Paths
   no-ambiguous-paths: warn
   no-identical-paths: error
-  path-excludes-patterns:
-    severity: error
-    patterns:
-      - ^\/internal
  # Responses
   operation-4xx-response: off
   operation-2xx-response: off
  # Schema
-  spec: off
   spec-strict-refs: off
  # Tags
   operation-tag-defined: off
@@ -50,3 +45,10 @@ rules:
     assertions:
       maxLength: 45
       minLength: 5
+  rule/path-exclude-pattern:
+    subject:
+      type: Paths
+    message: Do not include internal APIs
+    assertions:
+      notPattern: ^\/internal
+    severity: error


### PR DESCRIPTION

## Release notes
 [rn:skip] 

## What does this PR do?

This PR addresses the following linting errors reported 

```

[1] redocly.yaml:29:3 at #/rules/path-excludes-patterns

Property `path-excludes-patterns` is not expected here.

27 | no-ambiguous-paths: warn
28 | no-identical-paths: error
29 | path-excludes-patterns:
30 |   severity: error
31 |   patterns:

Warning was generated by the configuration struct rule.

[2] redocly.yaml:37:3 at #/rules/spec

Property `spec` is not expected here.

35 |  operation-2xx-response: off
36 | # Schema
37 |  spec: off
38 |  spec-strict-refs: off
39 | # Tags

Warning was generated by the configuration struct rule.

...

[2] logstash-api.yaml:2267:15 at #/components/schemas/PipelineReloadStats/properties/reloads/properties/last_error/nullable

Property `nullable` is not expected here.

2265 | last_error:
2266 |   type: string
2267 |   nullable: true
2268 | successes:
2269 |   type: integer

Error was generated by the struct rule.

```

## Why is it important/What is the impact to the user?

The redocly linter's behaviour changed per https://redocly.com/docs/cli/guides/migrate-to-v2 thus the configuration needed to be updated.

`nullable: true` is the format for OpenAPI 3.0 and that also changed in 3.1 so updates were required in that formatting too.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

N/A

## How to test this PR locally

`redocly lint logstash-api.yaml --config redocly.yaml`

## Related issues

N/A

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A
