### PR TITLE
Fix aarch64 acceptance tests

### DIFF
--- a/.buildkite/aarch64_pipeline.yml
+++ b/.buildkite/aarch64_pipeline.yml
@@ -127,14 +127,15 @@ steps:
             - limit: 3
 
   - group: "Acceptance Phase"
-    depends_on: "testing-phase"
     key: "acceptance-phase"
     steps:
       - label: "Docker [{{matrix}}] flavor acceptance"
-        command:
+        command: |
           set -euo pipefail
+
+          source .buildkite/scripts/common/vm-agent.sh
           export ARCH="aarch64"
-          source .buildkite/scripts/common/vm-agent.sh && ci/docker_acceptance_tests.sh {{matrix}}
+          ci/docker_acceptance_tests.sh {{matrix}}
         retry:
           automatic:
             - limit: 3


### PR DESCRIPTION
This commit fixes the aarch64 acceptance tests. With
https://github.com/elastic/logstash/pull/18079 a new env var was added to
aarch64 docker acceptance tests. At that time the fact that the `command` was
missing a block scalar `|` was missed. Thus the newlines were not respected and
the script for preparing a vm agent was not executed correctly. This resulted in
`bundle` command not being found on the test runner. This commit fixes the
`command` section to include a block scalar. Additionally we stop waiting on
unit tests before starting docker tests as this is unncessary.