### PR TITLE
Allow exhaustive tests to be triggered by org members

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -560,7 +560,7 @@ spec:
         build_tags: false
         filter_enabled: true
         filter_condition: >-
-          build.creator.name == 'elasticmachine' && build.pull_request.id != null
+          build.pull_request.id != null
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       teams:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
This commit fixes a bug whereby PRs raised from branches from the Elastic master copy of logstash (as opposed to a branch from a fork) are unable to trigger exhaustive tests with a comment. The issue is the check for build.creator.name. When a PR is from a branch in another fork, that ends up being elasticmachine, but when the branch is created from an org member their username is associated with the branch and the check fails. With this change org members who originate a branch can trigger exhaustive tests. Note this still ensures that only org members can trigger the tests (it does not open anything up to non-org members).


We noticed this yesterday trying to trigger exhaustive tests on a mergify backport https://github.com/elastic/logstash/pull/18609#issuecomment-3776148130 