### PR TITLE
Doc: Fix links in Logstash-to-serverless 8.18

### DIFF
--- a/docs/static/ls-to-serverless.asciidoc
+++ b/docs/static/ls-to-serverless.asciidoc
@@ -6,13 +6,13 @@ When you use Elasticsearch on Elastic Cloud Serverless you don’t need to worry
 
 .{ls} to {serverless-full}
 ****
-You’ll use the {ls} link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md[{es} output plugin] to send data to {serverless-full}.
+You'll use the {ls} link:https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html[{es} output plugin] to send data to {serverless-full}.
 Note these differences between {es-serverless} and both {ech} and self-managed {es}:
 
-* Use link:/reference/secure-connection.md#ls-api-keys[**API keys**] to access {serverless-full} from {ls} as it does not support native user authentication.
-  Any user-based security settings in your link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md[{es} output plugin] configuration are ignored and may cause errors.
-* {serverless-full} uses **data streams** and link:docs-content://manage-data/lifecycle/data-stream.md[{dlm} ({dlm-init})] instead of {ilm} ({ilm-init}). Any {ilm-init} settings in your link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md[{es} output plugin] configuration are ignored and may cause errors.
-* **{ls} monitoring** is available through the link:https://github.com/elastic/integrations/blob/main/packages/logstash/_dev/build/docs/README.md[{ls} Integration] in link:docs-content://solutions/observability.md[Elastic Observability] on {serverless-full}.
+* Use link:https://www.elastic.co/guide/en/logstash/8.18/ls-security.html#ls-api-keys[API keys] to access {serverless-full} from {ls} as it does not support native user authentication.
+  Any user-based security settings in your {ls} link:https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html[{es} output plugin] configuration are ignored and may cause errors.
+* {serverless-full} uses **data streams** and link:https://www.elastic.co/guide/en/elasticsearch/reference/8.18/data-stream-lifecycle.html[{dlm} ({dlm-init})] instead of {ilm} ({ilm-init}). Any {ilm-init} settings in your link:https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html[{es} output plugin] configuration are ignored and may cause errors.
+* **{ls} monitoring** is available through the link:https://github.com/elastic/integrations/blob/main/packages/logstash/docs/README.md[{ls} Integration] in link:https://www.elastic.co/guide/en/observability/8.18/index.html[Elastic Observability] on {serverless-full}.
 
 *Known issue for Logstash to Elasticsearch Serverless.* +
 The logstash-output-elasticsearch `hosts` setting defaults to port :9200. +
@@ -22,14 +22,14 @@ Set the value to port :443 instead.
 [[connecting-to-elasticsearch-serverless]]
 ==== Communication between {ls} and {es-serverless} 
 
-link:docs-content://solutions/search/serverless-elasticsearch-get-started.md[{es-serverless}] simplifies safe, secure communication between {ls} and {es}.
-When you configure the Elasticsearch output plugin to use link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-cloud_id[`cloud_id`] and an link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-api_key[`api_key`], no additional SSL configuration is needed.
+{es-serverless} simplifies safe, secure communication between {ls} and {es}.
+When you configure the Elasticsearch output plugin to use link:https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-cloud_id[`cloud_id`] and an https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-api_key[`api_key`], no additional SSL configuration is needed.
 
 Example:
 
 * `output {elasticsearch { cloud_id => "<cloud id>" api_key => "<api key>" } }`
 
-Note that the value of the link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-api_key[`api_key` option] is in the format `id:api_key`, where `id` and `api_key` are the values returned by the link:https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key[Create API key API].
+The value of the https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-api_key[`api_key` option] is in the format `id:api_key`, where `id` and `api_key` are the values returned by the link:https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key[Create API key API].
 
 [[cloud-id-serverless]]
 ===== Cloud ID 
@@ -48,10 +48,10 @@ This option formats the API key in the correct `id:api_key` format required by {
 
 The Elasticsearch input, output, and filter plugins, as well as the Elastic_integration filter plugin, support cloud_id in their configurations.
 
-* link:logstash-docs-md://lsr/plugins-inputs-elasticsearch.md#plugins-inputs-elasticsearch-cloud_id[Elasticsearch input plugin]
-* link:logstash-docs-md://lsr/plugins-filters-elasticsearch.md#plugins-filters-elasticsearch-cloud_id[Elasticsearch filter plugin]
-* link:logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-cloud_id[Elasticsearch output plugin]
-* link:logstash-docs-md://lsr/plugins-filters-elastic_integration.md#plugins-filters-elastic_integration-cloud_id[Elastic_integration filter plugin]
+* link:https://www.elastic.co/guide/en/logstash/8.18/plugins-inputs-elasticsearch.html#plugins-inputs-elasticsearch-cloud_id[{es} input plugin Cloud ID option]
+* link:https://www.elastic.co/guide/en/logstash/8.18/plugins-filters-elasticsearch.html#plugins-filters-elasticsearch-cloud_id[{es} filter plugin Cloud ID option]
+* link:https://www.elastic.co/guide/en/logstash/8.18/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-cloud_id[{es} output plugin Cloud ID option]
+* link:https://www.elastic.co/guide/en/logstash/8.18/plugins-filters-elastic_integration.html#plugins-filters-elastic_integration-cloud_id[Elastic_integration filter plugin Cloud ID option]
 
 [cpm-serverless]
 ==== Using {ls} Central Pipeline Management with {es-serverless} 


### PR DESCRIPTION
Fix asciidoc cross-doc links

PREVIEW:  https://logstash_bk_18540.docs-preview.app.elstc.co/guide/en/logstash/8.18/logstash-to-elasticsearch-serverless.html