### PR TITLE
chore: delete SECURITY.md to use organization-wide policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,0 @@
-# Security Policy
-
-## Reporting a Vulnerability
-
-For security vulnerabilities please only send reports to security@elastic.co.
-See https://www.elastic.co/community/security for more information.


### PR DESCRIPTION
This PR deletes the repository-specific SECURITY.md file to consolidate to a single source of truth for the security policy, which is https://github.com/elastic/.github/blob/main/SECURITY.md.