### PR TITLE
Update default container config to avoid deprecation warning

### DIFF
--- a/docker/data/logstash/config/logstash-full.yml
+++ b/docker/data/logstash/config/logstash-full.yml
@@ -1,2 +1,2 @@
-http.host: "0.0.0.0"
+api.http.host: "0.0.0.0"
 xpack.monitoring.elasticsearch.hosts: [ "http://elasticsearch:9200" ]

--- a/docker/data/logstash/config/logstash-oss.yml
+++ b/docker/data/logstash/config/logstash-oss.yml
@@ -1,1 +1,1 @@
-http.host: "0.0.0.0"
+api.http.host: "0.0.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
The default configuration for logstash container images no longer warns of a deprecated `http.host` configuration option.

## What does this PR do?
Use the `api.http.host` instead of `http.post` in the default container config to avoid noisy deprecation warnings. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
Consumers of container will not need to modify the default config to avoid seeing deprecation warnings. 

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
