### PR TITLE
fix(core): Use absolute string anchors in regex to prevent multi-line validation bypass

### DIFF
--- a/logstash-core/lib/logstash/util/thread_safe_attributes.rb
+++ b/logstash-core/lib/logstash/util/thread_safe_attributes.rb
@@ -21,7 +21,7 @@ module LogStash
     module ThreadSafeAttributes
       # Thread-safe lazy initialized attribute with a given (variable) name.
       def lazy_init_attr(attribute, variable: "@#{attribute}".to_sym, &block)
-        raise ArgumentError.new("invalid attribute name: #{attribute}") unless attribute.match? /^[_A-Za-z]\w*$/
+        raise ArgumentError.new("invalid attribute name: #{attribute}") unless attribute.match? /\A[_A-Za-z]\w*\z/
         raise ArgumentError.new('no block given') unless block_given?
         send(:define_method, attribute.to_sym) do
           if instance_variable_defined?(variable)


### PR DESCRIPTION
To correctly validate that the input string represents a valid attribute name and does not allow multi-line bypass, change the regular expression on line 24 to use the absolute string anchors `\A` and `\z` instead of the line anchors `^` and `$`. Specifically, replace `/^[_A-Za-z]\w*$/` with `/\A[_A-Za-z]\w*\z/`. No other modifications or imports are needed, and existing functionality will be preserved. The change should be made only to line 24 in `logstash-core/lib/logstash/util/thread_safe_attributes.rb`, replacing the vulnerable regex.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works



## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

#### 🎟️Related issues https://github.com/elastic/logstash/issues/18414
