### PR TITLE
Only raise PR to bump java version when all artifacts are ready

### DIFF
--- a/.ci/updatecli/bump-java-version.yml
+++ b/.ci/updatecli/bump-java-version.yml
@@ -53,35 +53,31 @@ conditions:
   # The source checks linux-x86_64, these conditions check remaining platforms
   linux_aarch64_available:
     name: "Check linux-aarch64 JDK is available"
-    kind: json
+    kind: shell
     disablesourceinput: true
     spec:
-      file: 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-linux-aarch64'
-      key: 'url'
+      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-linux-aarch64'
 
   darwin_x86_64_available:
     name: "Check darwin-x86_64 JDK is available"
-    kind: json
+    kind: shell
     disablesourceinput: true
     spec:
-      file: 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin'
-      key: 'url'
+      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin'
 
   darwin_aarch64_available:
     name: "Check darwin-aarch64 JDK is available"
-    kind: json
+    kind: shell
     disablesourceinput: true
     spec:
-      file: 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin-aarch64'
-      key: 'url'
+      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin-aarch64'
 
   windows_x86_64_available:
     name: "Check windows-x86_64 JDK is available"
-    kind: json
+    kind: shell
     disablesourceinput: true
     spec:
-      file: 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-windows'
-      key: 'url'
+      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-windows'
 
 targets:
   update_jdk_revision:


### PR DESCRIPTION
Previously a PR would be raised to bump the java version shipped with LS once the artifact for x86_64 linux was available. In practice we also need the artifacts for arm, macos, windows, etc. This commit adds conditions to updatecli such that only after all artifacts are available will the PR be raised to bump the version. 