### PR TITLE
Run unit tests with full set of gems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,7 @@ project(":logstash-core") {
   ["rubyTests", "test"].each { tsk ->
     tasks.getByPath(":logstash-core:" + tsk).configure {
       dependsOn copyPluginTestAlias
+      dependsOn installDefaultGems
       dependsOn installDevelopmentGems
     }
   }
@@ -932,6 +933,7 @@ if (System.getenv('OSS') != 'true') {
   project(":logstash-xpack") {
     ["rubyTests", "rubyIntegrationTests", "test"].each { tsk ->
       tasks.getByPath(":logstash-xpack:" + tsk).configure {
+        dependsOn installDefaultGems
         dependsOn installDevelopmentGems
       }
     }


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Previously unit tests were run with a subset of gems. This masked issues where conflicts (specifically with loading jar-dependencies) with gem load/activation were causing issues. This updates the tests to install the full gem set for unit tests. The added test time is minimal (less than a minute) and should give us a more consistent gem environment for testing.

See https://github.com/elastic/logstash/issues/17873 for more details. 
