### PR TITLE
PQ settings refactor: propagate builder upward

### DIFF
--- a/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
+++ b/logstash-core/spec/logstash/acked_queue_concurrent_stress_spec.rb
@@ -28,8 +28,17 @@ describe LogStash::WrappedAckedQueue, :stress_test => true do
     let(:output_strings) { [] }
     let(:reject_memo_keys) { [:reject_memo_keys, :path, :queue, :writer_threads, :collector, :metric, :reader_threads, :output_strings] }
 
+    let(:queue_settings) do
+      LogStash::AckedQueue.file_settings_builder(path)
+                          .capacity(page_capacity)
+                          .checkpointMaxAcks(queue_checkpoint_acks)
+                          .checkpointMaxWrites(queue_checkpoint_writes)
+                          .queueMaxBytes(queue_capacity)
+                          .build
+    end
+
     let(:queue) do
-      described_class.new(path, page_capacity, 0, queue_checkpoint_acks, queue_checkpoint_writes, false, queue_capacity)
+      described_class.new(queue_settings)
     end
 
     let(:writer_threads) do

--- a/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
+++ b/logstash-core/spec/logstash/instrument/wrapped_write_client_spec.rb
@@ -125,7 +125,18 @@ describe LogStash::WrappedWriteClient do
 
   context "WrappedAckedQueue" do
     let(:path) { Stud::Temporary.directory }
-    let(:queue) { LogStash::WrappedAckedQueue.new(path, 1024, 10, 1024, 1024, false, 4096) }
+
+    let(:queue_settings) do
+      LogStash::AckedQueue.file_settings_builder(path)
+         .capacity(1024)
+         .maxUnread(10)
+         .checkpointMaxAcks(1024)
+         .checkpointMaxWrites(1024)
+         .queueMaxBytes(4096)
+         .build
+    end
+
+    let(:queue) { LogStash::WrappedAckedQueue.new(queue_settings) }
 
     before do
       read_client.set_events_metric(metric.namespace([:stats, :events]))

--- a/logstash-core/spec/logstash/util/wrapped_acked_queue_spec.rb
+++ b/logstash-core/spec/logstash/util/wrapped_acked_queue_spec.rb
@@ -53,7 +53,18 @@ describe LogStash::WrappedAckedQueue do
     let(:checkpoint_acks) { 1024 }
     let(:checkpoint_writes) { 1024 }
     let(:path) { Stud::Temporary.directory }
-    let(:queue) { LogStash::WrappedAckedQueue.new(path, page_capacity, max_events, checkpoint_acks, checkpoint_writes, false, max_bytes) }
+
+    let(:queue_settings) do
+      LogStash::AckedQueue.file_settings_builder(path)
+                          .capacity(page_capacity)
+                          .maxUnread(max_events)
+                          .checkpointMaxAcks(checkpoint_acks)
+                          .checkpointMaxWrites(checkpoint_writes)
+                          .queueMaxBytes(max_bytes)
+                          .build
+    end
+
+    let(:queue) { LogStash::WrappedAckedQueue.new(queue_settings) }
 
     after do
       queue.close

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/Settings.java
@@ -20,6 +20,9 @@
 
 package org.logstash.ackedqueue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Persistent queue settings definition.
  * */
