### PR TITLE
Ensure java updator runs on all active branches

### DIFF
--- a/.github/workflows/bump-java-version.yml
+++ b/.github/workflows/bump-java-version.yml
@@ -8,16 +8,27 @@ on:
 
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - id: generator
+        uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          exclude-branches: "7.17"
+          filter-branches: true
   bump:
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    needs: [filter]
     strategy:
-      matrix:
-        # When this workflow is triggered (manually or scheduled), it will update all the branches in this list
-        # Make sure to keep this list up to date with the "active" branchges in logstash. 
-        branch: ['main', '9.2', '9.1', '8.19']
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Previously the java updator action would run against only the main branch when the schedule triggered. This is because the schedule action only tracks the default branch in a repo. The other branches could be triggered manually with a workflow dispatch trigger (along with configuring "which branch to run workflow from"). This old pattern is now replaced with a matrix job which runs the action across all the active branches. This allows the schedule to update everything and reduces manual inputs when triggering with workflow dispatch.
