### PR TITLE
metric: improve accuracy of timer metric under contention

### DIFF
--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/ConcurrentLiveTimerMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/timer/ConcurrentLiveTimerMetric.java
@@ -1,13 +1,8 @@
 package org.logstash.instrument.metrics.timer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.logstash.instrument.metrics.AbstractMetric;
 
 import java.util.Objects;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongSupplier;


### PR DESCRIPTION

## Release notes

[rn: skip]

## What does this PR do?

Improves the accuracy of `ConcurrentLiveTimerMetric` in cases where many threads are contending to record their timings.

When using `AtomicReference#getAndUpdate(UnaryOperator)`, the provided operator may be run multiple times in cases where another thread has "won" the update. By moving the capture of the timestamp _out_ of this block, we ensure an accurate recording for the completion time of the measurement and prevent it from including the time contending to _write_ the measurement.

## Why is it important/What is the impact to the user?

No major user impact, but slightly improves the accuracy of timer-type metrics.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

Verification relies on the existing test coverage for `ConcurrentLiveTimerMetric`, along with an understanding of what bringing the call to `LongSupplier#getAsLong` _out_ of block means when the block needs to be re-run.
