### PR TITLE
Remove redundant testing and circular dependency from docker acceptance testing

### DIFF
--- a/.buildkite/scripts/dra/build_docker.sh
+++ b/.buildkite/scripts/dra/build_docker.sh
@@ -24,6 +24,9 @@ esac
 rake artifact:docker || error "artifact:docker build failed."
 rake artifact:docker_oss || error "artifact:docker_oss build failed."
 rake artifact:docker_wolfi || error "artifact:docker_wolfi build failed."
+
+# Generating public dockerfiles is the primary use case for NOT using local artifacts
+export LOCAL_ARTIFACTS=false
 rake artifact:dockerfiles || error "artifact:dockerfiles build failed."
 
 STACK_VERSION="$(./$(dirname "$0")/../common/qualified-version.sh)"

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -8,6 +8,9 @@ set -x
 export JRUBY_OPTS="-J-Xmx1g"
 export GRADLE_OPTS="-Xmx4g -Dorg.gradle.console=plain -Dorg.gradle.daemon=false -Dorg.gradle.logging.level=info -Dfile.encoding=UTF-8"
 
+# Use local artifacts for acceptance test Docker builds
+export LOCAL_ARTIFACTS=true
+
 if [ -n "$BUILD_JAVA_HOME" ]; then
   GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.java.home=$BUILD_JAVA_HOME"
 fi
@@ -48,7 +51,7 @@ if [[ $SELECTED_TEST_SUITE == "oss" ]]; then
 elif [[ $SELECTED_TEST_SUITE == "full" ]]; then
   echo "--- Building $SELECTED_TEST_SUITE docker images"
   cd $LS_HOME
-  rake artifact:build_docker_full
+  rake artifact:docker
   echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -132,23 +132,11 @@ public-dockerfiles_full: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		version_tag="${VERSION_TAG}" \
 		release="${RELEASE}" \
 		image_flavor="full" \
-		local_artifacts="false" \
+		local_artifacts="$(or $(LOCAL_ARTIFACTS),false)" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-full" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-full Dockerfile && \
 	tar -zcf ../logstash-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
-
-build-from-dockerfiles_full: public-dockerfiles_full
-	cd $(ARTIFACTS_DIR)/docker && \
-	mkdir -p dockerfile_build_full && cd dockerfile_build_full && \
-	tar -zxf ../../logstash-$(VERSION_TAG)-docker-build-context.tar.gz && \
-	cp ../../logstash-$(VERSION_TAG)-linux-$(ARCHITECTURE).tar.gz . && \
-	awk '/# Add Logstash itself and set permissions/{print; print "COPY logstash-$(VERSION_TAG)-linux-$(ARCHITECTURE).tar.gz /tmp/logstash.tar.gz"; next}1' Dockerfile > Dockerfile.tmp && \
-	sed '/curl --fail --location --output logstash.tar.gz.*tar.gz &&/d' Dockerfile.tmp > Dockerfile.tmp2 && \
-	sed 's|tar -zxf logstash.tar.gz|tar -zxf /tmp/logstash.tar.gz|' Dockerfile.tmp2 > Dockerfile.tmp3 && \
-	sed 's|rm logstash.tar.gz|rm /tmp/logstash.tar.gz|' Dockerfile.tmp3 > Dockerfile && \
-	rm -f Dockerfile.tmp* && \
-	docker build --progress=plain --network=host -t $(IMAGE_TAG)-dockerfile-full:$(VERSION_TAG) .
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -158,18 +146,11 @@ public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		version_tag="${VERSION_TAG}" \
 		release="${RELEASE}" \
 		image_flavor="oss" \
-		local_artifacts="false" \
+		local_artifacts="$(or $(LOCAL_ARTIFACTS),false)" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-oss" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-oss Dockerfile && \
 	tar -zcf ../logstash-oss-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
