### PR TITLE
Upgrade elastic_integration plugin after release.

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -301,7 +301,7 @@ GEM
       lru_redux (~> 1.1.0)
     logstash-filter-drop (3.0.5)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-elastic_integration (9.2.0-java)
+    logstash-filter-elastic_integration (9.3.0-java)
       logstash-core (>= 8.7.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-filter-elasticsearch (4.3.1)


### PR DESCRIPTION
Upgrades `elastic_integration` plugin after [9.3.0 release](https://rubygems.org/gems/logstash-filter-elastic_integration/versions/9.3.0-java)