### PR TITLE
Ensure docs gen inserts at correct place in file

### DIFF
--- a/tools/release/generate_release_notes_md.rb
+++ b/tools/release/generate_release_notes_md.rb
@@ -42,7 +42,7 @@ release_notes = IO.read(RELEASE_NOTES_PATH).split("\n")
 
 coming_tag_index = release_notes.find_index {|line| line.match(/^## #{current_release} \[logstash-#{current_release}-release-notes\]$/) }
 coming_tag_index += 1 if coming_tag_index
-release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/\[logstash-\d+-release-notes\]$/) }
+release_notes_entry_index = coming_tag_index || release_notes.find_index {|line| line.match(/^## .*\[logstash-.*-release-notes\]$/) }
 
 unless coming_tag_index
   report << "## #{current_release} [logstash-#{current_release}-release-notes]\n\n"


### PR DESCRIPTION
The regex for finding the latest release (as a fallback when current is not in the file) had a bug. This caused the generated docs to be inserted at the wrong place in the file (the end of the file) instead of the top. This commit fixes the logic such that we find the last release when the current is not found.

Closes https://github.com/elastic/logstash/issues/17952