### PR TITLE
Fix gauge type correctly where requesting pipeline metrics in condition.

### DIFF
--- a/logstash-core/lib/logstash/config/pipelines_info.rb
+++ b/logstash-core/lib/logstash/config/pipelines_info.rb
@@ -73,8 +73,6 @@ module LogStash; module Config;
 
        (stats || {}).reduce([]) do |acc, kv|
         plugin_id, plugin_stats = kv
-
-        props = Hash.new {|h, k| h[k] = []}
         next unless plugin_stats
 
         flattened = flatten_metrics(plugin_stats)
@@ -93,7 +91,7 @@ module LogStash; module Config;
 
             nested_type = if type_sym == :"counter/long"
                             :long_counters
-                          elsif type_sym == :"gauge/numeric"
+                          elsif type_sym == :"gauge/number"
                             :double_gauges
                           else
                             nil


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
A fix to receive gauge metric types in pipeline info which appears in pipeline vertex of node stats API.

## What does this PR do?

## Why is it important/What is the impact to the user?

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally
- pull this change and build Logstash
- Use elastic-agent input plugin (whose [`current_connections`](https://github.com/logstash-plugins/logstash-input-beats/blob/main/lib/logstash/inputs/beats/message_listener.rb#L208) and [`peak_connections`](https://github.com/logstash-plugins/logstash-input-beats/blob/main/lib/logstash/inputs/beats/message_listener.rb#L211) are `gauge/number`) in your pipeline
- call `GET localhost:9600/_node/stats?graph=true&vertices=true` API
- Check the response that 

## Related issues

- 

## Use cases
- Visualizations or monitoring tools which aligns on node stats API's vertex info

## Screenshots


## Logs

```
 "vertices": [
                {
                    "id": "input-agent",
                    "pipeline_ephemeral_id": "6fc8016a-de9f-42d9-ba38-6aed98d4ab92",
                    "double_gauges": [. // <----------- THIS WASN'T EXIST BEFORE
                        {
                            "name": "current_connections",
                            "value": 1
                        },
                        {
                            "name": "peak_connections",
                            "value": 3
                        }
                    ],
                    "queue_push_duration_in_millis": 0,
                    "events_out": 6
                },
                ...
]
```