### PR TITLE
Modified logger config to link deprecation logger to root logger by default

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -157,9 +157,9 @@ appender.deprecation_rolling.strategy.max = 30
 logger.deprecation.name = org.logstash.deprecation
 logger.deprecation.level = WARN
 logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
-logger.deprecation.additivity = false
+logger.deprecation.additivity = true
 
 logger.deprecation_root.name = deprecation
 logger.deprecation_root.level = WARN
 logger.deprecation_root.appenderRef.deprecation_rolling.ref = deprecation_plain_rolling
-logger.deprecation_root.additivity = false
+logger.deprecation_root.additivity = true

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -289,7 +289,7 @@ class LogStash::Runner < Clamp::StrictCommand
                                            :java_home => java.lang.System.getProperty("java.home"))
     end
 
-    logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]
+    deprecation_logger.deprecated I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]
     # Skip any validation and just return the version
     if version?
       show_version


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
- Modified logger config to link deprecation logger to root logger by default.

## What does this PR do?
- Previous default logger configuration wasn't linking deprecation logger to root (plain) logger. As a result, users who weren't aware about the [additivity parameter](https://logging.apache.org/log4j/2.x/manual/configuration.html#logger-attributes-additivity) in Apache Log4j2 logger might be overlooking the deprecation logs. With this change, the deprecation logger is linked to the root by default and will only be unlinked if the user sets`additivity parameter` to `false`.
- Changed `JAVA_HOME` deprecated log to be logged by deprecation logger.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
- This commit lets users that are using the default logger configuration to be aware about deprecation logs just following Logstash default output

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [X] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally
- Fetch Logstash version containing this changes, call `deprecation_logger.deprecated()` function with a test message and see it appears at default output as a WARN log.
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #18314 
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
