### PR TITLE
Change the default logger level for licensereader

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -132,7 +132,7 @@ logger.slowlog.appenderRef.rolling_slowlog.ref = ${sys:ls.log.format}_rolling_sl
 logger.slowlog.additivity = false
 
 logger.licensereader.name = logstash.licensechecker.licensereader
-logger.licensereader.level = error
+logger.licensereader.level = info
 
 # Silence http-client by default
 logger.apache_http_client.name = org.apache.http


### PR DESCRIPTION
Currently, the log level `error` hides TLS verification error message 

```
[2025-12-23T12:17:21,592][WARN][logstash.licensechecker.licensereader] Attempted to resurrect connection to dead ES instance, but got an error {:url=>"https://elastic:xxxxxx@localhost:9200/", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :message=>"Elasticsearch Unreachable: [https://localhost:9200/][Manticore::SocketException] Connect to localhost:9200 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused"}
```
After changing it to `info`, it gives error details 

```
[2025-12-23T12:32:45,832][WARN ][logstash.licensechecker.licensereader] Attempt to fetch Elasticsearch cluster info failed. Sleeping for 0.02 {:fail_count=>1, :exception=>"Elasticsearch Unreachable: [https://localhost:9200/][Manticore::ClientProtocolException] PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target"}
```