### PR TITLE
Ensure any file object in a tar archive has an mtime

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -664,12 +664,13 @@ namespace "artifact" do
 
     def write_to_tar(tar, path, path_in_tar)
       stat = File.lstat(path)
+      mtime = (stat.mtime || Time.now).to_i
       if stat.directory?
-        tar.mkdir(path_in_tar, :mode => stat.mode)
+        tar.mkdir(path_in_tar, :mode => stat.mode, :mtime => mtime)
       elsif stat.symlink?
-        tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode)
+        tar.symlink(path_in_tar, File.readlink(path), :mode => stat.mode, :mtime => mtime)
       else
-        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => (stat.mtime || Time.now).to_i) do |io|
+        tar.add_file_simple(path_in_tar, :mode => stat.mode, :size => stat.size, :mtime => mtime) do |io|
           File.open(path, 'rb') do |fd|
             chunk = nil
             size = 0

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -664,6 +664,7 @@ namespace "artifact" do
 
     def write_to_tar(tar, path, path_in_tar)
       stat = File.lstat(path)
+      # in the off-chance that mtime returns nil we don't want nil to be interpreted as epoch, so fall back to Time.now
       mtime = (stat.mtime || Time.now).to_i
       if stat.directory?
         tar.mkdir(path_in_tar, :mode => stat.mode, :mtime => mtime)


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

## Summary

Following up on https://github.com/elastic/logstash/pull/18091, when minitar writes a directory or symlink it also needs explicit mtime. After inspecting artifacts built from #18019 we see some other missing mtimes. This commit ensures that information is explicitly passed to the minitar writer.
