### PR TITLE
Set 45m timeout to exhaustive pipeline jobs.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -448,7 +448,7 @@ spec:
     spec:
       repository: elastic/logstash
       pipeline_file: ".buildkite/exhaustive_tests_pipeline.yml"
-      maximum_timeout_in_minutes: 90
+      maximum_timeout_in_minutes: 45
       provider_settings:
         build_branches: true
         build_pull_request_forks: false


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Sets 45 min timeout to exhaustive pipeline CI jobs.

## Why is it important/What is the impact to the user?
No user impact

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
