### PR TITLE
Bump to 9.1.4

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 9.1.3)
+      logstash-core (= 9.1.4)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (9.1.3-java)
+    logstash-core (9.1.4-java)
       clamp (~> 1, >= 1.3.3)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)

--- a/versions.yml
+++ b/versions.yml
@@ -1,7 +1,7 @@
 ---
 # alpha and beta qualifiers are now added via VERSION_QUALIFIER environment var
-logstash: 9.1.3
-logstash-core: 9.1.3
+logstash: 9.1.4
+logstash-core: 9.1.4
 logstash-core-plugin-api: 2.1.16
 
 bundled_jdk:


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

Bumps core version to 9.1.4