### PR TITLE
WIP: Upgrade from 8.19 in exhaustive tests

### DIFF
--- a/qa/acceptance/spec/lib/artifact_operation_spec.rb
+++ b/qa/acceptance/spec/lib/artifact_operation_spec.rb
@@ -23,5 +23,5 @@ require_relative '../shared_examples/updated'
 describe "artifacts operation" do
   logstash = ServiceTester::Artifact.new()
   it_behaves_like "installable_with_jdk", logstash
-  it_behaves_like "updated", logstash, from_release_branch="7.17"
+  it_behaves_like "updated", logstash, from_release_branch="8.19"
 end


### PR DESCRIPTION
7.17 is reaching EOL. Upgrade from 8.19 instead.

Test if this fixes CI, then figure out how we want to move forward. 
