### PR TITLE
Ensure acceptance test artifacts are being built for correct arch

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -125,6 +125,7 @@ set -eo pipefail
 source .buildkite/scripts/common/vm-agent.sh
 echo "--- Building all artifacts"
 ./gradlew clean bootstrap
+export ARCH="x86_64"
 rake artifact:deb artifact:rpm
 """),
         "artifact_paths": [


### PR DESCRIPTION
With the improvment in https://github.com/elastic/logstash/pull/17995 we only build packages that match the architecture of the host. This is specified with an enviornment variable. Previously the acceptance tests did not need to specifcy the architecture when building packages. This commit updates the builder to build packages with the correct arch.