@@ -40,6 +43,32 @@ public interface Settings {
     int getCheckpointMaxWrites();
 
     boolean getCheckpointRetry();
+
+    /**
+     * Validate and return the settings, or throw descriptive {@link QueueRuntimeException}
+     * @param settings the settings to validate
+     * @return the settings that were provided
+     */
+    static Settings ensureValid(final Settings settings) {
+        final List<String> errors = new ArrayList<>();
+
+        if (settings == null) {
+            errors.add("settings cannot be null");
+        } else {
+            if (settings.getDirPath() == null) {
+                errors.add("dirPath cannot be null");
+            }
+            if (settings.getElementClass() == null) {
+                errors.add("elementClass cannot be null");
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new QueueRuntimeException(String.format("Invalid Queue Settings: %s", errors));
+        }
+
+        return settings;
+    }
 
     /**
      * Persistent queue Setting's fluent builder definition

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
@@ -213,7 +213,7 @@ public class SettingsImpl implements Settings {
 
         @Override
         public Settings build() {
-            return new SettingsImpl(this);
+            return Settings.ensureValid(new SettingsImpl(this));
         }
 
         private Builder mutate(final Consumer<MutableBuilder> mutator) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/SettingsImpl.java
@@ -17,23 +17,20 @@
  * under the License.
  */
 
-
 package org.logstash.ackedqueue;
-
-import java.util.function.Consumer;
 
 /**
  * Persistent queue settings implementation.
  * */
 public class SettingsImpl implements Settings {
-    private String dirForFiles;
-    private Class<? extends Queueable> elementClass;
-    private int capacity;
-    private long queueMaxBytes;
-    private int maxUnread;
-    private int checkpointMaxAcks;
-    private int checkpointMaxWrites;
-    private boolean checkpointRetry;
+    private final String dirForFiles;
+    private final Class<? extends Queueable> elementClass;
+    private final int capacity;
+    private final long queueMaxBytes;
+    private final int maxUnread;
+    private final int checkpointMaxAcks;
+    private final int checkpointMaxWrites;
+    private final boolean checkpointRetry;
 
     public static Builder builder(final Settings settings) {
         return new BuilderImpl(settings);
@@ -129,19 +126,19 @@ public class SettingsImpl implements Settings {
 
         private final String dirForFiles;
 
-        private final Class<? extends Queueable> elementClass;
+        private Class<? extends Queueable> elementClass;
 
-        private final int capacity;
+        private int capacity;
 
-        private final long queueMaxBytes;
+        private long queueMaxBytes;
 
-        private final int maxUnread;
+        private int maxUnread;
 
-        private final int checkpointMaxAcks;
+        private int checkpointMaxAcks;
 
-        private final int checkpointMaxWrites;
+        private int checkpointMaxWrites;
 
-        private final boolean checkpointRetry;
+        private boolean checkpointRetry;
 
         private BuilderImpl(final String dirForFiles) {
             this.dirForFiles = dirForFiles;
@@ -165,80 +162,51 @@ public class SettingsImpl implements Settings {
             this.checkpointRetry = settings.getCheckpointRetry();
         }
 
-        private BuilderImpl(final MutableBuilder mutableBuilder) {
-            this.dirForFiles = mutableBuilder.dirForFiles;
-            this.elementClass = mutableBuilder.elementClass;
-            this.capacity = mutableBuilder.capacity;
-            this.queueMaxBytes = mutableBuilder.queueMaxBytes;
-            this.maxUnread = mutableBuilder.maxUnread;
-            this.checkpointMaxAcks = mutableBuilder.checkpointMaxAcks;
-            this.checkpointMaxWrites = mutableBuilder.checkpointMaxWrites;
-            this.checkpointRetry = mutableBuilder.checkpointRetry;
-        }
-
         @Override
         public Builder elementClass(final Class<? extends Queueable> elementClass) {
-            return mutate(mutable -> mutable.elementClass = elementClass);
+            this.elementClass = elementClass;
+            return this;
         }
 
         @Override
         public Builder capacity(final int capacity) {
-            return mutate(mutable -> mutable.capacity = capacity);
+            this.capacity = capacity;
+            return this;
         }
 
         @Override
         public Builder queueMaxBytes(final long size) {
-            return mutate(mutable -> mutable.queueMaxBytes = size);
+            this.queueMaxBytes = size;
+            return this;
         }
 
         @Override
         public Builder maxUnread(final int maxUnread) {
-            return mutate(mutable -> mutable.maxUnread = maxUnread);
+            this.maxUnread = maxUnread;
+            return this;
         }
 
         @Override
         public Builder checkpointMaxAcks(final int checkpointMaxAcks) {
-            return mutate(mutable -> mutable.checkpointMaxAcks = checkpointMaxAcks);
+            this.checkpointMaxAcks = checkpointMaxAcks;
+            return this;
         }
 
         @Override
         public Builder checkpointMaxWrites(final int checkpointMaxWrites) {
-            return mutate(mutable -> mutable.checkpointMaxWrites = checkpointMaxWrites);
+            this.checkpointMaxWrites = checkpointMaxWrites;
+            return this;
         }
 
         @Override
         public Builder checkpointRetry(final boolean checkpointRetry) {
-            return mutate(mutable -> mutable.checkpointRetry = checkpointRetry);
+            this.checkpointRetry = checkpointRetry;
+            return this;
         }
 
         @Override
         public Settings build() {
             return Settings.ensureValid(new SettingsImpl(this));
-        }
-
-        private Builder mutate(final Consumer<MutableBuilder> mutator) {
-            final MutableBuilder mutableBuilder = new MutableBuilder();
-            mutator.accept(mutableBuilder);
-            return mutableBuilder.toBuilder();
-        }
-
-        /**
-         * A {@link MutableBuilder} is an internal detail of the <em>immutable</em> {@link BuilderImpl}
-         * that allows its private {@link BuilderImpl#mutate} to work with a temporary mutable copy.
-         */
-        private class MutableBuilder {
-            protected String dirForFiles = BuilderImpl.this.dirForFiles;
-            protected Class<? extends Queueable> elementClass = BuilderImpl.this.elementClass;
-            protected int capacity = BuilderImpl.this.capacity;
-            protected long queueMaxBytes = BuilderImpl.this.queueMaxBytes;
-            protected int maxUnread = BuilderImpl.this.maxUnread;
-            protected int checkpointMaxAcks = BuilderImpl.this.checkpointMaxAcks;
-            protected int checkpointMaxWrites = BuilderImpl.this.checkpointMaxWrites;
-            protected boolean checkpointRetry = BuilderImpl.this.checkpointRetry;
-
-            Builder toBuilder() {
-                return new BuilderImpl(this);
-            }
         }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyAckedQueueExt.java
@@ -31,6 +31,7 @@ import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.Event;
@@ -39,6 +40,7 @@ import org.logstash.ackedqueue.AckedBatch;
 import org.logstash.ackedqueue.Batch;
 import org.logstash.ackedqueue.Queue;
 import org.logstash.ackedqueue.QueueExceptionMessages;
+import org.logstash.ackedqueue.Settings;
 import org.logstash.ackedqueue.SettingsImpl;
 
 /**
@@ -60,27 +62,27 @@ public final class JRubyAckedQueueExt extends RubyObject {
         return this.queue;
     }
 
-    public static JRubyAckedQueueExt create(String path, int capacity, int maxEvents, int checkpointMaxWrites,
-                                            int checkpointMaxAcks, boolean checkpointRetry, long maxBytes) {
+    public static JRubyAckedQueueExt create(final Settings settings) {
         JRubyAckedQueueExt queueExt = new JRubyAckedQueueExt(RubyUtil.RUBY, RubyUtil.ACKED_QUEUE_CLASS);
-        queueExt.initializeQueue(path, capacity, maxEvents, checkpointMaxWrites, checkpointMaxAcks, checkpointRetry,
-                maxBytes);
+        queueExt.queue = new Queue(settings);
         return queueExt;
     }
 
-    private void initializeQueue(String path, int capacity, int maxEvents, int checkpointMaxWrites,
-                                 int checkpointMaxAcks, boolean checkpointRetry, long maxBytes) {
-        this.queue = new Queue(
-                SettingsImpl.fileSettingsBuilder(path)
-                        .capacity(capacity)
-                        .maxUnread(maxEvents)
-                        .queueMaxBytes(maxBytes)
-                        .checkpointMaxAcks(checkpointMaxAcks)
-                        .checkpointMaxWrites(checkpointMaxWrites)
-                        .checkpointRetry(checkpointRetry)
-                        .elementClass(Event.class)
-                        .build()
-        );
+    /**
+     * Helper method for retrieving a ruby-usable {@link Settings.Builder} with the provided path as its directory,
+     * using {@link Event} as its element-type.
+     *
+     * @param context the ruby thread context
+     * @param recv noop receiver (will be rubified LogStash::AckedQueue class)
+     * @param path the path to the queue
+     * @return a ruby-usable proxy for {@link Settings.Builder}
+     */
+    @JRubyMethod(meta = true, name = "file_settings_builder")
+    public static IRubyObject fileSettingsBuilder(final ThreadContext context, IRubyObject recv, final RubyString path) {
+        final Settings.Builder settingsBuilder = SettingsImpl
+                .fileSettingsBuilder(path.asJavaString())
+                .elementClass(Event.class);
+        return JavaUtil.convertJavaToRuby(context.runtime, settingsBuilder);
     }
 
     @JRubyMethod(name = "max_unread_events")

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -25,13 +25,13 @@ import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.Arity;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.logstash.RubyUtil;
+import org.logstash.ackedqueue.Settings;
 import org.logstash.execution.AbstractWrappedQueueExt;
 import org.logstash.execution.QueueReadClientBase;
 import org.logstash.ext.JRubyAbstractQueueWriteClientExt;
@@ -49,21 +49,32 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
 
     private JRubyAckedQueueExt queue;
 
-    @JRubyMethod(optional = 8)
-    public JRubyWrappedAckedQueueExt initialize(ThreadContext context, IRubyObject[] args) throws IOException {
-        args = Arity.scanArgs(context.runtime, args, 7, 0);
-        int capacity = RubyFixnum.num2int(args[1]);
-        int maxEvents = RubyFixnum.num2int(args[2]);
-        int checkpointMaxWrites = RubyFixnum.num2int(args[3]);
-        int checkpointMaxAcks = RubyFixnum.num2int(args[4]);
-        boolean checkpointRetry = !((RubyBoolean) args[5]).isFalse();
-        long queueMaxBytes = RubyFixnum.num2long(args[6]);
-
-        this.queue = JRubyAckedQueueExt.create(args[0].asJavaString(), capacity, maxEvents,
-                checkpointMaxWrites, checkpointMaxAcks, checkpointRetry, queueMaxBytes);
+    @JRubyMethod(required=1)
+    public JRubyWrappedAckedQueueExt initialize(ThreadContext context, IRubyObject settings) throws IOException {
+        if (JavaUtil.isJavaObject(settings)) {
+            this.queue = JRubyAckedQueueExt.create(JavaUtil.unwrapJavaObject(settings));
+        } else {
+            // We should never get here, but previously had an initialize method
+            // that took 7 technically-optional ordered parameters.
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Failed to instantiate JRubyWrappedAckedQueueExt with <%s:%s>",
+                            settings.getClass().getName(),
+                            settings));
+        }
         this.queue.open();
 
         return this;
+    }
+
+    public static JRubyWrappedAckedQueueExt create(ThreadContext context, Settings settings) throws IOException {
+        return new JRubyWrappedAckedQueueExt(context.runtime, RubyUtil.WRAPPED_ACKED_QUEUE_CLASS, settings);
+    }
+
+    public JRubyWrappedAckedQueueExt(Ruby runtime, RubyClass metaClass, Settings settings) throws IOException {
+        super(runtime, metaClass);
+        this.queue = JRubyAckedQueueExt.create(settings);
+        this.queue.open();
     }
 
     public JRubyWrappedAckedQueueExt(final Ruby runtime, final RubyClass metaClass) {

--- a/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
+++ b/logstash-core/src/main/java/org/logstash/ackedqueue/ext/JRubyWrappedAckedQueueExt.java
@@ -51,9 +51,7 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
 
     @JRubyMethod(required=1)
     public JRubyWrappedAckedQueueExt initialize(ThreadContext context, IRubyObject settings) throws IOException {
-        if (JavaUtil.isJavaObject(settings)) {
-            this.queue = JRubyAckedQueueExt.create(JavaUtil.unwrapJavaObject(settings));
-        } else {
+        if (!JavaUtil.isJavaObject(settings)) {
             // We should never get here, but previously had an initialize method
             // that took 7 technically-optional ordered parameters.
             throw new IllegalArgumentException(
@@ -62,6 +60,7 @@ public final class JRubyWrappedAckedQueueExt extends AbstractWrappedQueueExt {
                             settings.getClass().getName(),
                             settings));
         }
+        this.queue = JRubyAckedQueueExt.create(JavaUtil.unwrapJavaObject(settings));
         this.queue.open();
 
         return this;


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?

This is an internal no-net-change refactor to pull upward the use of the `org.logstash.ackedqueue.Settings` into the JRuby queue extension classes, pared off of the existing PR #18121.

## Why is it important/What is the impact to the user?

There is no net change to the user.

The changes here underly code that is also going to need changes in @andsel 's current in-flight work. Paring it off as a separate PR unblocks his work.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

No net change. Rely on existing test coverage and usage.

## Related issues

 - Relates: #18121 
 - Relates: #18000

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
