### PR TITLE
docs: update security url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Logstash user base and our own goals for the project. Through this process, we t
 ## Found a Security Issue?
 
 If you've found a security issue, before submitting anything via a PR, please
-get in touch with our security team [here](https://www.elastic.co/community/security).
+get in touch with our security team [here](https://www.elastic.co/product-security).
 
 # Contributing Documentation and Code Changes
 
@@ -163,7 +163,7 @@ Labels (optional):
 - **`[DOC]`** for a change that affects only documentation, and not code.
 - **`[SECURITY]`** for a security fix. If you're working on a security issue, 
 please make sure to follow the process outlined by our security team. 
-If you haven't done so already, please [get in touch with them](https://www.elastic.co/community/security) first.
+If you haven't done so already, please [get in touch with them](https://www.elastic.co/product-security) first.
 
 Keywords (copied from [keepachangelog.com](https://keepachangelog.com/en/1.0.0/#how)):
 
@@ -176,7 +176,7 @@ Keywords (copied from [keepachangelog.com](https://keepachangelog.com/en/1.0.0/#
   - **Important reminder**: If you're working on a security issue, please make sure
   you're following the process outlined by our security team. If you haven't
   done so already, please get in touch with them
-  [here](https://www.elastic.co/community/security) first.
+  [here](https://www.elastic.co/product-security) first.
 
 Example:
 


### PR DESCRIPTION
This PR updates the security URL from `https://www.elastic.co/community/security` to `https://www.elastic.co/product-security`.