### PR TITLE
Ensure building ubi8 images for 8.19 follows orchestration pattern

### DIFF
--- a/.buildkite/scripts/dra/build_docker.sh
+++ b/.buildkite/scripts/dra/build_docker.sh
@@ -30,7 +30,7 @@ export LOCAL_ARTIFACTS=false
 ./gradlew artifactDockerfiles || error "artifactDockerfiles build failed."
 
 if [[ "$ARCH" != "aarch64" ]]; then
-  rake artifact:docker_ubi8 || error "artifact:docker_ubi8 build failed."
+  ./gradlew artifactDockerUbi8 || error "artifactDockerUbi8 build failed."
 fi
 
 STACK_VERSION="$(./$(dirname "$0")/../common/qualified-version.sh)"

--- a/build.gradle
+++ b/build.gradle
@@ -348,6 +348,16 @@ tasks.register("artifactDockerWolfi") {
     }
 }
 
+tasks.register("artifactDockerUbi8") {
+    description = "Build UBI8 docker image"
+    dependsOn dockerBootstrap
+    dependsOn copyJdk
+
+    doLast {
+        rake(projectDir, buildDir, 'artifact:docker_ubi8')
+    }
+}
+
 tasks.register("artifactDockerfiles") {
     description = "Generate all Dockerfiles and build contexts"
 

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -62,7 +62,7 @@ elif [[ $SELECTED_TEST_SUITE == "full" ]]; then
 elif [[ $SELECTED_TEST_SUITE == "ubi8" ]]; then
   echo "--- Building $SELECTED_TEST_SUITE docker images"
   cd $LS_HOME
-  rake artifact:docker_ubi8
+  ./gradlew artifactDockerUbi8
   echo "--- Acceptance: Installing dependencies"
   cd $QA_DIR
   bundle install


### PR DESCRIPTION
While backporting unified pattern for doing task orchestration in logstash a use case that exists in 8.19 but not 9.x/main was discovered. Specifically building ubi8 based container artifacts. This commit extends the pattern for making every entry point into the build system be gradle. The same rake tasks are used, they just have a gradle wrapper like the other containers.

Follow up for https://github.com/elastic/logstash/commit/5109950309f35c15c67a7f63f4dfa98e086aa24f