### PR TITLE
[DOCS] Fix OpenAPI enum error

### DIFF
--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -2354,7 +2354,8 @@ components:
                       type: object
                       properties:
                         goal:
-                          - enum:
+                          type: string
+                          enum:
                               - speed
                               - balanced
                               - size


### PR DESCRIPTION
## Release notes

[rn:skip] 

## What does this PR do?

Fixes the following linting error returned from ` redocly lint logstash-api.yaml --config redocly.yaml`:

```
[1] logstash-api.yaml:2357:27 at #/components/schemas/PipelineQueueStats/properties/queue/oneOf/0/properties/compression/properties/encode/properties/goal

Expected type `Schema` (object) but got `array`

2355 | properties:
2356 |   goal:
2357 |     - enum:
2358 |         - speed
   … |         < 2 more lines >
2361 |   ratio:
2362 |     type: object
2363 |     description: the ratio of event size in bytes to its representation on disk

Error was generated by the struct rule.
```

The `goal` property was missing a `type`.

## Why is it important/What is the impact to the user?

It caused the following error when we uploaded the OpenAPI docs:

`04:23:22 PM A JSON schema MUST be of type 'object'. Provided type 'Array' is not valid, we had to ignore this schema.`

Thus it seems to have made the OpenAPI document invalid or incomplete.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

N/A

## How to test this PR locally

Rerunning `redocly lint logstash-api.yaml --config redocly.yaml` confirms that the error no longer exists.

## Related issues

- Relates https://github.com/elastic/logstash/pull/18230

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A
