### PR TITLE
Stop tests from polluting maven settings

### DIFF
--- a/spec/unit/plugin_manager/proxy_support_spec.rb
+++ b/spec/unit/plugin_manager/proxy_support_spec.rb
@@ -30,7 +30,11 @@ describe "Proxy support" do
   end
 
   after do
-    FileUtils.mv(settings_backup, settings) if File.exist?(settings_backup)
+    if File.exist?(settings_backup)
+      FileUtils.mv(settings_backup, settings)
+    elsif File.exist?(settings)
+      FileUtils.rm(settings)
+    end
     environments.each { |key, _| ENV[key] = nil }
   end
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The pluginmanager tests modify `~/.m2/settings.xml`. Previously when that file exists it would be restored on test cleanup. However if that file did not exist prior to the tests, the file with nonsense values generated during testing would persist. This would cause subsequent issues when the pluginmanager or other systems that respect those maven settings. This commit updates the test to ensure the test file is deleted if it did not previously exist.

Previously any developer who run the tests locally and did not have an existing `~/.m2/settings.xml` would get a file with nonsense proxies which would break the pluginmanager's ability to download jar dependencies of gems. 

NOTE: Fortunately this did not affect logstash artifact creation because we do testing/packaging on separate hosts. 

## How to test this PR locally

```
# Ensure ~/.m2/settings.xml is empty or has "real" config in it
cat ~/.m2/settings.xml
# run tests 
./gradlew rubyTests
# Ensure settings.xml is the same (or does not exist if it did not previously). 
cat ~/.m2/settings.xml
```
## Logs

Previously the tests would leave behing a file like:

```
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
  https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <proxies>
    
    <proxy>
      <id>local.dev.0</id>
      <active>true</active>
      <protocol>http</protocol>
      <host>local.dev</host>
      <port>9898</port>
      <username>a</username>
      <password>b</password>
    </proxy>
  
    <proxy>
      <id>local.dev.1</id>
      <active>true</active>
      <protocol>https</protocol>
      <host>local.dev</host>
      <port>9898</port>
      <username>c</username>
      <password>d</password>
    </proxy>
  
  </proxies>
</settings>
```
This would cause issues with the pluginmanager when jar-dependencies need to dowload jars for gem installation. Unfortunately that is masked because of retry logic (the jar is failed to be downlaoded but the rest of the gem code *is*, so on the second retry the pluginmanager thinks the complete gem has been installed). 