### PR TITLE
Fix ironbank container build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -193,7 +193,7 @@ public-dockerfiles_ironbank: dockerfile_ironbank templates/hardening_manifest.ya
 	  elastic_version="${ELASTIC_VERSION}" \
 	  templates/hardening_manifest.yaml.erb > $(ARTIFACTS_DIR)/ironbank/hardening_manifest.yaml && \
 	cd $(ARTIFACTS_DIR)/ironbank && \
-	cp $(ARTIFACTS_DIR)/Dockerfile-ironbank Dockerfile && \
+	cp $(ARTIFACTS_DIR)/ironbank/Dockerfile-ironbank Dockerfile && \
 	tar -zcf ../logstash-ironbank-$(VERSION_TAG)-docker-build-context.tar.gz scripts Dockerfile hardening_manifest.yaml LICENSE README.md
 
 # Generate the Dockerfiles from ERB templates.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

The path for copying in the source Dockerfile was wrong, this commit fixes that.

As noted in https://github.com/elastic/logstash/pull/18619#discussion_r2716590803 this is split out. It is actually causing an error in CI so needs to be fixed. 

This shows a reproduction and running with the fix:

```
➜  logstash git:(337d2e437) ✗ ./gradlew artifactDockerfiles
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.11.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build

> Task :artifactDockerfiles
Skipping bundler install...
[plugin:install-default] Installing default plugins
Installing logstash-codec-avro, logstash-codec-cef, logstash-codec-collectd, logstash-codec-dots, logstash-codec-edn, logstash-codec-edn_lines, logstash-codec-es_bulk, logstash-codec-fluent, logstash-codec-graphite, logstash-codec-json, logstash-codec-json_lines, logstash-codec-line, logstash-codec-msgpack, logstash-codec-multiline, logstash-codec-netflow, logstash-codec-plain, logstash-codec-rubydebug, logstash-filter-aggregate, logstash-filter-anonymize, logstash-filter-cidr, logstash-filter-clone, logstash-filter-csv, logstash-filter-date, logstash-filter-de_dot, logstash-filter-dissect, logstash-filter-dns, logstash-filter-drop, logstash-filter-elastic_integration, logstash-filter-elasticsearch, logstash-filter-fingerprint, logstash-filter-geoip, logstash-filter-grok, logstash-filter-http, logstash-filter-json, logstash-filter-kv, logstash-filter-memcached, logstash-filter-metrics, logstash-filter-mutate, logstash-filter-prune, logstash-filter-ruby, logstash-filter-sleep, logstash-filter-split, logstash-filter-syslog_pri, logstash-filter-throttle, logstash-filter-translate, logstash-filter-truncate, logstash-filter-urldecode, logstash-filter-useragent, logstash-filter-uuid, logstash-filter-xml, logstash-input-azure_event_hubs, logstash-input-beats, logstash-input-couchdb_changes, logstash-input-dead_letter_queue, logstash-input-elasticsearch, logstash-input-exec, logstash-input-file, logstash-input-ganglia, logstash-input-gelf, logstash-input-generator, logstash-input-graphite, logstash-input-heartbeat, logstash-input-http, logstash-input-http_poller, logstash-input-jms, logstash-input-pipe, logstash-input-redis, logstash-input-stdin, logstash-input-syslog, logstash-input-tcp, logstash-input-twitter, logstash-input-udp, logstash-input-unix, logstash-input-elastic_serverless_forwarder, logstash-integration-jdbc, logstash-integration-kafka, logstash-integration-logstash, logstash-integration-rabbitmq, logstash-integration-snmp, logstash-integration-aws, logstash-output-csv, logstash-output-elasticsearch, logstash-output-email, logstash-output-file, logstash-output-graphite, logstash-output-http, logstash-output-lumberjack, logstash-output-nagios, logstash-output-null, logstash-output-pipe, logstash-output-redis, logstash-output-stdout, logstash-output-tcp, logstash-output-udp, logstash-output-webhdfs
Installation successful
[plugin:clean-duplicate-gems] Removing duplicate gems:
[dockerfiles] Building Dockerfiles
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Command failed: [{"ARTIFACTS_DIR"=>"/Users/cas/elastic-repos/logstash/build", "RELEASE"=>nil, "VERSION_QUALIFIER"=>nil, "BUILD_DATE"=>"2026-01-22T21:30:32-08:00", "LOCAL_ARTIFACTS"=>"true"}, "LOCAL_ARTIFACTS=true BUILD_DATE=2026-01-22T21:30:32-08:00 VERSION_QUALIFIER='' RELEASE='' ARTIFACTS_DIR=/Users/cas/elastic-repos/logstash/build make public-dockerfiles_ironbank"]
Output: mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/
mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/scripts
mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/scripts/bin
mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/scripts/config
mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/scripts/env2yaml
mkdir -p /Users/cas/elastic-repos/logstash/build/ironbank/scripts/pipeline
cp -r data/logstash/env2yaml/classes /Users/cas/elastic-repos/logstash/build/ironbank/scripts/env2yaml/
cp -r data/logstash/env2yaml/lib /Users/cas/elastic-repos/logstash/build/ironbank/scripts/env2yaml/
cp -f data/logstash/config/pipelines.yml /Users/cas/elastic-repos/logstash/build/ironbank/scripts/config/pipelines.yml
cp -f data/logstash/config/logstash-full.yml /Users/cas/elastic-repos/logstash/build/ironbank/scripts/config/logstash.yml
cp -f data/logstash/config/log4j2.file.properties /Users/cas/elastic-repos/logstash/build/ironbank/scripts/config/log4j2.file.properties
cp -f data/logstash/config/log4j2.properties /Users/cas/elastic-repos/logstash/build/ironbank/scripts/config/log4j2.properties
cp -f data/logstash/pipeline/default.conf /Users/cas/elastic-repos/logstash/build/ironbank/scripts/pipeline/default.conf
cp -f data/logstash/bin/docker-entrypoint /Users/cas/elastic-repos/logstash/build/ironbank/scripts/bin/docker-entrypoint
cp -f data/logstash/env2yaml/env2yaml /Users/cas/elastic-repos/logstash/build/ironbank/scripts/env2yaml/env2yaml
cp -f ironbank/LICENSE /Users/cas/elastic-repos/logstash/build/ironbank/LICENSE
cp -f ironbank/README.md /Users/cas/elastic-repos/logstash/build/ironbank/README.md
../vendor/jruby/bin/jruby -S erb -T "-"\
                created_date="2026-01-22T21:30:32-08:00" \
                elastic_version="9.4.0-SNAPSHOT" \
                arch="aarch64" \
                version_tag="9.4.0-SNAPSHOT" \
                release="" \
                image_flavor="ironbank" \
                local_artifacts="true" \
                templates/IronbankDockerfile.erb > "/Users/cas/elastic-repos/logstash/build/ironbank/Dockerfile-ironbank"
../vendor/jruby/bin/jruby -S erb -T "-"\
          elastic_version="9.4.0-SNAPSHOT" \
          templates/hardening_manifest.yaml.erb > /Users/cas/elastic-repos/logstash/build/ironbank/hardening_manifest.yaml && \
        cd /Users/cas/elastic-repos/logstash/build/ironbank && \
        cp /Users/cas/elastic-repos/logstash/build/Dockerfile-ironbank Dockerfile && \
        tar -zcf ../logstash-ironbank-9.4.0-SNAPSHOT-docker-build-context.tar.gz scripts Dockerfile hardening_manifest.yaml LICENSE README.md
cp: /Users/cas/elastic-repos/logstash/build/Dockerfile-ironbank: No such file or directory
make: *** [public-dockerfiles_ironbank] Error 1
Rake task error: RuntimeError: Got exit status 2 attempting to execute [{"ARTIFACTS_DIR"=>"/Users/cas/elastic-repos/logstash/build", "RELEASE"=>nil, "VERSION_QUALIFIER"=>nil, "BUILD_DATE"=>"2026-01-22T21:30:32-08:00", "LOCAL_ARTIFACTS"=>"true"}, "LOCAL_ARTIFACTS=true BUILD_DATE=2026-01-22T21:30:32-08:00 VERSION_QUALIFIER='' RELEASE='' ARTIFACTS_DIR=/Users/cas/elastic-repos/logstash/build make public-dockerfiles_ironbank"]!
Backtrace: /Users/cas/elastic-repos/logstash/rakelib/artifacts.rake:157:in `safe_system'
/Users/cas/elastic-repos/logstash/rakelib/artifacts.rake:900:in `block in build_dockerfile'
org/jruby/RubyDir.java:473:in `chdir'
/Users/cas/elastic-repos/logstash/rakelib/artifacts.rake:899:in `build_dockerfile'
/Users/cas/elastic-repos/logstash/rakelib/artifacts.rake:381:in `block in <main>'
/Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/rake-13.3.1/lib/rake/task.rb:281:in `block in execute'
org/jruby/RubyArray.java:2009:in `each'
/Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/rake-13.3.1/lib/rake/task.rb:281:in `execute'
/Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/rake-13.3.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
/Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/rake-13.3.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/cas/elastic-repos/logstash/vendor/bundle/jruby/3.1.0/gems/rake-13.3.1/lib/rake/task.rb:188:in `invoke'
<script>:6:in `<main>'

> Task :artifactDockerfiles FAILED

FAILURE: Build failed with an exception.

* Where:
Script '/Users/cas/elastic-repos/logstash/rubyUtils.gradle' line: 159

* What went wrong:
Execution failed for task ':artifactDockerfiles'.
> (null) Got exit status 2 attempting to execute [{"ARTIFACTS_DIR"=>"/Users/cas/elastic-repos/logstash/build", "RELEASE"=>nil, "VERSION_QUALIFIER"=>nil, "BUILD_DATE"=>"2026-01-22T21:30:32-08:00", "LOCAL_ARTIFACTS"=>"true"}, "LOCAL_ARTIFACTS=true BUILD_DATE=2026-01-22T21:30:32-08:00 VERSION_QUALIFIER='' RELEASE='' ARTIFACTS_DIR=/Users/cas/elastic-repos/logstash/build make public-dockerfiles_ironbank"]!

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 32s
3 actionable tasks: 1 executed, 2 up-to-date
➜  logstash git:(337d2e437) ✗ git checkout -
Previous HEAD position was 337d2e437 Allow exhaustive tests to be triggered by org members (#18616)
Switched to branch 'fix-ironbank-ci'
Your branch is ahead of 'upstream/main' by 1 commit.
  (use "git push" to publish your local commits)
➜  logstash git:(fix-ironbank-ci) ✗ ./gradlew artifactDockerfiles
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.11.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build

> Task :artifactDockerfiles
Skipping bundler install...
[plugin:install-default] Installing default plugins
Installing logstash-codec-avro, logstash-codec-cef, logstash-codec-collectd, logstash-codec-dots, logstash-codec-edn, logstash-codec-edn_lines, logstash-codec-es_bulk, logstash-codec-fluent, logstash-codec-graphite, logstash-codec-json, logstash-codec-json_lines, logstash-codec-line, logstash-codec-msgpack, logstash-codec-multiline, logstash-codec-netflow, logstash-codec-plain, logstash-codec-rubydebug, logstash-filter-aggregate, logstash-filter-anonymize, logstash-filter-cidr, logstash-filter-clone, logstash-filter-csv, logstash-filter-date, logstash-filter-de_dot, logstash-filter-dissect, logstash-filter-dns, logstash-filter-drop, logstash-filter-elastic_integration, logstash-filter-elasticsearch, logstash-filter-fingerprint, logstash-filter-geoip, logstash-filter-grok, logstash-filter-http, logstash-filter-json, logstash-filter-kv, logstash-filter-memcached, logstash-filter-metrics, logstash-filter-mutate, logstash-filter-prune, logstash-filter-ruby, logstash-filter-sleep, logstash-filter-split, logstash-filter-syslog_pri, logstash-filter-throttle, logstash-filter-translate, logstash-filter-truncate, logstash-filter-urldecode, logstash-filter-useragent, logstash-filter-uuid, logstash-filter-xml, logstash-input-azure_event_hubs, logstash-input-beats, logstash-input-couchdb_changes, logstash-input-dead_letter_queue, logstash-input-elasticsearch, logstash-input-exec, logstash-input-file, logstash-input-ganglia, logstash-input-gelf, logstash-input-generator, logstash-input-graphite, logstash-input-heartbeat, logstash-input-http, logstash-input-http_poller, logstash-input-jms, logstash-input-pipe, logstash-input-redis, logstash-input-stdin, logstash-input-syslog, logstash-input-tcp, logstash-input-twitter, logstash-input-udp, logstash-input-unix, logstash-input-elastic_serverless_forwarder, logstash-integration-jdbc, logstash-integration-kafka, logstash-integration-logstash, logstash-integration-rabbitmq, logstash-integration-snmp, logstash-integration-aws, logstash-output-csv, logstash-output-elasticsearch, logstash-output-email, logstash-output-file, logstash-output-graphite, logstash-output-http, logstash-output-lumberjack, logstash-output-nagios, logstash-output-null, logstash-output-pipe, logstash-output-redis, logstash-output-stdout, logstash-output-tcp, logstash-output-udp, logstash-output-webhdfs
Installation successful
[plugin:clean-duplicate-gems] Removing duplicate gems:
[dockerfiles] Building Dockerfiles
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build
Dockerfiles created in /Users/cas/elastic-repos/logstash/build

BUILD SUCCESSFUL in 31s
3 actionable tasks: 1 executed, 2 up-to-date
```