### PR TITLE
metrics: add support for user-defined metrics

### DIFF
--- a/logstash-core/lib/logstash/instrument/collector.rb
+++ b/logstash-core/lib/logstash/instrument/collector.rb
@@ -74,6 +74,12 @@ module LogStash module Instrument
       end
     end
 
+    ##
+    # @return [Metric]: the metric that exists after registration
+    def register(namespaces_path, key, &metric_supplier)
+      @metric_store.fetch_or_store(namespaces_path, key, &metric_supplier)
+    end
+
     # test injection, see MetricExtFactory
     def initialize_metric(type, namespaces_path, key)
       MetricType.create(type, namespaces_path, key)

--- a/logstash-core/src/main/java/co/elastic/logstash/api/NamespacedMetric.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/NamespacedMetric.java
@@ -52,6 +52,16 @@ public interface NamespacedMetric extends Metric {
     TimerMetric timer(String metric);
 
     /**
+     * Creates or retrieves a {@link UserMetric} with the provided {@code metric} name,
+     * using the supplied {@code userMetricFactory}.
+     * @param metric the name of the metric
+     * @param userMetricFactory a factory for creating the metric
+     * @return the resulting metric at the address, whether retrieved or created
+     * @param <USER_METRIC> the type of metric to create
+     */
+    <USER_METRIC extends UserMetric<?>> USER_METRIC register(String metric, UserMetric.Factory<USER_METRIC> userMetricFactory);
+
+    /**
      * Increment the {@code metric} metric by 1.
      *
      * @param metric metric to increment

--- a/logstash-core/src/main/java/co/elastic/logstash/api/UserMetric.java
+++ b/logstash-core/src/main/java/co/elastic/logstash/api/UserMetric.java
@@ -1,0 +1,64 @@
+package co.elastic.logstash.api;
+
+import java.util.function.Function;
+
+/**
+ * A custom metric.
+ * @param <VALUE_TYPE> must be jackson-serializable.
+ *
+ * NOTE: this interface is experimental and considered internal.
+ *       Its shape may change from one Logstash release to the next.
+ */
+public interface UserMetric<VALUE_TYPE> {
+    VALUE_TYPE getValue();
+
+    /**
+     * A {@link UserMetric.Factory<USER_METRIC>} is the primary way to register a custom user-metric
+     * along-side a null implementation for performance when metrics are disabled.
+     *
+     * @param <USER_METRIC> a sub-interface of {@link UserMetric}
+     */
+    interface Factory<USER_METRIC extends UserMetric<?>> {
+        Class<USER_METRIC> getType();
+        USER_METRIC create(String name);
+        USER_METRIC nullImplementation();
+    }
+
+    /**
+     * A {@link UserMetric.Provider} is an intermediate helper type meant to be statically available by any
+     * user-provided {@link UserMetric} interface, encapsulating its null implementation and providing
+     * a way to simply get a {@link UserMetric.Factory} for a given non-null implementation.
+     *
+     * @param <USER_METRIC> an interface that extends {@link UserMetric}.
+     */
+    class Provider<USER_METRIC extends UserMetric<?>> {
+        private final Class<USER_METRIC> type;
+        private final USER_METRIC nullImplementation;
+
+        public Provider(final Class<USER_METRIC> type, final USER_METRIC nullImplementation) {
+            assert type.isInterface() : String.format("type must be an interface, got %s", type);
+
+            this.type = type;
+            this.nullImplementation = nullImplementation;
+        }
+
+        public Factory<USER_METRIC> getFactory(final Function<String, USER_METRIC> supplier) {
+            return new Factory<USER_METRIC>() {
+                @Override
+                public USER_METRIC create(final String name) {
+                    return supplier.apply(name);
+                }
+
+                @Override
+                public Class<USER_METRIC> getType() {
+                    return type;
+                }
+
+                @Override
+                public USER_METRIC nullImplementation() {
+                    return nullImplementation;
+                }
+            };
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractNamespacedMetricExt.java
@@ -53,6 +53,11 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
         return getTimer(context, key);
     }
 
+    @JRubyMethod
+    public IRubyObject register(final ThreadContext context, final IRubyObject key, final Block metricSupplier) {
+        return doRegister(context, key, metricSupplier);
+    }
+
     @JRubyMethod(required = 1, optional = 1)
     public IRubyObject increment(final ThreadContext context, final IRubyObject[] args) {
         return doIncrement(context, args);
@@ -103,6 +108,8 @@ public abstract class AbstractNamespacedMetricExt extends AbstractMetricExt {
     protected abstract IRubyObject doIncrement(ThreadContext context, IRubyObject[] args);
 
     protected abstract IRubyObject doDecrement(ThreadContext context, IRubyObject[] args);
+
+    protected abstract IRubyObject doRegister(ThreadContext context, IRubyObject key, Block metricSupplier);
 
     public abstract AbstractMetricExt getMetric();
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractSimpleMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/AbstractSimpleMetricExt.java
@@ -74,6 +74,11 @@ public abstract class AbstractSimpleMetricExt extends AbstractMetricExt {
         return doTime(context, namespace, key, block);
     }
 
+    @JRubyMethod(name = "register")
+    public IRubyObject register(final ThreadContext context, final IRubyObject namespace, final IRubyObject key, final Block metricSupplier) {
+        return doRegister(context, namespace, key, metricSupplier);
+    }
+
     protected abstract IRubyObject doDecrement(ThreadContext context, IRubyObject[] args);
 
     protected abstract IRubyObject doIncrement(ThreadContext context, IRubyObject[] args);
@@ -88,4 +93,6 @@ public abstract class AbstractSimpleMetricExt extends AbstractMetricExt {
 
     protected abstract IRubyObject doTime(ThreadContext context, IRubyObject namespace,
         IRubyObject key, Block block);
+
+    protected abstract IRubyObject doRegister(ThreadContext context, IRubyObject namespace, IRubyObject key, Block metricSupplier);
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricExt.java
@@ -154,6 +154,12 @@ public final class MetricExt extends AbstractSimpleMetricExt {
     }
 
     @Override
+    protected IRubyObject doRegister(ThreadContext context, IRubyObject namespace, IRubyObject key, Block supplier) {
+        MetricExt.validateKey(context, null, key);
+        return collector.callMethod(context, "register", new IRubyObject[]{normalizeNamespace(namespace), key}, supplier);
+    }
+
+    @Override
     protected IRubyObject doReportTime(final ThreadContext context, final IRubyObject namespace,
         final IRubyObject key, final IRubyObject duration) {
         MetricExt.validateKey(context, null, key);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricType.java
@@ -77,6 +77,11 @@ public enum MetricType {
      * A flow-rate {@link FlowMetric}, instantiated with one or more backing {@link Metric}{@code <Number>}.
      */
     FLOW_RATE("flow/rate"),
+
+    /**
+     * A user metric
+     */
+    USER("user"),
     ;
 
     private final String type;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NamespacedMetricExt.java
@@ -53,6 +53,11 @@ public final class NamespacedMetricExt extends AbstractNamespacedMetricExt {
         super(runtime, metaClass);
     }
 
+    @Override
+    protected IRubyObject doRegister(ThreadContext context, IRubyObject key, Block metricSupplier) {
+        return metric.register(context, namespaceName, key, metricSupplier);
+    }
+
     @JRubyMethod(visibility = Visibility.PRIVATE)
     public NamespacedMetricExt initialize(final ThreadContext context, final IRubyObject metric,
         final IRubyObject namespaceName) {

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullMetricExt.java
@@ -112,6 +112,11 @@ public final class NullMetricExt extends AbstractSimpleMetricExt {
     }
 
     @Override
+    protected IRubyObject doRegister(ThreadContext context, IRubyObject namespace, IRubyObject key, Block metricSupplier) {
+        return context.nil;
+    }
+
+    @Override
     protected AbstractNamespacedMetricExt createNamespaced(final ThreadContext context,
         final IRubyObject name) {
         MetricExt.validateName(context, name, RubyUtil.METRIC_NO_NAMESPACE_PROVIDED_CLASS);

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/NullNamespacedMetricExt.java
@@ -113,6 +113,11 @@ public final class NullNamespacedMetricExt extends AbstractNamespacedMetricExt {
     }
 
     @Override
+    protected IRubyObject doRegister(ThreadContext context, IRubyObject key, Block metricSupplier) {
+        return context.nil;
+    }
+
+    @Override
     @SuppressWarnings("rawtypes")
     protected RubyArray getNamespaceName(final ThreadContext context) {
         return namespaceName;

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UserMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UserMetric.java
@@ -31,12 +31,12 @@ public class UserMetric {
 
         final IRubyObject result = metric.register(context, key, metricSupplier);
         final Class<USER_METRIC> type = metricFactory.getType();
-        if (type.isAssignableFrom(result.getJavaClass())) {
-            return result.toJava(type);
-        } else {
+        if (!type.isAssignableFrom(result.getJavaClass())) {
             LOGGER.warn("UserMetric type mismatch for %s (expected: %s, received: %s); " +
                     "a null implementation will be substituted", key.asJavaString(), type, result.getJavaClass());
             return metricFactory.nullImplementation();
         }
+        
+        return result.toJava(type);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UserMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UserMetric.java
@@ -1,0 +1,42 @@
+package org.logstash.instrument.metrics;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jruby.RubySymbol;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.JavaInternalBlockBody;
+import org.jruby.runtime.Signature;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.logstash.RubyUtil;
+
+public class UserMetric {
+    private UserMetric() {}
+
+    private static Logger LOGGER = LogManager.getLogger(UserMetric.class);
+
+    public static <USER_METRIC extends co.elastic.logstash.api.UserMetric<?>> USER_METRIC fromRubyBase(
+            final AbstractNamespacedMetricExt metric,
+            final RubySymbol key,
+            final co.elastic.logstash.api.UserMetric.Factory<USER_METRIC> metricFactory
+    ) {
+        final ThreadContext context = RubyUtil.RUBY.getCurrentContext();
+
+        final Block metricSupplier = new Block(new JavaInternalBlockBody(context.runtime, Signature.NO_ARGUMENTS) {
+            @Override
+            public IRubyObject yield(ThreadContext threadContext, IRubyObject[] iRubyObjects) {
+                return RubyUtil.toRubyObject(metricFactory.create(key.asJavaString()));
+            }
+        });
+
+        final IRubyObject result = metric.register(context, key, metricSupplier);
+        final Class<USER_METRIC> type = metricFactory.getType();
+        if (type.isAssignableFrom(result.getJavaClass())) {
+            return result.toJava(type);
+        } else {
+            LOGGER.warn("UserMetric type mismatch for %s (expected: %s, received: %s); " +
+                    "a null implementation will be substituted", key.asJavaString(), type, result.getJavaClass());
+            return metricFactory.nullImplementation();
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/plugins/NamespacedMetricImpl.java
+++ b/logstash-core/src/main/java/org/logstash/plugins/NamespacedMetricImpl.java
@@ -23,6 +23,7 @@ package org.logstash.plugins;
 import co.elastic.logstash.api.CounterMetric;
 import co.elastic.logstash.api.Metric;
 import co.elastic.logstash.api.NamespacedMetric;
+import co.elastic.logstash.api.UserMetric;
 import org.jruby.RubyArray;
 import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
@@ -34,6 +35,7 @@ import org.logstash.instrument.metrics.timer.TimerMetric;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -65,6 +67,13 @@ public class NamespacedMetricImpl implements NamespacedMetric {
     @Override
     public co.elastic.logstash.api.TimerMetric timer(final String metric) {
         return TimerMetric.fromRubyBase(metrics, threadContext.getRuntime().newString(metric).intern());
+    }
+
+    @Override
+    public <USER_METRIC extends UserMetric<?>> USER_METRIC register(String metric, UserMetric.Factory<USER_METRIC> userMetricFactory) {
+        USER_METRIC userMetric = org.logstash.instrument.metrics.UserMetric.fromRubyBase(metrics, threadContext.runtime.newSymbol(metric), userMetricFactory);
+
+        return Objects.requireNonNullElseGet(userMetric, userMetricFactory::nullImplementation);
     }
 
     @Override

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MetricTypeTest.java
@@ -52,6 +52,7 @@ public class MetricTypeTest {
         nameMap.put(MetricType.GAUGE_RUBYHASH, "gauge/rubyhash");
         nameMap.put(MetricType.GAUGE_RUBYTIMESTAMP, "gauge/rubytimestamp");
         nameMap.put(MetricType.FLOW_RATE, "flow/rate");
+        nameMap.put(MetricType.USER, "user");
 
         //ensure we are testing all of the enumerations
         assertThat(EnumSet.allOf(MetricType.class).size()).isEqualTo(nameMap.size());

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/MockNamespacedMetric.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/MockNamespacedMetric.java
@@ -24,7 +24,7 @@ public class MockNamespacedMetric extends AbstractNamespacedMetricExt {
 
     private static final long serialVersionUID = -6507123659910450215L;
 
-    private transient final ConcurrentMap<String, Metric> metrics = new ConcurrentHashMap<>();
+    private transient final ConcurrentMap<String, Object> metrics = new ConcurrentHashMap<>();
 
     public static MockNamespacedMetric create() {
         return new MockNamespacedMetric(RubyUtil.RUBY, RubyUtil.NAMESPACED_METRIC_CLASS);
@@ -81,6 +81,11 @@ public class MockNamespacedMetric extends AbstractNamespacedMetricExt {
     @Override
     public AbstractMetricExt getMetric() {
         return NullMetricExt.create();
+    }
+
+    @Override
+    protected IRubyObject doRegister(ThreadContext context, IRubyObject key, Block metricSupplier) {
+        return RubyUtil.toRubyObject(metrics.computeIfAbsent(key.asJavaString(), (k) -> metricSupplier.call(context)));
     }
 
     @Override


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?

Provides a way for registering non-standard metrics, without needing to wire them through publicly.

It does so by introducing an API `UserMetric<VALUE_TYPE>` marked as Logstash-internal, a companion `UserMetric.Factory<USER_METRIC>` to encapsulate the logic for its type and a null implementation, and introducing `NamespacedMetric#register(String metric, UserMetric.Factory<USER_METRIC> userMetricFactory)`.

Together, these methods and the wiring through to the metric collector allow anything with an `api.NamespacedMetric` to provide its own metric implementation.

## Why is it important/What is the impact to the user?

This is necessary ground-work for #18107 which will add ratio and relative-spend metrics from within the Logstash code-base.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Resolves #18175

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
