### PR TITLE
Only ship x-pack library code with artifacts

### DIFF
--- a/rakelib/artifacts.rake
+++ b/rakelib/artifacts.rake
@@ -263,9 +263,10 @@ namespace "artifact" do
     )
     license_details = ['ELASTIC-LICENSE','-observability-sre', exclude_paths]
     create_archive_pack(license_details, ARCH, "linux") do |dedicated_directory_tar|
-      # injection point: Use `DedicatedDirectoryTarball#write(source_file, destination_path)` to
-      # copy additional files into the tarball
-      puts "HELLO(#{dedicated_directory_tar})"
+      Dir.glob("x-pack/distributions/internal/observabilitySRE/config/**/*").each do |source_file|
+        next if File.directory?(source_file)
+        dedicated_directory_tar.write(source_file)
+      end
     end
   end
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Clean up unused files in `x-pack` for logstash artifacts. 

## What does this PR do?

This commit updates artifact generation to *only* include x-pack files which are needed at runtime for consumers of an artifact. Previously *all* files (including build/test/conf) were shipped which are unused at runtime and clutter up artifacts.

## Why is it important/What is the impact to the user?
Clean up artifacts such that unused files are not installed. 

## Related issues
-  Closes https://github.com/elastic/logstash/issues/18544
