### PR TITLE
Validate supplied branch and tag exist for RN gen

### DIFF
--- a/.github/workflows/gen_release_notes.yml
+++ b/.github/workflows/gen_release_notes.yml
@@ -21,21 +21,24 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.event.inputs.branch }}
+      LAST_RELEASE: ${{ github.event.inputs.last_release }}
+      ACTOR: ${{ github.actor }}
     steps:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        fetch-tags: true
     - name: Validate the supplied target branch and last release tag exist
       run: |
-        git fetch --tags
-        
-        if ! git rev-parse --verify "origin/${{ github.event.inputs.branch }}" >/dev/null 2>&1; then
-          echo "Error: Branch ${{ github.event.inputs.branch }} does not exist"
+        if ! git rev-parse --verify "origin/${BRANCH}" >/dev/null 2>&1; then
+          echo "Error: Branch ${BRANCH} does not exist"
           exit 1
         fi
-        
-        if ! git rev-parse --verify "v${{ github.event.inputs.last_release }}" >/dev/null 2>&1; then
-          echo "Error: Tag v${{ github.event.inputs.last_release }} does not exist"
+
+        if ! git rev-parse --verify "v${LAST_RELEASE}" >/dev/null 2>&1; then
+          echo "Error: Tag v${LAST_RELEASE} does not exist"
           exit 1
         fi
     - name: Set up Ruby
@@ -46,12 +49,12 @@ jobs:
     - run: git config --global user.name "logstashmachine"
     - name: Create Release Notes Draft
       run: |
-        if [[ "${{ github.event.inputs.branch }}" =~ ^([0-8])\.[0-9]+$ ]]; then
+        if [[ "${BRANCH}" =~ ^([0-8])\.[0-9]+$ ]]; then
           echo "Using Asciidoc generator"
           SCRIPT="./tools/release/generate_release_notes.rb"
         else
           echo "Using Markdown generator"
           SCRIPT="./tools/release/generate_release_notes_md.rb"
         fi
-        
-        $SCRIPT "${{ github.event.inputs.branch }}" "${{ github.event.inputs.last_release }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
+
+        $SCRIPT "${BRANCH}" "${LAST_RELEASE}" "${ACTOR}" "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Add a validation step to the action for generating release notes. Without input validation tags/branches that do not exist (due to typo, errors in workflow inputs) can go un-noticed with PRs that have empty commit ranges.

