### PR TITLE
Change kafka integration dependency to 11.x

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -559,7 +559,7 @@ GEM
       sequel (>= 5.74.0)
       tzinfo
       tzinfo-data
-    logstash-integration-kafka (12.0.2-java)
+    logstash-integration-kafka (11.8.1-java)
       logstash-codec-json
       logstash-codec-plain
       logstash-core (>= 8.3.0)


### PR DESCRIPTION
The original dependency bump changed the kafka dependency to 12.x which introduces a breaking change. This reverts the change back to 11.x

