### PR TITLE
simplify x-pack/build.gradle

### DIFF
--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -7,7 +7,6 @@
 description = """Logstash X-Pack"""
 
 project.ext.LOGSTASH_CORE_PATH = "${projectDir}/../logstash-core"
-apply from: "../rubyUtils.gradle"
 
 repositories {
   mavenCentral()
@@ -62,7 +61,7 @@ tasks.register("rubyIntegrationTests", Test) {
   }
   testClassesDirs = sourceSets.test.output.classesDirs
   classpath = sourceSets.test.runtimeClasspath
-  dependsOn (":copyEs")
+  dependsOn ":copyEs"
   dependsOn ":assemble"
   dependsOn "buildFipsValidationGem"
   inputs.files fileTree("${projectDir}/qa")


### PR DESCRIPTION
There is no need to apply rubyUtils.gradle to `x-pack/build.gralde`, which defined the entire set of tasks from the former into the latter. This can lead to confusing situations like running `./gradlew downloadAndInstallJRuby` installing JRuby twice (once in project root and another in x-pack/) since gradle will run all tasks matching that name.

Exhaustive test suite passed: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/2803/steps/canvas