### PR TITLE
Snyk scanning pipeline fixes.

### DIFF
--- a/.buildkite/scripts/snyk/plugins-scan/generate-steps.py
+++ b/.buildkite/scripts/snyk/plugins-scan/generate-steps.py
@@ -69,7 +69,6 @@ def parse_plugin_entry(entry) -> list:
     Entries can be either:
     - A simple string: "logstash-filter-date" -> uses default branch, no logstash
     - A dict with scan_branches: explicit list of {branch, logstash} pairs
-    - A dict with requires_logstash_core: true -> clones and builds logstash main
     - A dict with branches: list of plugin branches
     """
     if isinstance(entry, str):
@@ -77,15 +76,11 @@ def parse_plugin_entry(entry) -> list:
 
     if isinstance(entry, dict):
         scan_branches = None
-        requires_logstash_core = False
-        branches = [DEFAULT_BRANCH]
 
         for key, value in entry.items():
             plugin_name = key
             if isinstance(value, dict):
                 scan_branches = value.get('scan_branches')
-                requires_logstash_core = value.get('requires_logstash_core', False)
-                branches = value.get('branches') or branches
 
         # If scan_branches is defined, use it directly (explicit branch pairs)
         if scan_branches:
@@ -108,12 +103,10 @@ def parse_plugin_entry(entry) -> list:
             else:
                 resolved_branches.append(branch)
 
-        # Determine logstash branch for each plugin branch
+        # Build result for each branch
         result = []
         for branch in set(resolved_branches):
-            # If requires_logstash_core is true, use 'main' branch for logstash
-            logstash_branch = DEFAULT_BRANCH if requires_logstash_core else None
-            result.append((plugin_name, branch, logstash_branch))
+            result.append((plugin_name, branch, None))
         return result
 
     return []

--- a/.buildkite/scripts/snyk/plugins-scan/plugins-snyk-scan-matrix.yaml
+++ b/.buildkite/scripts/snyk/plugins-scan/plugins-snyk-scan-matrix.yaml
@@ -1,26 +1,42 @@
 plugins:
   - logstash-filter-date:
-      requires_logstash_core: true
+      scan_branches:
+        - branch: main
+          logstash: main
   - logstash-filter-dissect:
-      requires_logstash_core: true
+      scan_branches:
+        - branch: main
+          logstash: main
   - logstash-filter-geoip:
-      requires_logstash_core: true
+      scan_branches:
+        - branch: main
+          logstash: main
   - logstash-filter-useragent
   - logstash-input-azure_event_hubs
   - logstash-input-dead_letter_queue:
-      requires_logstash_core: true
+      scan_branches:
+        - branch: main
+          logstash: main
   - logstash-input-file
   - logstash-integration-jdbc
   - logstash-integration-kafka:
-      branches: [main, 11.x]
+      scan_branches:
+        - branch: main
+        - branch: 11.x
   - logstash-integration-snmp
   - logstash-integration-aws
   - logstash-input-http:
-      branches: [main, 3.x]
+      scan_branches:
+        - branch: main
+        - branch: 3.x
   - logstash-input-tcp:
-      branches: [main, 6.x]
+      scan_branches:
+        - branch: main
+        - branch: 6.x
   - logstash-input-beats:
-      branches: [main, 6.x]
+      scan_branches:
+        - branch: main
+        - branch: 6.x
   - logstash-filter-elastic_integration:
       scan_branches:
         - branch: main


### PR DESCRIPTION
With this PR, the improvements are:
-  fixes the bug where `elastic_integration` is in the `elastic` org
-  snyk CLI needs to be located in the cloned plugin repo. CI jobs are green but if we open it Snyk CLI is actually not available: `/bin/bash: line 14: ./snyk: No such file or directory`
- introduces a feature to use Logstash branch in the matrix (e.g: `logstash_branch: 'main'`) if requires (e.g: `elastic_integration` or date-filter require logstash-core gems)

With the matrix definition, the key points are:
- `requires_logstash_core`: some plugins require LS core gems, we need to clone LS repo and define LS core path;
  - Some plugins in the matrix require Logstash core gems, some do not. For example the date-filter, its gradle requires `logstashCoreGemPath`, eventually `:vendor => "gradle.properties"` rake task creates it.
- `branches`: some plugins have multiple active branches (e.g: main, 11.x) to scan;
- `scan_branches`: `elastic_integration` plugin requires 1:1 branch map
