### PR TITLE
Measure current batch byte size and event count

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -173,6 +173,8 @@ module LogStash
           end
 
           def refine_batch_metrics(stats)
+            # current is a tuple of [event_count, byte_size] store the reference locally to avoid repeatedly
+            # reading and retrieve unrelated values
             current_data_point = stats[:batch][:current]
             {
               :event_count => {

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -173,14 +173,17 @@ module LogStash
           end
 
           def refine_batch_metrics(stats)
+            current_data_point = stats[:batch][:current]
             {
               :event_count => {
+                :current => current_data_point,
                 :average => {
                   # average return a FlowMetric which and we need to invoke getValue to obtain the map with metric details.
                   :lifetime => stats[:batch][:event_count][:average].value["lifetime"] ? stats[:batch][:event_count][:average].value["lifetime"].round : 0
                 }
               },
               :byte_size => {
+                :current => current_data_point,
                 :average => {
                   :lifetime => stats[:batch][:byte_size][:average].value["lifetime"] ? stats[:batch][:byte_size][:average].value["lifetime"].round : 0
                 }

--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -176,14 +176,15 @@ module LogStash
             current_data_point = stats[:batch][:current]
             {
               :event_count => {
-                :current => current_data_point,
+                # current_data_point is an instance of org.logstash.instrument.metrics.gauge.LazyDelegatingGauge so need to invoke getValue() to obtain the actual value
+                :current => current_data_point.value[0],
                 :average => {
                   # average return a FlowMetric which and we need to invoke getValue to obtain the map with metric details.
                   :lifetime => stats[:batch][:event_count][:average].value["lifetime"] ? stats[:batch][:event_count][:average].value["lifetime"].round : 0
                 }
               },
               :byte_size => {
-                :current => current_data_point,
+                :current => current_data_point.value[1],
                 :average => {
                   :lifetime => stats[:batch][:byte_size][:average].value["lifetime"] ? stats[:batch][:byte_size][:average].value["lifetime"].round : 0
                 }

--- a/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/node_stats_spec.rb
@@ -150,11 +150,13 @@ describe LogStash::Api::Modules::NodeStats do
        },
        "batch" => {
          "event_count" => {
+           "current" => Numeric,
            "average" => {
              "lifetime" => Numeric
            }
          },
          "byte_size" => {
+           "current" => Numeric,
            "average" => {
              "lifetime" => Numeric
            }

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -691,20 +691,20 @@ public class AbstractPipelineExt extends RubyBasicObject {
         return Optional.of((NumberGauge) delegatingGauge.getMetric().get());
     }
 
-    private Optional<TextGauge> initOrGetTextGaugeMetric(final ThreadContext context,
-                                                         final RubySymbol[] subPipelineNamespacePath,
-                                                         final RubySymbol metricName) {
-        final IRubyObject collector = this.metric.collector(context);
-        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
-        final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, metricName, context.runtime.newSymbol("gauge")});
-
-        LazyDelegatingGauge delegatingGauge = retrievedMetric.toJava(LazyDelegatingGauge.class);
-        if (Objects.isNull(delegatingGauge.getType()) || delegatingGauge.getType() != MetricType.GAUGE_TEXT) {
-            return Optional.empty();
-        }
-
-        return Optional.of((TextGauge) delegatingGauge.getMetric().get());
-    }
+//    private Optional<TextGauge> initOrGetTextGaugeMetric(final ThreadContext context,
+//                                                         final RubySymbol[] subPipelineNamespacePath,
+//                                                         final RubySymbol metricName) {
+//        final IRubyObject collector = this.metric.collector(context);
+//        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
+//        final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, metricName, context.runtime.newSymbol("gauge")});
+//
+//        LazyDelegatingGauge delegatingGauge = retrievedMetric.toJava(LazyDelegatingGauge.class);
+//        if (Objects.isNull(delegatingGauge.getType()) || delegatingGauge.getType() != MetricType.GAUGE_TEXT) {
+//            return Optional.empty();
+//        }
+//
+//        return Optional.of((TextGauge) delegatingGauge.getMetric().get());
+//    }
 
     private UptimeMetric initOrGetUptimeMetric(final ThreadContext context,
                                                final RubySymbol[] subPipelineNamespacePath,

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -608,14 +608,6 @@ public class AbstractPipelineExt extends RubyBasicObject {
         final FlowMetric byteSizePerBatch = createFlowMetric(BATCH_AVERAGE_KEY, totalBytes, batchCounter);
         this.scopedFlowMetrics.register(ScopedFlowMetrics.Scope.WORKER, byteSizePerBatch);
         storeMetric(context, batchSizeNamespace, byteSizePerBatch);
-
-//        initOrGetTextGaugeMetric(context, buildNamespace(BATCH_KEY), BATCH_CURRENT_KEY);
-//        Optional<TextGauge> textGauge = initOrGetTextGaugeMetric(context, buildNamespace(BATCH_KEY), BATCH_CURRENT_KEY);
-//        if (textGauge.isPresent()) {
-//            storeMetric(context, batchSizeNamespace, textGauge.get());
-//        } else {
-//            LOGGER.warn("Unable to initialize batch.current gauge, it will not be available");
-//        }
     }
 
     private boolean isBatchMetricsEnabled(ThreadContext context) {
@@ -690,21 +682,6 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
         return Optional.of((NumberGauge) delegatingGauge.getMetric().get());
     }
-
-//    private Optional<TextGauge> initOrGetTextGaugeMetric(final ThreadContext context,
-//                                                         final RubySymbol[] subPipelineNamespacePath,
-//                                                         final RubySymbol metricName) {
-//        final IRubyObject collector = this.metric.collector(context);
-//        final IRubyObject fullNamespace = pipelineNamespacedPath(subPipelineNamespacePath);
-//        final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, metricName, context.runtime.newSymbol("gauge")});
-//
-//        LazyDelegatingGauge delegatingGauge = retrievedMetric.toJava(LazyDelegatingGauge.class);
-//        if (Objects.isNull(delegatingGauge.getType()) || delegatingGauge.getType() != MetricType.GAUGE_TEXT) {
-//            return Optional.empty();
-//        }
-//
-//        return Optional.of((TextGauge) delegatingGauge.getMetric().get());
-//    }
 
     private UptimeMetric initOrGetUptimeMetric(final ThreadContext context,
                                                final RubySymbol[] subPipelineNamespacePath,

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
@@ -73,7 +73,6 @@ class QueueReadClientBatchMetrics {
             pipelineMetricBatchCount.increment();
             pipelineMetricBatchTotalEvents.increment(batch.filteredSize());
             pipelineMetricBatchByteSize.increment(totalSize);
-//            currentBatchDimensions.set(String.format("%d-%d", batch.filteredSize(), totalSize));
             currentBatchDimensions.set(Arrays.asList(batch.filteredSize(), totalSize));
         } catch (IllegalArgumentException e) {
             LOG.error("Failed to calculate batch byte size for metrics", e);

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
@@ -43,12 +43,13 @@ class QueueReadClientBatchMetrics {
     }
 
     public void updateBatchMetrics(QueueBatch batch) {
-        if (batch.events().isEmpty()) {
-            // avoid to increment batch count for empty batches
+        if (batchMetricMode == QueueFactoryExt.BatchMetricMode.DISABLED) {
             return;
         }
 
-        if (batchMetricMode == QueueFactoryExt.BatchMetricMode.DISABLED) {
+        if (batch.events().isEmpty()) {
+            // avoid to increment batch count for empty batches
+            currentBatchDimensions.set(Arrays.asList(0L, 0L));
             return;
         }
 

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
@@ -10,6 +10,7 @@ import org.logstash.instrument.metrics.counter.LongCounter;
 import org.logstash.instrument.metrics.gauge.LazyDelegatingGauge;
 
 import java.security.SecureRandom;
+import java.util.Arrays;
 
 import static org.logstash.instrument.metrics.MetricKeys.*;
 
@@ -72,7 +73,8 @@ class QueueReadClientBatchMetrics {
             pipelineMetricBatchCount.increment();
             pipelineMetricBatchTotalEvents.increment(batch.filteredSize());
             pipelineMetricBatchByteSize.increment(totalSize);
-            currentBatchDimensions.set(String.format("%d-%d", batch.filteredSize(), totalSize));
+//            currentBatchDimensions.set(String.format("%d-%d", batch.filteredSize(), totalSize));
+            currentBatchDimensions.set(Arrays.asList(batch.filteredSize(), totalSize));
         } catch (IllegalArgumentException e) {
             LOG.error("Failed to calculate batch byte size for metrics", e);
         }

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
@@ -48,7 +48,7 @@ class QueueReadClientBatchMetrics {
         }
 
         if (batch.events().isEmpty()) {
-            // avoid to increment batch count for empty batches
+            // don't update averages for empty batches, but set current back to zero
             currentBatchDimensions.set(Arrays.asList(0L, 0L));
             return;
         }

--- a/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
+++ b/logstash-core/src/main/java/org/logstash/execution/QueueReadClientBatchMetrics.java
@@ -67,14 +67,14 @@ class QueueReadClientBatchMetrics {
     private void updateBatchSizeMetric(QueueBatch batch) {
         try {
             // if an error occurs in estimating the size of the batch, no counter has to be updated
-            long totalSize = 0L;
+            long totalByteSize = 0L;
             for (JrubyEventExtLibrary.RubyEvent rubyEvent : batch.events()) {
-                totalSize += rubyEvent.getEvent().estimateMemory();
+                totalByteSize += rubyEvent.getEvent().estimateMemory();
             }
             pipelineMetricBatchCount.increment();
             pipelineMetricBatchTotalEvents.increment(batch.filteredSize());
-            pipelineMetricBatchByteSize.increment(totalSize);
-            currentBatchDimensions.set(Arrays.asList(batch.filteredSize(), totalSize));
+            pipelineMetricBatchByteSize.increment(totalByteSize);
+            currentBatchDimensions.set(Arrays.asList(batch.filteredSize(), totalByteSize));
         } catch (IllegalArgumentException e) {
             LOG.error("Failed to calculate batch byte size for metrics", e);
         }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
@@ -52,7 +52,7 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
     private static final RubySymbol DECREMENT = RubyUtil.RUBY.newSymbol("decrement");
 
-    private static final RubySymbol GAUGE = RubyUtil.RUBY.newSymbol("gauge");
+    public static final RubySymbol GAUGE = RubyUtil.RUBY.newSymbol("gauge");
     private static final RubySymbol TIMER = RubyUtil.RUBY.newSymbol("timer");
     private static final RubySymbol SET = RubyUtil.RUBY.newSymbol("set");
     private static final RubySymbol GET = RubyUtil.RUBY.newSymbol("get");

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
@@ -44,15 +44,15 @@ public final class MetricExt extends AbstractSimpleMetricExt {
 
     private static final long serialVersionUID = 1L;
 
-    public static final RubySymbol COUNTER = RubyUtil.RUBY.newSymbol("counter");
+    // These two metric type symbols need to be package-private because used in NamespacedMetricExt
+    static final RubySymbol COUNTER = RubyUtil.RUBY.newSymbol("counter");
+    static final RubySymbol GAUGE = RubyUtil.RUBY.newSymbol("gauge");
 
     private static final RubyFixnum ONE = RubyUtil.RUBY.newFixnum(1);
 
     private static final RubySymbol INCREMENT = RubyUtil.RUBY.newSymbol("increment");
 
     private static final RubySymbol DECREMENT = RubyUtil.RUBY.newSymbol("decrement");
-
-    public static final RubySymbol GAUGE = RubyUtil.RUBY.newSymbol("gauge");
     private static final RubySymbol TIMER = RubyUtil.RUBY.newSymbol("timer");
     private static final RubySymbol SET = RubyUtil.RUBY.newSymbol("set");
     private static final RubySymbol GET = RubyUtil.RUBY.newSymbol("get");

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -131,4 +131,6 @@ public final class MetricKeys {
 
     public static final RubySymbol BATCH_BYTE_SIZE_KEY = RubyUtil.RUBY.newSymbol("byte_size");
 
+    public static final RubySymbol BATCH_CURRENT_KEY = RubyUtil.RUBY.newSymbol("current");
+
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -76,7 +76,7 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
     @Override
     protected IRubyObject getGauge(final ThreadContext context, final IRubyObject key,
         final IRubyObject value) {
-//        return metric.gauge(context, namespaceName, key, value);
+        metric.gauge(context, namespaceName, key, value);
         return collector(context).callMethod(
                 context, "get", new IRubyObject[]{namespaceName, key, MetricExt.GAUGE}
         );

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -76,7 +76,10 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
     @Override
     protected IRubyObject getGauge(final ThreadContext context, final IRubyObject key,
         final IRubyObject value) {
-        return metric.gauge(context, namespaceName, key, value);
+//        return metric.gauge(context, namespaceName, key, value);
+        return collector(context).callMethod(
+                context, "get", new IRubyObject[]{namespaceName, key, MetricExt.GAUGE}
+        );
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -23,8 +23,13 @@ package org.logstash.instrument.metrics.gauge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jruby.RubyHash;
+import org.jruby.RubySymbol;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
 import org.logstash.ext.JrubyTimestampExtLibrary.RubyTimestamp;
 import org.logstash.instrument.metrics.AbstractMetric;
+import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricType;
 
 import java.util.List;
@@ -39,10 +44,27 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
 
     private static final Logger LOGGER = LogManager.getLogger(LazyDelegatingGauge.class);
 
+    public static final LazyDelegatingGauge DUMMY_GAUGE = new LazyDelegatingGauge("dummy");
+
     protected final String key;
 
     @SuppressWarnings("rawtypes")
     private GaugeMetric lazyMetric;
+
+
+    public static LazyDelegatingGauge fromRubyBase(final AbstractNamespacedMetricExt metric, final RubySymbol key) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+        // just initialize an empty gauge
+        final IRubyObject gauge = metric.gauge(context, key, context.runtime.newString("undefined"));
+//        gauge.callMethod(context, "set", context.runtime.newString("zero"));
+        final LazyDelegatingGauge javaGauge;
+        if (LazyDelegatingGauge.class.isAssignableFrom(gauge.getJavaClass())) {
+            javaGauge = gauge.toJava(LazyDelegatingGauge.class);
+        } else {
+            javaGauge = DUMMY_GAUGE;
+        }
+        return javaGauge;
+    }
 
     /**
      * Constructor - null initial value

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -57,7 +57,6 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         // just initialize an empty gauge
         final IRubyObject gauge = metric.gauge(context, key, context.runtime.newArray(context.runtime.newString("undefined"), context.runtime.newString("undefined")));
-//        gauge.callMethod(context, "set", context.runtime.newString("zero"));
         final LazyDelegatingGauge javaGauge;
         if (LazyDelegatingGauge.class.isAssignableFrom(gauge.getJavaClass())) {
             javaGauge = gauge.toJava(LazyDelegatingGauge.class);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/gauge/LazyDelegatingGauge.java
@@ -32,6 +32,7 @@ import org.logstash.instrument.metrics.AbstractMetric;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
 import org.logstash.instrument.metrics.MetricType;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,7 +56,7 @@ public class LazyDelegatingGauge extends AbstractMetric<Object> implements Gauge
     public static LazyDelegatingGauge fromRubyBase(final AbstractNamespacedMetricExt metric, final RubySymbol key) {
         final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
         // just initialize an empty gauge
-        final IRubyObject gauge = metric.gauge(context, key, context.runtime.newString("undefined"));
+        final IRubyObject gauge = metric.gauge(context, key, context.runtime.newArray(context.runtime.newString("undefined"), context.runtime.newString("undefined")));
 //        gauge.callMethod(context, "set", context.runtime.newString("zero"));
         final LazyDelegatingGauge javaGauge;
         if (LazyDelegatingGauge.class.isAssignableFrom(gauge.getJavaClass())) {

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MockNamespacedMetric.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MockNamespacedMetric.java
@@ -9,6 +9,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
 import org.logstash.instrument.metrics.counter.LongCounter;
+import org.logstash.instrument.metrics.gauge.LazyDelegatingGauge;
 import org.logstash.instrument.metrics.timer.TimerMetric;
 
 import java.util.Objects;
@@ -36,7 +37,9 @@ public class MockNamespacedMetric extends AbstractNamespacedMetricExt {
 
     @Override
     protected IRubyObject getGauge(ThreadContext context, IRubyObject key, IRubyObject value) {
-        return null;
+        Objects.requireNonNull(key);
+        requireRubySymbol(key, "key");
+        return RubyUtil.toRubyObject(metrics.computeIfAbsent(key.asJavaString(), LazyDelegatingGauge::new));
     }
 
     @Override

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -269,11 +269,17 @@ describe "Test Monitoring API" do
           expect(batch_stats["event_count"]["average"]["lifetime"]).to be_a_kind_of(Numeric)
           expect(batch_stats["event_count"]["average"]["lifetime"]).to be > 0
 
+          expect(batch_stats["event_count"]["current"]).not_to be_nil
+          expect(batch_stats["event_count"]["current"]).to be >= 0
+
           expect(batch_stats["byte_size"]).not_to be_nil
           expect(batch_stats["byte_size"]["average"]).not_to be_nil
           expect(batch_stats["byte_size"]["average"]["lifetime"]).not_to be_nil
           expect(batch_stats["byte_size"]["average"]["lifetime"]).to be_a_kind_of(Numeric)
           expect(batch_stats["byte_size"]["average"]["lifetime"]).to be > 0
+
+          expect(batch_stats["byte_size"]["current"]).not_to be_nil
+          expect(batch_stats["byte_size"]["current"]).to be >= 0
         end
       end
     end


### PR DESCRIPTION
## Release notes
Implements current batch event count and byte size metrics.


## What does this PR do?

Introduce a new gauge metric to collect list of values, used a a couple, the first element count of events in the batch and the second one is the estimated memory occupation of the batch.
This list is later grabbed in the API layer to populate the two `current` values for `event_count` and `batch_size`.

## Why is it important/What is the impact to the user?

Exposes the current batch size in terms of events and estimated memory consumption.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Start Logstash with `pipeline.batch.metrics.sampling_mode` set to `full` running an HTTP input pipeline, load it with `wrk` and verify that the metric API `pipelines.main.batch.event_count.current` and `pipelines.main.batch.byte_size.current` goes down to 0 when `wrk` is interrupted and gets a value other than 0 when the load `wrk` resumes.


1. Create a file named `input_sample.txt` with some content
2. Create a script `send_file.lua` as
```lua
wrk.method = "POST"
local f = io.open("input_sample.txt", "r")
wrk.body   = f:read("*all")%
```
3. enable the metric in `config/logstash.yml`:
```yaml
pipeline.batch.metrics.sampling_mode: full
```
4. run Logstash with pipeline:
```
input {
  http {
    response_headers => {"Content-Type" => "application/json"}
    ecs_compatibility => disabled
  }
}
output {
  sink {}
}
```
5. open a shell to verify the metrics on Logstash:
```sh
while true; do curl http://localhost:9600/_node/stats | jq .pipelines.main.batch; sleep 1; clear; done
```
6. start and stop `wrk`, checking the metrics:
```sh
wrk --threads 4 --connections 12 -d10m -s send_file.lua --latency http://localhost:8080
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #17997 
- Relates #18000 

