### PR TITLE
Update RedHat docker Ironbank UBI image to 10.1 for long term support

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -171,8 +171,8 @@ ci/docker_acceptance_tests.sh {flavor}"""),
         if flavor == "ironbank":
             step["env"] = {
                 "BASE_REGISTRY": "docker.io",
-                "BASE_IMAGE": "redhat/ubi9",
-                "BASE_TAG": "9.7"
+                "BASE_IMAGE": "redhat/ubi10",
+                "BASE_TAG": "10.1"
             }
         
         steps.append(step)

--- a/docker/templates/IronbankDockerfile.erb
+++ b/docker/templates/IronbankDockerfile.erb
@@ -1,8 +1,8 @@
 # This Dockerfile was generated from templates/IronbankDockerfile.erb
 
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.7
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi10
+ARG BASE_TAG=10.1
 ARG LOGSTASH_VERSION=<%= elastic_version %>
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}

--- a/docker/templates/hardening_manifest.yaml.erb
+++ b/docker/templates/hardening_manifest.yaml.erb
@@ -13,8 +13,8 @@ tags:
 
 # Build args passed to Dockerfile ARGs
 args:
-  BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "9.7"
+  BASE_IMAGE: "redhat/ubi/ubi10"
+  BASE_TAG: "10.1"
   LOGSTASH_VERSION: "<%= elastic_version %>"
 
 # Docker image labels


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- enhancement
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Update RedHat docker Ironbank UBI image to 10.1 for long term support

## What does this PR do?
The RedHat docker base image UBI 9.6 just reached End of Life, and as a result IronBank images are now failing compliance.

## Why is it important/What is the impact to the user?

It is recommended to update Ironbank images to 10.1 for long term support.

## How to test this PR locally
This PR CI already runs Ironbank docker acceptance tests using Regular RedHat UBI 10.1 image.

## Investigation
Followed steps described [here](https://github.com/elastic/observability-robots/issues/3164#issuecomment-3541230367).
Also tested different logstash pipeline configurations, including common plugins (es-input, es-output, mutate, heartbeat, jdbc-input, http, beats and allso persistent queue tests)
No single problem has been detected from updating to 10.1

## Related issues
Closes [#6420](https://github.com/elastic/ingest-dev/issues/6420)

