### PR TITLE
Fix smart exhaustive test pipeline

### DIFF
--- a/.buildkite/smart_exhaustive_tests_pipeline.yml
+++ b/.buildkite/smart_exhaustive_tests_pipeline.yml
@@ -3,7 +3,7 @@ steps:
     if: build.pull_request.id != null && build.env("GITHUB_PR_TRIGGER_COMMENT") != "run exhaustive tests"
     plugins:
       - monorepo-diff#v1.0.1:
-          diff: "git diff --name-only origin/${GITHUB_PR_TARGET_BRANCH}...HEAD"
+          diff: "git diff --name-only origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD"
           interpolation: false
           watch:
             - path:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Fix the smart exhaustive test pipeline when PRs are raised by bots or from branches in the elastic master repo of logstash. Use BUILDKITE_PULL_REQUEST_BASE_BRANCH as it is consistently set. Previously GITHUB_PR_TARGET_BRANCH was used which is not always set. This resulted in the pipeline failing due to not being able to compute changes.

## Additional info:

View of failing instances: https://buildkite.com/elastic/logstash-smart-exhaustive-tests-pipeline

If you look at the `environment` tab in a failing instance https://buildkite.com/elastic/logstash-smart-exhaustive-tests-pipeline/builds/472#019bfb94-599f-4259-9d95-fdb17ccb9e69 you can see the env var is not set. In a passing instance it is https://buildkite.com/elastic/logstash-smart-exhaustive-tests-pipeline/builds/486#019c0015-912f-4b25-9047-c3418c476c02 in BOTH instances the new var is set. 

Here is what the bug looks like:
```
2026-01-26 10:33:57 PST | INFO[0000] --- running monorepo-diff-buildkite-plugin 2.0.0
-- | --
2026-01-26 10:33:57 PST | INFO[2026-01-26T18:33:57Z] Running diff command: git diff --name-only origin/...HEAD
2026-01-26 10:33:57 PST | FATA[2026-01-26T18:33:57Z] diff command failed: command `bash` failed: exit status 128
```
You can see that `git diff --name-only origin/...HEAD` is mangled due to the env var being missing. 