### PR TITLE
Keep psych minor version in line with jruby 9.4.13.0

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -44,3 +44,4 @@ gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default
+gem 'psych', '~> 5.2.3' # Pins psych to minor version corresponding with jruby 9.4.13.0 to keep snakeyaml-engine dep in line (5.3 includes newer snakeyaml-engine dep)


### PR DESCRIPTION
The latest psych 5.3 minor version has bumped snakeyaml-engine https://github.com/ruby/psych/pull/762. This is causing issues in bundler. Constrain the psych gem to the 5.2 minor version while we are still on jruby 9.4.13.0.

The issue presents as:
```
Errno::ENOENT: No such file or directory - /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/gems/shared/gems/psych-5.3.1-java/deps.lst
  org/jruby/RubyIO.java:1279:in `sysopen'
          org/jruby/RubyIO.java:4275:in `read'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/jars/installer.rb:75:in `load_from_maven'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/jars/installer.rb:220:in `install_dependencies'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/jars/installer.rb:209:in `do_install'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/jars/installer.rb:154:in `vendor_jars'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/defaults/jruby.rb:110:in `block in <main>'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/installer.rb:367:in `block in run_post_install_hooks'
          org/jruby/RubyArray.java:2009:in `each'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/rubygems/installer.rb:366:in `run_post_install_hooks'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/rubygems_gem_installer.rb:48:in `install'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/source/rubygems.rb:205:in `install'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:55:in `install'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:133:in `do_install'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/installer/parallel_installer.rb:124:in `block in worker_pool'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:62:in `apply_func'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:57:in `block in process_queue'
          org/jruby/RubyKernel.java:1725:in `loop'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:54:in `process_queue'
          /Users/cas/elastic-repos/logstash/vendor/jruby/lib/ruby/stdlib/bundler/worker.rb:90:in `block in create_threads'
```

There has been a long standing string of issues around this:
- https://github.com/jruby/jruby/issues/8606
- https://github.com/jruby/jruby/pull/8477
- https://github.com/jruby/jar-dependencies/issues/90
- https://github.com/ruby/psych/issues/690


The current issue seems to be that when psych depends on a different version of snakeyaml-engine that is shipped in jruby (Logstash is on 9.4.13.0 which vendors `snakeyaml-engine 2.9`). 