### PR TITLE
Fix race condition with version bump action

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -51,7 +51,7 @@ jobs:
       - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ env.INPUTS_BUMP }} --strict
       - run: mv Gemfile.lock Gemfile.jruby-*.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
-      - run: echo "BRANCH=update_lock_${T}" >> $GITHUB_ENV
+      - run: echo "BRANCH=update_lock_${{ env.INPUTS_BRANCH }}_${T}" >> $GITHUB_ENV
       - run: |
           git checkout -b $BRANCH
           git add .


### PR DESCRIPTION
When handling multiple releases on the same schedule it is common to kick off this action across multiple branches. Using *only* the time for a branch name to create a PR for to update lock file results in a race condition where a target branch can conflict. In order to fix this we now include the target branch (logstash stream) in the branch name to raise the PR from.
