### PR TITLE
Revert "Update bundled JDK to 21.0.10 build 7"

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -10,8 +10,8 @@ logstash-release-track: 9.current
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1
   vendor: "adoptium"
-  revision: 21.0.10
-  build: "7"
+  revision: 21.0.9
+  build: 10
 
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time


### PR DESCRIPTION
Reverts elastic/logstash#18648 due to `adoptiumjdk-21.0.10+7-linux-aarch64` not being available yet