### PR TITLE
Dont persist bundler config state across ci tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -500,6 +500,7 @@ def qaVendorPath = "${qaBuildPath}/vendor"
 
 tasks.register("installIntegrationTestGems") {
   dependsOn assembleTarDistribution
+  dependsOn unpackTarDistribution
   def gemfilePath = file("${projectDir}/qa/integration/Gemfile")
   inputs.files gemfilePath
   inputs.files file("${projectDir}/qa/integration/integration_tests.gemspec")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
\
Using the bundler flag for group selection results in local state being preserved. In the serverless testing workflow the persisted state breaks a combination of install tasks. The installDevelopmentGems task should not persist any bundler state related to config. This replaces the use of the CLI flag with an env var which should *not* result in config state being persisted across tasks.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- https://github.com/elastic/logstash/issues/18403
