### PR TITLE
Downgrade jruby to 9.4.13.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -42,4 +42,5 @@ gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
+gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default

--- a/versions.yml
+++ b/versions.yml
@@ -13,8 +13,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 9.4.14.0
-  sha256: 7ea2be8d0c5989714c795b4544492bf9941c9576e7a78f593a19c85567bc0452
+  version: 9.4.13.0
+  sha256: 226d9c3a2e332f8f249838f96c20e87e0df2b9a464a11477b47be6dafb66412c
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby
 #jruby-runtime-override:
 #  url: https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/9.3.0.0-SNAPSHOT/jruby-dist-9.3.0.0-20210723.214927-259-bin.tar.gz


### PR DESCRIPTION
This reverts commit fe4a735c64b710796fd21144166ed9b9b8832e85. After merging we discovered https://github.com/jruby/jruby/issues/9000. Continue using 9.4.13.0 until we figure out a path forward for resultion of that upstream jruby issue.
