### PR TITLE
Stop waiting on ALL steps before staring junit annotation

### DIFF
--- a/.buildkite/pull_request_pipeline.yml
+++ b/.buildkite/pull_request_pipeline.yml
@@ -553,10 +553,8 @@ steps:
       docker build -t test-runner-image -f x-pack/distributions/internal/observabilitySRE/docker/Dockerfile .
       docker run -e FEDRAMP_HIGH_MODE=true test-runner-image x-pack/ci/integration_tests.sh
 
-  - wait: ~
-    continue_on_failure: true
-
   - label: "🏁 Annotate JUnit results"
+    depends_on: "java-unit-tests"
     # the plugin requires docker run, hence the use of a VM
     agents:
       provider: gcp


### PR DESCRIPTION
The junit annotation previously would wait for EVERY step to finish before running. It takes a non trivial amount of time and was consistenly adding several minute to the total run time. The only artifacts it annotates are emmited by the java unit tests. This commit updates the buildkite manifest to properly define that relationship such that it will start as soon as the java tests step is done instead of waiting for ALL steps.

Relates to https://github.com/elastic/ingest-dev/issues/5579