### PR TITLE
Adds integration test for the `_health_report` and `_node/plugins` APIs.

### DIFF
--- a/qa/integration/services/monitoring_api.rb
+++ b/qa/integration/services/monitoring_api.rb
@@ -79,4 +79,9 @@ class MonitoringAPI
     resp = Manticore.get("http://localhost:#{@port}/_health_report").body
     JSON.parse(resp)
   end
+
+  def node_plugins
+    resp = Manticore.get("http://localhost:#{@port}/_node/plugins").body
+    JSON.parse(resp)
+  end
 end


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
This PR adds an integration test for the `_health_report` and `_node/plugins` APIs.


## Why is it important/What is the impact to the user?
No user impact

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- Closes #18304 

## Use cases


## Screenshots

## Logs
