### PR TITLE
Preserve mtime explicitly when creating tar artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -669,7 +669,7 @@ namespace "artifact" do
       elsif stat.symlink?
         tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
       else
-        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => stat.mtime&.to_i || 0) do |io|
+        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => stat.mtime&.to_i || Time.now.to_i) do |io|
           File.open(path, 'rb') do |fd|
             chunk = nil
             size = 0

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -669,7 +669,7 @@ namespace "artifact" do
       elsif stat.symlink?
         tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
       else
-        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => stat.mtime&.to_i || Time.now.to_i) do |io|
+        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => (stat.mtime || Time.now).to_i) do |io|
           File.open(path, 'rb') do |fd|
             chunk = nil
             size = 0

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -669,7 +669,7 @@ namespace "artifact" do
       elsif stat.symlink?
         tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
       else
-        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size) do |io|
+        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => stat.mtime&.to_i || 0) do |io|
           File.open(path, 'rb') do |fd|
             chunk = nil
             size = 0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Improvement to logstash release artifacts file metadata: mtime is preserved when buiilding tar archives 

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

When building tar archives, explicitly set mtime. This avoids losing that information in the minitar `Writer.add_file_simple` method
 https://github.com/halostatue/minitar/blob/a531136b17b9efdddf0a0f39537845b454c2371e/lib/minitar/writer.rb#L139

## Why is it important/What is the impact to the user?

Files containing mtime 0 lead to undesireable behavior in some use cases https://github.com/elastic/logstash/issues/17925 and do not show any clues to modification time. Avoiding setting mtime to 0 in many cases will help provide artifacts with the least amount of surprise to users. 

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/elastic/logstash/issues/17925
- https://github.com/elastic/sdh-logstash/issues/1695

