### PR TITLE
[9.2] [DOCS] Fix OpenAPI enum error (#18344)

### DIFF
--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -2364,7 +2364,8 @@ components:
                       type: object
                       properties:
                         goal:
-                          - enum:
+                          type: string
+                          enum:
                               - speed
                               - balanced
                               - size


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[DOCS] Fix OpenAPI enum error (#18344)](https://github.com/elastic/logstash/pull/18344)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)