### PR TITLE
Doc: Attribute fixes in release notes 9.1.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -31,8 +31,8 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ### Fixes [logstash-9.1.4-fixes]
 
-* Gauge type metrics, such as current and peak connection counts of Elastic Agent, are now available in the `_node/stats` API response when the `vertices=true` parameter is included. These metrics are particularly useful for monitoring {ls} plugin activity on the {ls} Integration dashboards [#18090](https://github.com/elastic/logstash/pull/18090)
-* Improve logstash release artifacts file metadata: mtime is preserved when buiilding tar archives [#18091](https://github.com/elastic/logstash/pull/18091)
+* Gauge type metrics, such as current and peak connection counts of Elastic Agent, are now available in the `_node/stats` API response when the `vertices=true` parameter is included. These metrics are particularly useful for monitoring {{ls}} plugin activity on the {{ls}} Integration dashboards [#18090](https://github.com/elastic/logstash/pull/18090)
+* Improve {{ls}} release artifacts file metadata: mtime is preserved when building tar archives [#18091](https://github.com/elastic/logstash/pull/18091)
 
 
 ### Plugins [logstash-plugin-9.1.4-changes]


### PR DESCRIPTION
Related: #18224 

We didn't get a clean backport because we have more backport work to catch up on. 