### PR TITLE
Stop new snyk pipeline schedule while being developed

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -165,11 +165,12 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
-      schedules:
-        Daily Plugins Snyk scan:
-          branch: main
-          cronline: "@daily"
-          message: "Run the Logstash Plugins Snyk report every day."
+      #TODO: re-enable schedule once tests are expected to pass
+      # schedules:
+      #   Daily Plugins Snyk scan:
+      #     branch: main
+      #     cronline: "@daily"
+      #     message: "Run the Logstash Plugins Snyk report every day."
 
 # ***********************************
 # SECTION START: DRA pipelines


### PR DESCRIPTION
This pipeline is running on a schedule but still needs work. It is polluting the notifications channel with failures. This commit removes the schedule while the pipeline is still under development. This can be reverted once it is in a working state and expected to pass consistently.