-
-build-from-dockerfiles_oss: public-dockerfiles_oss
-	cd $(ARTIFACTS_DIR)/docker && \
-	mkdir -p dockerfile_build_oss && cd dockerfile_build_oss && \
-	tar -zxf ../../logstash-$(VERSION_TAG)-docker-build-context.tar.gz && \
-	sed 's/artifacts/snapshots/g' Dockerfile > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile && \
-	docker build --progress=plain --network=host -t $(IMAGE_TAG)-dockerfile-oss:$(VERSION_TAG) .
 
 public-dockerfiles_wolfi: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -179,18 +160,11 @@ public-dockerfiles_wolfi: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 		version_tag="${VERSION_TAG}" \
 		release="${RELEASE}" \
 		image_flavor="wolfi" \
-		local_artifacts="false" \
+		local_artifacts="$(or $(LOCAL_ARTIFACTS),false)" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-wolfi" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-wolfi Dockerfile && \
 	tar -zcf ../logstash-wolfi-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
-
-build-from-dockerfiles_wolfi: public-dockerfiles_wolfi
-	cd $(ARTIFACTS_DIR)/docker && \
-	mkdir -p dockerfile_build_wolfi && cd dockerfile_build_wolfi && \
-	tar -zxf ../../logstash-$(VERSION_TAG)-docker-build-context.tar.gz && \
-	sed 's/artifacts/snapshots/g' Dockerfile > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile && \
-	docker build --progress=plain --network=host -t $(IMAGE_TAG)-dockerfile-wolfi:$(VERSION_TAG) .
 
 public-dockerfiles_observability-sre: templates/Dockerfile.erb docker_paths $(COPY_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -200,18 +174,11 @@ public-dockerfiles_observability-sre: templates/Dockerfile.erb docker_paths $(CO
 		version_tag="${VERSION_TAG}" \
 		release="${RELEASE}" \
 		image_flavor="observability-sre" \
-		local_artifacts="false" \
+		local_artifacts="$(or $(LOCAL_ARTIFACTS),false)" \
 		templates/Dockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-observability-sre" && \
 	cd $(ARTIFACTS_DIR)/docker && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-observability-sre Dockerfile && \
 	tar -zcf ../logstash-observability-sre-$(VERSION_TAG)-docker-build-context.tar.gz Dockerfile bin config env2yaml pipeline
-
-build-from-dockerfiles_observability-sre: public-dockerfiles_observability-sre
-	cd $(ARTIFACTS_DIR)/docker && \
-	mkdir -p dockerfile_build_observability-sre && cd dockerfile_build_observability-sre && \
-	tar -zxf ../../logstash-observability-sre-$(VERSION_TAG)-docker-build-context.tar.gz && \
-	sed 's/artifacts/snapshots/g' Dockerfile > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile && \
-	docker build --progress=plain --network=host -t $(IMAGE_TAG)-dockerfile-observability-sre:$(VERSION_TAG) .
 
 public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/IronbankDockerfile.erb ironbank_docker_paths $(COPY_IRONBANK_FILES)
 	../vendor/jruby/bin/jruby -S erb -T "-"\
@@ -224,7 +191,7 @@ public-dockerfiles_ironbank: templates/hardening_manifest.yaml.erb templates/Iro
 		version_tag="${VERSION_TAG}" \
 		release="${RELEASE}" \
 		image_flavor="ironbank" \
-		local_artifacts="false" \
+		local_artifacts="$(or $(LOCAL_ARTIFACTS),false)" \
 		templates/IronbankDockerfile.erb > "${ARTIFACTS_DIR}/Dockerfile-ironbank" && \
 	cd $(ARTIFACTS_DIR)/ironbank && \
 	cp $(ARTIFACTS_DIR)/Dockerfile-ironbank Dockerfile && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -142,7 +142,12 @@ build-from-dockerfiles_full: public-dockerfiles_full
 	cd $(ARTIFACTS_DIR)/docker && \
 	mkdir -p dockerfile_build_full && cd dockerfile_build_full && \
 	tar -zxf ../../logstash-$(VERSION_TAG)-docker-build-context.tar.gz && \
-	sed 's/artifacts/snapshots/g' Dockerfile > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile && \
+	cp ../../logstash-$(VERSION_TAG)-linux-$(ARCHITECTURE).tar.gz . && \
+	awk '/# Add Logstash itself and set permissions/{print; print "COPY logstash-$(VERSION_TAG)-linux-$(ARCHITECTURE).tar.gz /tmp/logstash.tar.gz"; next}1' Dockerfile > Dockerfile.tmp && \
+	sed '/curl --fail --location --output logstash.tar.gz.*tar.gz &&/d' Dockerfile.tmp > Dockerfile.tmp2 && \
+	sed 's|tar -zxf logstash.tar.gz|tar -zxf /tmp/logstash.tar.gz|' Dockerfile.tmp2 > Dockerfile.tmp3 && \
+	sed 's|rm logstash.tar.gz|rm /tmp/logstash.tar.gz|' Dockerfile.tmp3 > Dockerfile && \
+	rm -f Dockerfile.tmp* && \
 	docker build --progress=plain --network=host -t $(IMAGE_TAG)-dockerfile-full:$(VERSION_TAG) .
 
 public-dockerfiles_oss: templates/Dockerfile.erb docker_paths $(COPY_FILES)

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -169,7 +169,7 @@ namespace "artifact" do
 
   desc "Generate rpm, deb, tar and zip artifacts"
   task "all" => ["prepare", "build"]
-  task "docker_only" => ["prepare", "build_docker_full", "build_docker_oss", "build_docker_wolfi", "build_docker_observabilitySRE"]
+  task "docker_only" => ["prepare", "docker", "docker_oss", "docker_wolfi", "docker_observabilitySRE"]
 
   desc "Build all (jdk bundled and not) tar.gz and zip of default logstash plugins with all dependencies"
   task "archives" => ["prepare", "generate_build_metadata"] do
@@ -397,24 +397,10 @@ namespace "artifact" do
     build_dockerfile('oss')
   end
 
-  namespace "dockerfile_oss" do
-    desc "Build Oss Docker image from Dockerfile context files"
-    task "docker" => ["archives_docker", "dockerfile_oss"]  do
-      build_docker_from_dockerfiles('oss')
-    end
-  end
-
   desc "Generate Dockerfile for observability-sre images"
   task "dockerfile_observabilitySRE" => ["prepare-observabilitySRE", "generate_build_metadata"] do
     puts("[dockerfiles] Building observability-sre Dockerfile")
     build_dockerfile('observability-sre')
-  end
-
-  namespace "dockerfile_observabilitySRE" do
-    desc "Build ObservabilitySrE Docker image from Dockerfile context files"
-    task "docker" => ["archives_docker_observabilitySRE", "dockerfile_observabilitySRE"] do
-      build_docker_from_dockerfiles('observability-sre')
-    end
   end
 
   desc "Generate Dockerfile for full images"
@@ -423,24 +409,10 @@ namespace "artifact" do
     build_dockerfile('full')
   end
 
-  namespace "dockerfile_full" do
-    desc "Build Full Docker image from Dockerfile context files"
-    task "docker" => ["archives_docker", "dockerfile_full"]  do
-      build_docker_from_dockerfiles('full')
-    end
-  end
-
   desc "Generate Dockerfile for wolfi images"
   task "dockerfile_wolfi" => ["prepare", "generate_build_metadata"] do
     puts("[dockerfiles] Building wolfi Dockerfiles")
     build_dockerfile('wolfi')
-  end
-
-  namespace "dockerfile_wolfi" do
-    desc "Build Wolfi Docker image from Dockerfile context files"
-    task "docker" => ["archives_docker", "dockerfile_wolfi"]  do
-      build_docker_from_dockerfiles('wolfi')
-    end
   end
 
   desc "Generate build context for ironbank"
@@ -467,30 +439,6 @@ namespace "artifact" do
     Rake::Task["artifact:deb_oss"].invoke
     Rake::Task["artifact:rpm_oss"].invoke
     Rake::Task["artifact:archives_oss"].invoke
-  end
-
-  task "build_docker_full" => [:generate_build_metadata] do
-    Rake::Task["artifact:docker"].invoke
-    Rake::Task["artifact:dockerfile_full"].invoke
-    Rake::Task["artifact:dockerfile_full:docker"].invoke
-  end
-
-  task "build_docker_oss" => [:generate_build_metadata] do
-    Rake::Task["artifact:docker_oss"].invoke
-    Rake::Task["artifact:dockerfile_oss"].invoke
-    Rake::Task["artifact:dockerfile_oss:docker"].invoke
-  end
-
-  task "build_docker_observabilitySRE" => [:generate_build_metadata] do
-    Rake::Task["artifact:docker_observabilitySRE"].invoke
-    Rake::Task["artifact:dockerfile_observabilitySRE"].invoke
-    Rake::Task["artifact:dockerfile_observabilitySRE:docker"].invoke
-  end
-
-  task "build_docker_wolfi" => [:generate_build_metadata] do
-    Rake::Task["artifact:docker_wolfi"].invoke
-    Rake::Task["artifact:dockerfile_wolfi"].invoke
-    Rake::Task["artifact:dockerfile_wolfi:docker"].invoke
   end
 
   task "generate_build_metadata" do

--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -875,24 +875,10 @@ namespace "artifact" do
       "ARTIFACTS_DIR" => ::File.join(Dir.pwd, "build"),
       "RELEASE" => ENV["RELEASE"],
       "VERSION_QUALIFIER" => VERSION_QUALIFIER,
-      "BUILD_DATE" => BUILD_DATE,
-      "LOCAL_ARTIFACTS" => LOCAL_ARTIFACTS
+      "BUILD_DATE" => BUILD_DATE
     }
     Dir.chdir("docker") do |dir|
       safe_system(env, "make build-from-local-#{flavor}-artifacts")
-    end
-  end
-
-  def build_docker_from_dockerfiles(flavor)
-    env = {
-      "ARTIFACTS_DIR" => ::File.join(Dir.pwd, "build"),
-      "RELEASE" => ENV["RELEASE"],
-      "VERSION_QUALIFIER" => VERSION_QUALIFIER,
-      "BUILD_DATE" => BUILD_DATE,
-      "LOCAL_ARTIFACTS" => LOCAL_ARTIFACTS
-    }
-    Dir.chdir("docker") do |dir|
-      safe_system(env, "make build-from-dockerfiles_#{flavor}")
     end
   end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Previously we would build an image (which would not actually be used), build dockerfiles, modify dockerfiles to curl from
`https://snapshots.elastic.co/downloads/logstash'` then build the image used for testing based on the modified dockerfile. This resulted in testing the last published image to `snapshots`. This presents two problems 1. The test is running against the last published image (not the tip of the branch being tested) 2. this carries a dependency on both a DRA and unified stack release having been run. Therefor acceptance tests will fail in between the time we bump logstash version and a successful run of unified release.

For docker acceptance tests three steps were performed: 
 1. Build container images (based on local artifacts) 
 2. Build "public" dockerfiles 
 3. Build container based on (a modified) file from step 2. 

The ONLY difference between the dockerfile that ultimately is used to define an image between 1 and 2 is WHERE the logstash source is downloaded from. In acceptance testing we WANT to use the source at the current checkout of logstash (not a remote). Using remote causes a dependency issue when changes are not published. Publishing is tied to unified release and gated on tests so naturally this is a bad fit for that dependency. 

This commit removes the redundancy by ONLY generating images for testing (step 1 from above). This also firms up our use of LOCAL_ARTIFACTS. Namely, the ONLY time we want that set to false is when we build a "public" dockerfile. We explicitly set that in the corresponding DRA script now. Similarly we explicitly set it to true when testing.
## Why is it important/What is the impact to the user?


n/a

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

You can run the test locally with:
```
# Set arch appropriately (i've got a mac with arm)
ARCH="aarch64"
ci/docker_acceptance_tests.sh full
```
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/elastic/ingest-dev/issues/5763
