### PR TITLE
[Docs] Add hyphen to the pipeline ID restriction description.

### DIFF
--- a/docs/reference/configuring-centralized-pipelines.md
+++ b/docs/reference/configuring-centralized-pipelines.md
@@ -144,7 +144,7 @@ This setting can be used only if `xpack.management.elasticsearch.ssl.certificate
 ## Wildcard support in pipeline ID [wildcard-in-pipeline-id]
 
 
-Pipeline IDs must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens and numbers. You can use `*` in `xpack.management.pipeline.id` to match any number of letters, underscores, dashes, hyphens and numbers.
+Pipeline IDs must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens and numbers. You can use `*` in `xpack.management.pipeline.id` to match any number of letters, underscores, dashes, hyphens, and numbers.
 
 ```shell
 xpack.management.pipeline.id: ["*logs", "*apache*", "tomcat_log"]

--- a/x-pack/lib/config_management/bootstrap_check.rb
+++ b/x-pack/lib/config_management/bootstrap_check.rb
@@ -14,7 +14,7 @@ module LogStash
     class BootstrapCheck
       include LogStash::Util::Loggable
 
-      # pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens and numbers
+      # pipeline ID must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens, and numbers
       # wildcard character `*` is also acceptable and follows globbing rules
       PIPELINE_ID_PATTERN = %r{\A[a-z_*][a-z_\-0-9*]*\Z}i
 
@@ -43,7 +43,7 @@ module LogStash
 
         invalid_patterns = pipeline_ids.reject { |entry| PIPELINE_ID_PATTERN =~ entry }
         if invalid_patterns.any?
-          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_patterns.join(', ')}"
+          raise LogStash::BootstrapCheckError, "Pipeline id in `xpack.management.pipeline.id` must begin with a letter or underscore and contain only letters, underscores, dashes, hyphens, and numbers. The asterisk wildcard `*` can also be used. Invalid ids: #{invalid_patterns.join(', ')}"
         end
 
         duplicate_ids = find_duplicate_ids(pipeline_ids)


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Pipeline ID restriction ([regex patter](https://github.com/elastic/logstash/blob/main/x-pack/lib/config_management/bootstrap_check.rb#L19)) allows hyphen to the pipeline ID but this isn't mention in the docs and pipeline ID validation message. This PR closes this gap to provide detailed guide/message to end users.

## Why is it important/What is the impact to the user?
Clearer message to the end users about how pipeline ID should be.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- 

## Use cases


## Screenshots
Doc change preview

TBD

## Logs
