### PR TITLE
docs: Use new `applies_to` version syntax

### DIFF
--- a/docs/reference/keystore.md
+++ b/docs/reference/keystore.md
@@ -138,8 +138,8 @@ When prompted, enter a value for each key.
 ::::{note}
 Key values are limited to:
 
-* {applies_to}`stack: ga 9.0.1` ASCII letters (`a`-`z`, `A`-`Z`), numbers (`0`-`9`), underscores (`_`), and dots (`.`). Key values must be at least one character long and cannot begin with a number.
-* {applies_to}`stack: ga 9.0.0` ASCII characters including digits, letters, and a few special symbols.
+* {applies_to}`stack: ga 9.0.1+!` ASCII letters (`a`-`z`, `A`-`Z`), numbers (`0`-`9`), underscores (`_`), and dots (`.`). Key values must be at least one character long and cannot begin with a number.
+* {applies_to}`stack: ga =9.0.0!` ASCII characters including digits, letters, and a few special symbols.
 ::::
 
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs-content/issues/4361

## Release notes

Skip

## What does this PR do?

This PR updates existing uses of `applies_to` in the docs to be more precise.

<img width="901" height="226" alt="Screenshot 2026-01-15 at 10 44 08 AM" src="https://github.com/user-attachments/assets/357e27eb-e3a5-4cb9-8c74-a686cb47794e" />

## Why is it important/What is the impact to the user?

We recently added support for more specific syntax for versions in `applies_to` badges including version ranges. Read more in [the docs-builder docs](https://elastic.github.io/docs-builder/syntax/applies/#version-syntax). 

## Related issues

- Relates to https://github.com/elastic/docs-content/issues/4361

cc @karenzone