### PR TITLE
Restore ubi8 docker acceptance tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -719,6 +719,15 @@ tasks.register("runDockerWolfiTests", Exec) {
     commandLine "${projectDir}/vendor/jruby/bin/jruby", "-S", "bundle", "exec", "rspec", "docker/spec/wolfi"
 }
 
+tasks.register("runDockerUbi8Tests", Exec) {
+    description = "Run UBI8 docker acceptance tests"
+    dependsOn installAcceptanceTestGems
+    dependsOn artifactDockerUbi8
+    workingDir "${projectDir}/qa"
+    environment "BUNDLE_PATH", "vendor/bundle"
+    commandLine "${projectDir}/vendor/jruby/bin/jruby", "-S", "bundle", "exec", "rspec", "docker/spec/ubi8"
+}
+
 tasks.register("runAllDockerTests", Exec) {
     description = "Run all docker acceptance tests"
     dependsOn installAcceptanceTestGems

--- a/ci/docker_acceptance_tests.sh
+++ b/ci/docker_acceptance_tests.sh
@@ -41,6 +41,9 @@ elif [[ $SELECTED_TEST_SUITE == "wolfi" ]]; then
 elif [[ $SELECTED_TEST_SUITE == "ironbank" ]]; then
   echo "--- Building and testing $SELECTED_TEST_SUITE docker images"
   ./gradlew runDockerIronbankTests
+elif [[ $SELECTED_TEST_SUITE == "ubi8" ]]; then
+  echo "--- Building and testing $SELECTED_TEST_SUITE docker images"
+  ./gradlew runDockerUbi8Tests
 else
   echo "--- Building and testing all docker images"
   ./gradlew runAllDockerTests


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

On [last backport](https://github.com/elastic/logstash/commit/4a7726967c97468564185c04ece86fc43206e034) to 8.19 branch to have a consistent bundled jruby across all CI tasks, the docker ubi8 flavor image was removed from acceptance tests script ([change](https://github.com/elastic/logstash/commit/4a7726967c97468564185c04ece86fc43206e034#diff-b2aada9c1d2a7a66169d21a9742dcafc0f2cdcafff906aaa67ad61df508396cdL62-R37)), but the ubi8 buildkite job was being created (https://github.com/elastic/logstash/blob/8.19/.buildkite/scripts/exhaustive-tests/generate-steps.py#L158). This caused the non expected [default docker acceptante test case](https://github.com/elastic/logstash/blob/8.19/ci/docker_acceptance_tests.sh#L46) to be executed for ubi8 buildkite job, which is running docker tests for all flavors, including ironbank without setting proper `BASE_*`variables necessary to download docker image instead of the Ironbank one.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
This PR adds the missing ubi8 gradlew task and fixes the CI in 8.19 branch.

