### PR TITLE
Add lockfile for new 9.2 branch

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -1,0 +1,990 @@
+PATH
+  remote: logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 9.1.5)
+
+PATH
+  remote: logstash-core
+  specs:
+    logstash-core (9.1.5-java)
+      clamp (~> 1, >= 1.3.3)
+      concurrent-ruby (~> 1, < 1.1.10)
+      down (~> 5.2.0)
+      elasticsearch (~> 8)
+      filesize (~> 0.2)
+      gems (~> 1)
+      i18n (~> 1)
+      jrjackson (= 0.4.20)
+      manticore (~> 0.6)
+      minitar (~> 1)
+      pry (~> 0.12)
+      puma (~> 6.3, >= 6.4.2)
+      rack (~> 3)
+      rubyzip (~> 1)
+      sinatra (~> 4)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.6)
+      thwait
+      treetop (~> 1)
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    amazing_print (1.8.1)
+    arr-pm (0.0.12)
+    ast (2.4.3)
+    atomic (1.1.101-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    avro (1.10.2)
+      multi_json (~> 1)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1126.0)
+    aws-sdk-cloudfront (1.119.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-cloudwatch (1.116.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-core (3.226.3)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.106.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-resourcegroups (1.83.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.192.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sns (1.100.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.96.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    back_pressure (1.0.0)
+    backports (3.25.1)
+    base64 (0.3.0)
+    belzebuth (0.2.3)
+      childprocess
+    benchmark-ips (2.14.0)
+    bigdecimal (3.2.3-java)
+    bindata (2.5.1)
+    buftok (0.2.0)
+    builder (3.3.0)
+    cabin (0.9.1)
+    cgi (0.3.7-java)
+    childprocess (4.1.0)
+    ci_reporter (2.1.0)
+      builder (>= 2.1.2)
+      rexml
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (1.3.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    dalli (3.2.8)
+    date (3.3.3-java)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    domain_name (0.6.20240107)
+    dotenv (3.1.8)
+    down (5.2.4)
+      addressable (~> 2.8)
+    e2mmap (0.1.0)
+    edn (1.1.1)
+    elastic-transport (8.4.0)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.18.1)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.18.1)
+    elasticsearch-api (8.18.1)
+      multi_json
+    equalizer (0.0.11)
+    et-orbi (1.2.11)
+      tzinfo
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    ffi (1.17.2-java)
+    filesize (0.2.0)
+    fileutils (1.7.3)
+    fivemat (1.3.7)
+    flores (0.0.8)
+    fpm (1.16.0)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (>= 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    fugit (1.11.2)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
+    gelfd2 (0.4.1)
+    gem_publisher (1.5.0)
+    gems (1.3.0)
+    gene_pool (1.5.0)
+      concurrent-ruby (>= 1.0)
+    hashdiff (1.2.1)
+    hitimes (1.3.1-java)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0-java)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    insist (1.0.0)
+    jar-dependencies (0.5.4)
+    jls-grok (0.11.5)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.6.2)
+    jrjackson (0.4.20-java)
+    jruby-jms (1.3.0-java)
+      gene_pool
+      semantic_logger
+    jruby-openssl (0.15.5-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (2.12.2-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    logstash-codec-avro (3.4.1-java)
+      avro (~> 1.10.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-cef (6.2.8-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-collectd (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.1.0)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-edn_lines (3.1.0)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-es_bulk (3.1.0)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-fluent (3.4.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-json (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-json_lines (3.2.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-line (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-msgpack (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.1.2)
+      concurrent-ruby
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-patterns-core
+    logstash-codec-netflow (4.3.2)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-plain (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-rubydebug (3.1.0)
+      amazing_print (~> 1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (2.6.2-java)
+      fivemat
+      gem_publisher
+      kramdown (~> 2)
+      logstash-codec-plain
+      logstash-core (>= 6.3)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.10.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-cidr (3.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-clone (4.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-csv (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-date (3.1.15)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.2.5)
+      jar-dependencies
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elastic_integration (9.1.1-java)
+      logstash-core (>= 8.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (4.3.1)
+      elasticsearch (>= 7.14.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+    logstash-filter-fingerprint (3.4.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-geoip (7.3.1-java)
+      logstash-core (>= 7.14.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.3)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-patterns-core (>= 4.3.0, < 5)
+      stud (~> 0.0.22)
+    logstash-filter-http (2.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-json (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-kv (4.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-memcached (1.2.0)
+      dalli (~> 3)
+      logstash-core-plugin-api (~> 2.0)
+    logstash-filter-metrics (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.5.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-prune (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-sleep (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.4.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      psych (>= 5.1.0)
+    logstash-filter-truncate (1.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.3.5-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-uuid (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.3.2)
+      logstash-core (>= 8.15.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri (>= 1.18.9)
+      xml-simple
+    logstash-input-azure_event_hubs (1.5.2)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      stud (>= 0.0.22)
+    logstash-input-beats (7.0.3-java)
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.6)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (2.0.1)
+      logstash-codec-plain
+      logstash-core (>= 8.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elastic_serverless_forwarder (2.0.0-java)
+      logstash-codec-json_lines
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-http (>= 3.7.2)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-plugin_factory_support
+    logstash-input-elasticsearch (5.2.1)
+      elasticsearch (>= 7.17.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+      tzinfo
+      tzinfo-data
+    logstash-input-exec (3.6.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-scheduler (~> 1.0)
+      stud (~> 0.0.22)
+    logstash-input-file (4.4.6)
+      addressable
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-ganglia (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.3.2)
+      gelfd2 (= 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-generator (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-graphite (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-event_support (~> 1.0)
+      stud
+    logstash-input-http (4.1.3-java)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+    logstash-input-http_poller (6.0.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-input-jms (3.3.1-java)
+      jruby-jms (>= 1.2.0)
+      logstash-codec-json (~> 3.0)
+      logstash-codec-plain (~> 3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      semantic_logger (< 4.0.0)
+    logstash-input-pipe (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      stud (~> 0.0.22)
+    logstash-input-redis (3.7.1)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (>= 4.0.1, < 5)
+    logstash-input-stdin (3.4.0)
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-syslog (3.7.1)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok (>= 4.4.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-tcp (7.0.3-java)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-twitter (4.1.1)
+      http-form_data (~> 2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      public_suffix (> 4, < 6)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 6.2.0)
+    logstash-input-udp (3.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.1.2)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-integration-aws (7.2.1-java)
+      aws-sdk-cloudfront
+      aws-sdk-cloudwatch
+      aws-sdk-core (~> 3)
+      aws-sdk-resourcegroups
+      aws-sdk-s3
+      aws-sdk-sns
+      aws-sdk-sqs
+      concurrent-ruby
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      rexml
+      rufus-scheduler (>= 3.0.9)
+      stud (~> 0.0.22)
+    logstash-integration-jdbc (5.6.1)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      lru_redux
+      sequel (>= 5.74.0)
+      tzinfo
+      tzinfo-data
+    logstash-integration-kafka (11.6.4-java)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core (>= 8.3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-logstash (1.0.4-java)
+      logstash-codec-json_lines (~> 3.1)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-input-http (>= 3.7.0)
+      logstash-mixin-http_client (~> 7.3)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.1)
+      stud
+    logstash-integration-rabbitmq (7.4.0-java)
+      back_pressure (~> 1.0)
+      logstash-codec-json
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      march_hare (~> 4.0)
+      stud (~> 0.0.22)
+    logstash-integration-snmp (4.0.7-java)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-mixin-ca_trusted_fingerprint_support (1.0.1-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-deprecation_logger_support (1.0.0-java)
+      logstash-core (>= 5.0.0)
+    logstash-mixin-ecs_compatibility_support (1.3.0-java)
+      logstash-core (>= 6.0.0)
+    logstash-mixin-event_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-mixin-http_client (7.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+    logstash-mixin-normalize_config_support (1.0.0-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-plugin_factory_support (1.0.0-java)
+      logstash-core (>= 7.13.0)
+    logstash-mixin-scheduler (1.0.1-java)
+      logstash-core (>= 7.16)
+      rufus-scheduler (>= 3.0.9)
+    logstash-mixin-validator_support (1.1.1-java)
+      logstash-core (>= 6.8)
+    logstash-output-csv (3.0.10)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-output-file
+    logstash-output-elasticsearch (12.0.7-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.8)
+      mustache (>= 0.99.8)
+    logstash-output-file (4.3.0)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (6.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+    logstash-output-lumberjack (3.1.9)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.6)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-redis (5.2.0)
+      logstash-core (>= 6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 4)
+      stud
+    logstash-output-stdout (3.1.4)
+      logstash-codec-rubydebug
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (7.0.1)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.2.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      webhdfs
+    logstash-patterns-core (4.3.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    manticore (0.9.1-java)
+      openssl_pkcs8_pure
+    march_hare (4.7.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (1.1.0)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mini_mime (1.1.5)
+    minitar (1.0.2)
+    msgpack (1.8.0-java)
+    multi_json (1.15.0)
+    multipart-post (2.4.1)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
+    naught (1.1.0)
+    net-http (0.6.0)
+      uri
+    net-imap (0.5.10)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.4-java)
+    nokogiri (1.18.10-java)
+      racc (~> 1.4)
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    openssl_pkcs8_pure (0.0.0.2)
+    paquet (0.2.1)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.15.2-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    psych (5.2.6-java)
+      date
+      jar-dependencies (>= 0.1.7)
+    public_suffix (5.1.1)
+    puma (6.6.1-java)
+      nio4r (~> 2.0)
+    raabro (1.4.0)
+    racc (1.8.1-java)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    redis (4.8.1)
+    regexp_parser (2.10.0)
+    rexml (3.4.4)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
+    rspec-wait (1.0.2)
+      rspec (>= 3.4)
+    rubocop (1.74.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.42.0)
+      parser (>= 3.3.7.2)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (1.3.0)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    semantic_logger (3.4.1)
+      concurrent-ruby (~> 1.0)
+    sequel (5.94.0)
+      bigdecimal
+    simple_oauth (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-json (0.2.3)
+      json
+      simplecov
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.6.1)
+    timeout (0.4.3)
+    treetop (1.6.14)
+      polyglot (~> 0.3)
+    twitter (6.2.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
+    unicode-display_width (3.1.5)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.3)
+    webhdfs (0.11.0)
+      addressable
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.9)
+      rexml
+
+PLATFORMS
+  java
+  universal-java-17
+  universal-java-21
+
+DEPENDENCIES
+  belzebuth
+  benchmark-ips
+  bigdecimal (~> 3.1)
+  cgi (~> 0.3.7)
+  childprocess (~> 4)
+  ci_reporter_rspec (~> 1)
+  date (= 3.3.3)
+  fileutils (~> 1.7)
+  flores (~> 0.0.8)
+  fpm (~> 1, >= 1.14.1)
+  gems (~> 1)
+  jar-dependencies (= 0.5.4)
+  json-schema (~> 2)
+  logstash-codec-avro
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (~> 2.6.0)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elastic_integration
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-http
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-memcached
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-prune
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-azure_event_hubs
+  logstash-input-beats
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elastic_serverless_forwarder
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-jms
+  logstash-input-pipe
+  logstash-input-redis
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-integration-aws
+  logstash-integration-jdbc
+  logstash-integration-kafka
+  logstash-integration-logstash
+  logstash-integration-rabbitmq
+  logstash-integration-snmp
+  logstash-output-csv
+  logstash-output-elasticsearch (>= 11.14.0)
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pipe
+  logstash-output-redis
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  minitar (~> 1)
+  murmurhash3 (= 0.1.6)
+  octokit (~> 4.25)
+  paquet (~> 0.2)
+  pleaserun (~> 0.0.28)
+  polyglot
+  rack-test
+  rake (~> 13)
+  rspec (~> 3.5)
+  rubocop
+  rubocop-ast (= 1.42.0)
+  ruby-progressbar (~> 1)
+  rubyzip (~> 1)
+  simplecov (~> 0.22.0)
+  simplecov-json
+  stud (~> 0.0.22)
+  thwait
+  treetop
+  webmock (~> 3)
+
+BUNDLED WITH
+   2.6.3


### PR DESCRIPTION
Add a lockfile for the newly created 9.2 stream for logstash.

Prepared with:

```shell
➜  logstash git:(1493d4637f) ✗ curl -O https://raw.githubusercontent.com/elastic/logstash/9.1/Gemfile.jruby-3.1.lock.release
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 30925  100 30925    0     0   123k      0 --:--:-- --:--:-- --:--:--  123k
➜  logstash git:(1493d4637f) ✗ git checkout -b new-lockfile-9.2 upstream/9.2
Previous HEAD position was 1493d4637f Adapted test to suggestion https://github.com/elastic/logstash/pull/18203#discussion_r2375165810
branch 'new-lockfile-9.2' set up to track 'upstream/9.2'.
Switched to a new branch 'new-lockfile-9.2'
➜  logstash git:(new-lockfile-9.2) ✗ git add Gemfile.jruby-3.1.lock.release
➜  logstash git:(new-lockfile-9.2) ✗ git commit -m "Lock file copied from 9.1"
[new-lockfile-9.2 79ecd0765a] Lock file copied from 9.1
 1 file changed, 990 insertions(+)
 create mode 100644 Gemfile.jruby-3.1.lock.release
➜  logstash git:(new-lockfile-9.2) ✗ ./gradlew clean installDefaultGems
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build

> Task :downloadJRuby
Download https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.13.0/jruby-dist-9.4.13.0-bin.tar.gz

> Task :logstash-core:compileJava
Note: Processing Log4j annotations
Note: Annotations processed
Note: Processing Log4j annotations
Note: No elements to process

> Task :installDefaultGems
Skipping bundler install...
Building logstash-core using gradle
./gradlew assemble
[plugin:install-default] Installing default plugins
Installing logstash-codec-avro, logstash-codec-cef, logstash-codec-collectd, logstash-codec-dots, logstash-codec-edn, logstash-codec-edn_lines, logstash-codec-es_bulk, logstash-codec-fluent, logstash-codec-graphite, logstash-codec-json, logstash-codec-json_lines, logstash-codec-line, logstash-codec-msgpack, logstash-codec-multiline, logstash-codec-netflow, logstash-codec-plain, logstash-codec-rubydebug, logstash-filter-aggregate, logstash-filter-anonymize, logstash-filter-cidr, logstash-filter-clone, logstash-filter-csv, logstash-filter-date, logstash-filter-de_dot, logstash-filter-dissect, logstash-filter-dns, logstash-filter-drop, logstash-filter-elastic_integration, logstash-filter-elasticsearch, logstash-filter-fingerprint, logstash-filter-geoip, logstash-filter-grok, logstash-filter-http, logstash-filter-json, logstash-filter-kv, logstash-filter-memcached, logstash-filter-metrics, logstash-filter-mutate, logstash-filter-prune, logstash-filter-ruby, logstash-filter-sleep, logstash-filter-split, logstash-filter-syslog_pri, logstash-filter-throttle, logstash-filter-translate, logstash-filter-truncate, logstash-filter-urldecode, logstash-filter-useragent, logstash-filter-uuid, logstash-filter-xml, logstash-input-azure_event_hubs, logstash-input-beats, logstash-input-couchdb_changes, logstash-input-dead_letter_queue, logstash-input-elasticsearch, logstash-input-exec, logstash-input-file, logstash-input-ganglia, logstash-input-gelf, logstash-input-generator, logstash-input-graphite, logstash-input-heartbeat, logstash-input-http, logstash-input-http_poller, logstash-input-jms, logstash-input-pipe, logstash-input-redis, logstash-input-stdin, logstash-input-syslog, logstash-input-tcp, logstash-input-twitter, logstash-input-udp, logstash-input-unix, logstash-input-elastic_serverless_forwarder, logstash-integration-jdbc, logstash-integration-kafka, logstash-integration-logstash, logstash-integration-rabbitmq, logstash-integration-snmp, logstash-integration-aws, logstash-output-csv, logstash-output-elasticsearch, logstash-output-email, logstash-output-file, logstash-output-graphite, logstash-output-http, logstash-output-lumberjack, logstash-output-nagios, logstash-output-null, logstash-output-pipe, logstash-output-redis, logstash-output-stdout, logstash-output-tcp, logstash-output-udp, logstash-output-webhdfs
Installation successful
cleaned orphaned dependency ruby-maven (3.9.3)
cleaned orphaned dependency ruby-maven-libs (3.9.9)

[Incubating] Problems report is available at: file:///Users/cas/elastic-repos/logstash/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 39s
43 actionable tasks: 40 executed, 3 up-to-date
➜  logstash git:(new-lockfile-9.2) ✗ ./vendor/jruby/bin/jruby -S bundle update --all --strict
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

jruby: Error: Java executable not found!
➜  logstash git:(new-lockfile-9.2) ✗ export JAVA_HOME="$(jenv prefix)"
➜  logstash git:(new-lockfile-9.2) ✗ ./vendor/jruby/bin/jruby -S bundle update --all --strict
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching rake 13.3.0
Installing rake 13.3.0
Fetching arr-pm 0.0.12
Fetching amazing_print 1.8.1
Fetching aws-eventstream 1.4.0
Fetching public_suffix 5.1.1
Fetching atomic 1.1.101 (java)
Fetching multi_json 1.17.0 (was 1.15.0)
Fetching base64 0.3.0
Fetching aws-partitions 1.1168.0 (was 1.1126.0)
Fetching ast 2.4.3
Fetching jmespath 1.6.2
Fetching bigdecimal 3.2.3 (java)
Fetching logger 1.7.0
Installing public_suffix 5.1.1
Installing aws-eventstream 1.4.0
Installing amazing_print 1.8.1
Fetching back_pressure 1.0.0
Fetching backports 3.25.1
Installing atomic 1.1.101 (java)
Installing multi_json 1.17.0 (was 1.15.0)
Installing arr-pm 0.0.12
Fetching benchmark-ips 2.14.0
Fetching childprocess 4.1.0
Fetching bindata 2.5.1
Installing base64 0.3.0
Fetching buftok 0.2.0
Fetching builder 3.3.0
Installing aws-partitions 1.1168.0 (was 1.1126.0)
Installing ast 2.4.3
Fetching cabin 0.9.1
Installing logger 1.7.0
Fetching cgi 0.3.7 (java)
Installing jmespath 1.6.2
Fetching rexml 3.4.4
Installing bigdecimal 3.2.3 (java)
Fetching rspec-support 3.13.6
Fetching diff-lcs 1.6.2
Installing back_pressure 1.0.0
Fetching clamp 1.3.3
Installing benchmark-ips 2.14.0
Installing childprocess 4.1.0
Installing backports 3.25.1
Fetching coderay 1.1.3
Installing bindata 2.5.1
Installing buftok 0.2.0
Installing builder 3.3.0
Fetching concurrent-ruby 1.1.9
Installing cabin 0.9.1
Fetching dalli 3.2.8
Installing cgi 0.3.7 (java)
Fetching date 3.3.3 (java)
Installing rexml 3.4.4
Fetching docile 1.4.1
Installing rspec-support 3.13.6
Fetching domain_name 0.6.20240107
Fetching dotenv 3.1.8
Installing diff-lcs 1.6.2
Installing clamp 1.3.3
Installing coderay 1.1.3
Fetching e2mmap 0.1.0
Fetching edn 1.1.1
Installing concurrent-ruby 1.1.9
Installing dalli 3.2.8
Fetching uri 1.0.3
Installing date 3.3.3 (java)
Fetching json 2.15.0 (java) (was 2.12.2)
Installing docile 1.4.1
Fetching equalizer 0.0.11
Fetching ffi 1.17.2 (java)
Fetching filesize 0.2.0
Installing domain_name 0.6.20240107
Fetching fileutils 1.7.3
Installing dotenv 3.1.8
Installing e2mmap 0.1.0
Fetching fivemat 1.3.7
Fetching flores 0.0.8
Fetching insist 1.0.0
Installing edn 1.1.1
Installing uri 1.0.3
Installing json 2.15.0 (java) (was 2.12.2)
Fetching mustache 0.99.8
Fetching stud 0.0.23
Installing equalizer 0.0.11
Fetching raabro 1.4.0
Installing ffi 1.17.2 (java)
Fetching gelfd2 0.4.1
Installing filesize 0.2.0
Installing fileutils 1.7.3
Fetching gem_publisher 1.5.0
Installing fivemat 1.3.7
Fetching gems 1.3.0
Installing flores 0.0.8
Installing insist 1.0.0
Installing mustache 0.99.8
Installing stud 0.0.23
Fetching hashdiff 1.2.1
Installing raabro 1.4.0
Fetching http-form_data 2.3.0
Fetching jar-dependencies 0.5.4
Fetching http_parser.rb 0.6.0 (java)
Fetching hitimes 1.3.1 (java)
Fetching jrjackson 0.4.20 (java)
Installing gelfd2 0.4.1
Installing gem_publisher 1.5.0
Installing gems 1.3.0
Fetching jruby-openssl 0.15.5 (java)
Fetching jruby-stdin-channel 0.2.0 (java)
Installing hashdiff 1.2.1
Fetching language_server-protocol 3.17.0.5
Fetching lint_roller 1.1.0
Fetching openssl_pkcs8_pure 0.0.0.2
Fetching minitar 1.1.0 (was 1.0.2)
Fetching method_source 1.1.0
Installing jrjackson 0.4.20 (java)
Installing http_parser.rb 0.6.0 (java)
Installing jar-dependencies 0.5.4
Installing hitimes 1.3.1 (java)
Installing http-form_data 2.3.0
Fetching nio4r 2.7.4 (java)
Fetching rack 3.2.1 (was 3.1.16)
Fetching rubyzip 1.3.0
Fetching ruby2_keywords 0.0.5
Fetching tilt 2.6.1
Installing jruby-stdin-channel 0.2.0 (java)
Fetching thread_safe 0.3.6 (java)
Installing language_server-protocol 3.17.0.5
Installing lint_roller 1.1.0
Installing openssl_pkcs8_pure 0.0.0.2
Fetching polyglot 0.3.5
Installing minitar 1.1.0 (was 1.0.2)
Fetching msgpack 1.8.0 (java)
Installing method_source 1.1.0
Installing nio4r 2.7.4 (java)
Fetching murmurhash3 0.1.6 (java)
Installing jruby-openssl 0.15.5 (java)
Installing rack 3.2.1 (was 3.1.16)
Installing rubyzip 1.3.0
Fetching lru_redux 1.1.0
Fetching racc 1.8.1 (java)
Installing ruby2_keywords 0.0.5
Installing tilt 2.6.1
Fetching redis 4.8.1
Fetching multipart-post 2.4.1
Installing thread_safe 0.3.6 (java)
Installing polyglot 0.3.5
Fetching naught 1.1.0
Fetching simple_oauth 0.3.1
Installing msgpack 1.8.0 (java)
Installing murmurhash3 0.1.6 (java)
Fetching march_hare 4.8.0 (java) (was 4.7.0)
Fetching mini_mime 1.1.5
Installing lru_redux 1.1.0
Fetching timeout 0.4.3
Fetching paquet 0.2.1
Fetching parallel 1.27.0
Installing racc 1.8.1 (java)
Fetching rainbow 3.1.1
Installing redis 4.8.1
Installing multipart-post 2.4.1
Fetching regexp_parser 2.11.3 (was 2.10.0)
Installing naught 1.1.0
Fetching ruby-progressbar 1.13.0
Fetching unicode-emoji 4.1.0 (was 4.0.4)
Installing simple_oauth 0.3.1
Fetching simplecov-html 0.13.2
Fetching simplecov_json_formatter 0.1.4
Fetching addressable 2.8.7
Installing march_hare 4.8.0 (java) (was 4.7.0)
Installing mini_mime 1.1.5
Fetching aws-sigv4 1.12.1
Installing timeout 0.4.3
Fetching avro 1.10.2
Fetching elasticsearch-api 8.19.1 (was 8.18.1)
Installing paquet 0.2.1
Fetching avl_tree 1.2.1
Installing parallel 1.27.0
Fetching sequel 5.96.0 (was 5.94.0)
Installing rainbow 3.1.1
Installing regexp_parser 2.11.3 (was 2.10.0)
Fetching belzebuth 0.2.3
Installing ruby-progressbar 1.13.0
Installing unicode-emoji 4.1.0 (was 4.0.4)
Fetching jls-grok 0.11.5
Installing simplecov-html 0.13.2
Installing simplecov_json_formatter 0.1.4
Fetching rspec-core 3.13.5
Fetching ci_reporter 2.1.0
Fetching crack 1.0.0
Installing addressable 2.8.7
Fetching kramdown 2.5.1
Installing aws-sigv4 1.12.1
Installing avro 1.10.2
Fetching xml-simple 1.1.9
Fetching rspec-expectations 3.13.5
Installing elasticsearch-api 8.19.1 (was 8.18.1)
Installing avl_tree 1.2.1
Fetching rspec-mocks 3.13.5
Fetching http-cookie 1.1.0 (was 1.0.8)
Installing sequel 5.96.0 (was 5.94.0)
Installing belzebuth 0.2.3
Installing jls-grok 0.11.5
Fetching thwait 0.2.0
Fetching tzinfo 2.0.6
Installing rspec-core 3.13.5
Installing ci_reporter 2.1.0
Installing crack 1.0.0
Fetching gene_pool 1.5.0
Fetching i18n 1.14.7
Installing kramdown 2.5.1
Installing xml-simple 1.1.9
Fetching jls-lumberjack 0.0.26
Fetching semantic_logger 3.4.1
Installing rspec-expectations 3.13.5
Installing rspec-mocks 3.13.5
Installing http-cookie 1.1.0 (was 1.0.8)
Fetching net-http 0.6.0
Fetching pleaserun 0.0.32
Installing thwait 0.2.0
Fetching spoon 0.0.6
Fetching psych 5.2.6 (java)
Installing tzinfo 2.0.6
Fetching manticore 0.9.1 (java)
Installing i18n 1.14.7
Installing gene_pool 1.5.0
Installing jls-lumberjack 0.0.26
Fetching puma 6.6.1 (java)
Fetching mustermann 3.0.4
Fetching rack-protection 4.1.1
Installing semantic_logger 3.4.1
Fetching rack-session 2.1.1
Installing net-http 0.6.0
Installing pleaserun 0.0.32
Fetching rack-test 2.2.0
Installing spoon 0.0.6
Fetching treetop 1.6.14
Installing psych 5.2.6 (java)
Fetching memoizable 0.4.2
Fetching nokogiri 1.18.10 (java)
  jar dependencies for psych-5.2.6-java.gemspec . . .
Installing gem 'ruby-maven' . . .
Installing manticore 0.9.1 (java)
Installing puma 6.6.1 (java)
Installing mustermann 3.0.4
Installing rack-protection 4.1.1
Fetching parser 3.3.9.0
Installing rack-session 2.1.1
Fetching net-protocol 0.2.2
Installing rack-test 2.2.0
Fetching unicode-display_width 3.2.0 (was 3.1.5)
Fetching simplecov 0.22.0
Fetching aws-sdk-core 3.233.0 (was 3.226.3)
Fetching down 5.2.4
Fetching json-schema 2.8.1
Installing treetop 1.6.14
Installing memoizable 0.4.2
Fetching webhdfs 0.11.0
Fetching metriks 0.9.9.8
Fetching webmock 3.25.1
Installing net-protocol 0.2.2
Fetching rspec 3.13.1
Installing unicode-display_width 3.2.0 (was 3.1.5)
Installing parser 3.3.9.0
Fetching http 3.3.0
Installing simplecov 0.22.0
Installing nokogiri 1.18.10 (java)
Installing aws-sdk-core 3.233.0 (was 3.226.3)
Installing down 5.2.4
Fetching et-orbi 1.4.0 (was 1.2.11)
Installing json-schema 2.8.1
Fetching tzinfo-data 1.2025.2
Installing webhdfs 0.11.0
Fetching faraday-net_http 3.4.1
Installing metriks 0.9.9.8
Fetching jruby-jms 1.3.0 (java)
Installing webmock 3.25.1
Fetching pry 0.15.2 (java)
Fetching fpm 1.16.0
Installing rspec 3.13.1
Installing http 3.3.0
Fetching sinatra 4.1.1
Installing gem 'ruby-maven-libs' . . .
Installing et-orbi 1.4.0 (was 1.2.11)
Fetching net-imap 0.5.10
Fetching net-pop 0.1.2
Installing tzinfo-data 1.2025.2
Installing faraday-net_http 3.4.1
Installing jruby-jms 1.3.0 (java)
Fetching net-smtp 0.5.1
Installing pry 0.15.2 (java)
Fetching simplecov-json 0.2.3
Installing fpm 1.16.0
Fetching rubocop-ast 1.42.0
Installing sinatra 4.1.1
Installing net-imap 0.5.10
Installing net-pop 0.1.2
Fetching ci_reporter_rspec 1.0.0
Installing net-smtp 0.5.1
Fetching rspec-wait 1.0.2
Installing simplecov-json 0.2.3
Fetching fugit 1.12.0 (was 1.11.2)
Fetching faraday 2.14.0 (was 2.13.4)
Fetching twitter 6.2.0
Installing rubocop-ast 1.42.0
Fetching aws-sdk-cloudwatch 1.122.0 (was 1.116.0)
Fetching aws-sdk-cloudfront 1.129.0 (was 1.119.0)
Installing ci_reporter_rspec 1.0.0
Fetching aws-sdk-kms 1.113.0 (was 1.106.0)
Installing rspec-wait 1.0.2
Fetching aws-sdk-resourcegroups 1.88.0 (was 1.83.0)
Fetching aws-sdk-sns 1.106.0 (was 1.100.0)
Fetching aws-sdk-sqs 1.104.0 (was 1.96.0)
Installing fugit 1.12.0 (was 1.11.2)
Fetching mail 2.8.1
Fetching rufus-scheduler 3.9.2
Installing faraday 2.14.0 (was 2.13.4)
Installing twitter 6.2.0
Fetching rubocop 1.74.0
Installing aws-sdk-cloudfront 1.129.0 (was 1.119.0)
Installing aws-sdk-cloudwatch 1.122.0 (was 1.116.0)
Fetching elastic-transport 8.4.0
Fetching sawyer 0.9.2

using maven for the first time results in maven
downloading all its default plugin and can take time.
as those plugins get cached on disk and further execution
of maven is much faster then the first time.

Installing aws-sdk-kms 1.113.0 (was 1.106.0)
Installing aws-sdk-resourcegroups 1.88.0 (was 1.83.0)
Installing aws-sdk-sqs 1.104.0 (was 1.96.0)
Fetching aws-sdk-s3 1.199.1 (was 1.192.0)
Installing aws-sdk-sns 1.106.0 (was 1.100.0)
Installing rufus-scheduler 3.9.2
Installing mail 2.8.1
Installing rubocop 1.74.0
Installing elastic-transport 8.4.0
Installing sawyer 0.9.2
Fetching octokit 4.25.1
Fetching elasticsearch 8.19.1 (was 8.18.1)
Installing aws-sdk-s3 1.199.1 (was 1.192.0)
Installing octokit 4.25.1
Installing elasticsearch 8.19.1 (was 8.18.1)
Fetching logstash-mixin-validator_support 1.1.1 (java)
Fetching logstash-mixin-ca_trusted_fingerprint_support 1.0.1 (java)
Fetching logstash-mixin-ecs_compatibility_support 1.3.0 (java)
Fetching logstash-mixin-event_support 1.0.1 (java)
Fetching logstash-mixin-normalize_config_support 1.0.0 (java)
Fetching logstash-mixin-deprecation_logger_support 1.0.0 (java)
Fetching logstash-mixin-scheduler 1.0.1 (java)
Fetching logstash-mixin-plugin_factory_support 1.0.0 (java)
Fetching logstash-codec-dots 3.0.6
Installing logstash-mixin-ecs_compatibility_support 1.3.0 (java)
Fetching logstash-patterns-core 4.3.4
Installing logstash-mixin-validator_support 1.1.1 (java)
Fetching logstash-codec-rubydebug 3.1.0
Installing logstash-mixin-normalize_config_support 1.0.0 (java)
Installing logstash-mixin-event_support 1.0.1 (java)
Fetching logstash-filter-aggregate 2.10.0
Installing logstash-mixin-plugin_factory_support 1.0.0 (java)
Fetching logstash-filter-anonymize 3.0.7
Fetching logstash-filter-cidr 3.1.3 (java)
Fetching logstash-filter-date 3.1.15
Installing logstash-mixin-deprecation_logger_support 1.0.0 (java)
Fetching logstash-filter-de_dot 1.1.0
Installing logstash-mixin-scheduler 1.0.1 (java)
Fetching logstash-filter-dissect 1.2.5
Installing logstash-mixin-ca_trusted_fingerprint_support 1.0.1 (java)
Fetching logstash-filter-dns 3.2.0
Installing logstash-codec-dots 3.0.6
Fetching logstash-filter-drop 3.0.5
Installing logstash-patterns-core 4.3.4
Installing logstash-codec-rubydebug 3.1.0
Installing logstash-filter-aggregate 2.10.0
Fetching logstash-filter-elastic_integration 9.1.1 (java)
Fetching logstash-filter-memcached 1.2.0
Installing logstash-filter-anonymize 3.0.7
Installing logstash-filter-cidr 3.1.3 (java)
Fetching logstash-filter-metrics 4.0.7
Fetching logstash-filter-mutate 3.5.8
Fetching logstash-filter-prune 3.0.4
Installing logstash-filter-date 3.1.15
Installing logstash-filter-de_dot 1.1.0
Fetching logstash-filter-ruby 3.1.8
Fetching logstash-filter-sleep 3.0.7
Installing logstash-filter-dissect 1.2.5
Installing logstash-filter-dns 3.2.0
Fetching logstash-filter-split 3.1.8
Fetching logstash-filter-throttle 4.0.4
Installing logstash-filter-drop 3.0.5
Fetching logstash-filter-truncate 1.0.6
Fetching logstash-filter-urldecode 3.0.6
      org.snakeyaml:snakeyaml-engine:2.9:compile
Fetching logstash-filter-uuid 3.0.5
Installing logstash-filter-memcached 1.2.0
Fetching logstash-filter-xml 4.3.2
Installing logstash-filter-metrics 4.0.7
Fetching logstash-output-email 4.1.3
Installing logstash-filter-mutate 3.5.8
Fetching logstash-output-graphite 3.1.6
Installing logstash-filter-prune 3.0.4
Fetching logstash-output-lumberjack 3.1.9
Installing logstash-filter-ruby 3.1.8
Installing logstash-filter-sleep 3.0.7
Fetching logstash-output-redis 5.2.0
Installing logstash-filter-split 3.1.8
Fetching logstash-output-webhdfs 3.1.0 (java)
Fetching logstash-filter-clone 4.2.0
Installing logstash-filter-throttle 4.0.4
Fetching logstash-filter-fingerprint 3.4.4
Installing logstash-filter-truncate 1.0.6
Installing logstash-filter-urldecode 3.0.6
Fetching logstash-filter-geoip 7.3.1 (java)
Installing logstash-filter-uuid 3.0.5
Fetching logstash-filter-syslog_pri 3.2.1
Installing logstash-filter-xml 4.3.2
Fetching logstash-filter-useragent 3.3.5 (java)
Installing logstash-output-email 4.1.3
Fetching logstash-filter-csv 3.1.1
Fetching logstash-filter-json 3.2.1
Installing logstash-output-graphite 3.1.6
Fetching logstash-filter-kv 4.7.0
Installing logstash-output-lumberjack 3.1.9
Fetching logstash-codec-avro 3.4.1 (java)
Installing logstash-output-redis 5.2.0
Fetching logstash-codec-cef 6.2.8 (java)
Installing logstash-output-webhdfs 3.1.0 (java)
Installing logstash-filter-clone 4.2.0
Fetching logstash-codec-collectd 3.1.0
Installing logstash-filter-fingerprint 3.4.4
Fetching logstash-codec-edn 3.1.0
Fetching logstash-codec-line 3.1.1
Installing logstash-filter-elastic_integration 9.1.1 (java)
Fetching logstash-codec-fluent 3.4.3 (java)
Installing logstash-filter-syslog_pri 3.2.1
Fetching logstash-codec-json 3.1.1
Installing logstash-filter-useragent 3.3.5 (java)
Installing logstash-filter-csv 3.1.1
Fetching logstash-codec-json_lines 3.2.2
Installing logstash-filter-json 3.2.1
Fetching logstash-codec-netflow 4.3.2
Fetching logstash-codec-msgpack 3.1.0 (java)
Installing logstash-filter-kv 4.7.0
Fetching logstash-codec-plain 3.1.0
Installing logstash-codec-avro 3.4.1 (java)
Fetching logstash-input-twitter 4.1.1
Installing logstash-codec-cef 6.2.8 (java)
Fetching logstash-filter-elasticsearch 4.3.1
Installing logstash-codec-collectd 3.1.0
Fetching logstash-input-elasticsearch 5.2.1
Installing logstash-codec-edn 3.1.0
Fetching logstash-output-elasticsearch 12.0.7 (java)
Installing logstash-codec-line 3.1.1
Fetching logstash-output-stdout 3.1.4
Installing logstash-codec-fluent 3.4.3 (java)
Fetching logstash-codec-multiline 3.1.2
Installing logstash-codec-json 3.1.1
Installing logstash-codec-json_lines 3.2.2
Fetching logstash-filter-grok 4.4.3
Fetching logstash-filter-translate 3.5.0 (was 3.4.3)
Installing logstash-codec-netflow 4.3.2
Installing logstash-codec-msgpack 3.1.0 (java)
Fetching logstash-codec-edn_lines 3.1.0
Installing logstash-codec-plain 3.1.0
Fetching logstash-codec-es_bulk 3.1.0
Installing logstash-input-twitter 4.1.1
Fetching logstash-codec-graphite 3.0.6
Fetching logstash-input-stdin 3.4.0
Installing logstash-filter-elasticsearch 4.3.1
Installing logstash-input-elasticsearch 5.2.1
Fetching logstash-input-unix 3.1.2
Fetching logstash-input-redis 3.7.1
Installing logstash-output-elasticsearch 12.0.7 (java)
Installing logstash-output-stdout 3.1.4
Fetching logstash-integration-rabbitmq 7.4.0 (java)
Installing logstash-codec-multiline 3.1.2
Fetching logstash-output-tcp 7.0.1
Installing logstash-filter-grok 4.4.3
Fetching logstash-output-udp 3.2.0
Fetching logstash-output-file 4.3.0
Installing logstash-filter-translate 3.5.0 (was 3.4.3)
Installing logstash-codec-edn_lines 3.1.0
Fetching logstash-devutils 2.6.2 (java)
Fetching logstash-mixin-http_client 7.5.0
Installing logstash-codec-es_bulk 3.1.0
Fetching logstash-input-azure_event_hubs 1.5.2
Installing logstash-codec-graphite 3.0.6
Fetching logstash-input-couchdb_changes 3.1.6
Installing logstash-input-stdin 3.4.0
Fetching logstash-input-dead_letter_queue 2.0.1
Installing logstash-input-unix 3.1.2
Fetching logstash-input-http 4.1.3 (java)
Installing logstash-input-redis 3.7.1
Fetching logstash-input-exec 3.6.0
Installing logstash-integration-rabbitmq 7.4.0 (java)
Installing logstash-output-tcp 7.0.1
Installing logstash-filter-geoip 7.3.1 (java)
Fetching logstash-input-ganglia 3.1.4
Fetching logstash-input-gelf 3.3.2
Installing logstash-output-udp 3.2.0
Fetching logstash-input-generator 3.1.0
Installing logstash-output-file 4.3.0
Fetching logstash-input-heartbeat 3.1.1
Installing logstash-devutils 2.6.2 (java)
Fetching logstash-input-jms 3.3.1 (java)
Installing logstash-mixin-http_client 7.5.0
Fetching logstash-input-pipe 3.1.0
Installing logstash-input-couchdb_changes 3.1.6
Fetching logstash-input-udp 3.5.0
Installing logstash-input-dead_letter_queue 2.0.1
Fetching logstash-integration-aws 7.2.1 (java)
Fetching logstash-integration-jdbc 5.6.1
Installing logstash-input-azure_event_hubs 1.5.2
Installing logstash-input-exec 3.6.0
Fetching logstash-integration-kafka 11.6.4 (java)
Installing logstash-input-http 4.1.3 (java)
Installing logstash-input-gelf 3.3.2
Fetching logstash-integration-snmp 4.1.0 (java) (was 4.0.7)
Installing logstash-input-ganglia 3.1.4
Installing logstash-input-generator 3.1.0
Fetching logstash-output-nagios 3.0.6
Installing logstash-input-heartbeat 3.1.1
Fetching logstash-output-null 3.0.5
Installing logstash-input-jms 3.3.1 (java)
Fetching logstash-output-pipe 3.0.6
Fetching logstash-input-beats 7.0.3 (java)
Installing logstash-input-pipe 3.1.0
Fetching logstash-input-file 4.4.6
Installing logstash-input-udp 3.5.0
Fetching logstash-input-tcp 7.0.3 (java)
Fetching logstash-input-syslog 3.7.1
Installing logstash-integration-aws 7.2.1 (java)
Fetching logstash-output-csv 3.0.10
Fetching logstash-filter-http 2.0.0
Installing logstash-integration-jdbc 5.6.1
Fetching logstash-input-http_poller 6.0.0
Installing logstash-output-nagios 3.0.6
Fetching logstash-output-http 6.0.0
Installing logstash-output-null 3.0.5
Fetching logstash-input-elastic_serverless_forwarder 2.0.0 (java)
Installing logstash-output-pipe 3.0.6
Installing logstash-integration-kafka 11.6.4 (java)
Fetching logstash-integration-logstash 1.0.4 (java)
Installing logstash-integration-snmp 4.1.0 (java) (was 4.0.7)
Installing logstash-input-file 4.4.6
Installing logstash-input-beats 7.0.3 (java)
Installing logstash-input-syslog 3.7.1
Installing logstash-input-tcp 7.0.3 (java)
Installing logstash-output-csv 3.0.10
Installing logstash-filter-http 2.0.0
Installing logstash-input-http_poller 6.0.0
Fetching logstash-input-graphite 3.0.6
Installing logstash-output-http 6.0.0
Installing logstash-input-elastic_serverless_forwarder 2.0.0 (java)
Installing logstash-integration-logstash 1.0.4 (java)
Installing logstash-input-graphite 3.0.6
Bundle updated!
Post-install message from atomic:
This gem has been deprecated and merged into Concurrent Ruby (http://concurrent-ruby.com).
Post-install message from jar-dependencies:

if you want to use the executable lock_jars then install ruby-maven gem before using lock_jars

  $ gem install ruby-maven -v '~> 3.9'

or add it as a development dependency to your Gemfile

   gem 'ruby-maven', '~> 3.9'

Post-install message from logstash-filter-elastic_integration:
This Logstash plugin embeds a subset of Elasticsearch (https://elastic.co/)
and packages from Apache Lucene, including software developed by The Apache
Software Foundation (http://www.apache.org/).
➜  logstash git:(new-lockfile-9.2) ✗ git push -f origin new-lockfile-9.2
Enumerating objects: 4, done.
Counting objects: 100% (4/4), done.
Delta compression using up to 12 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 5.62 KiB | 1.12 MiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
remote:
remote: Create a pull request for 'new-lockfile-9.2' on GitHub by visiting:
remote:      https://github.com/donoghuc/logstash/pull/new/new-lockfile-9.2
remote:
To github.com:donoghuc/logstash.git
 * [new branch]            new-lockfile-9.2 -> new-lockfile-9.2
 ```