### PR TITLE
Ensure jruby managed with gradle bootstrap is used everywher in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,6 +272,16 @@ tasks.findByPath(':logstash-core:processTestResources').dependsOn(copyPluginTest
 
 // Tasks
 
+tasks.register("printStackVersion") {
+    description = "Print the stack version from logstash-plugins CI"
+    doLast {
+        def releaseTrack = gradle.ext.versions['logstash-release-track']
+        def url = new URL("https://raw.githubusercontent.com/logstash-plugins/.ci/1.x/logstash-versions.yml")
+        def remoteVersions = new org.yaml.snakeyaml.Yaml().load(url.text)
+        println remoteVersions['snapshots'][releaseTrack]
+    }
+}
+
 clean {
   delete "${projectDir}/Gemfile"
   delete "${projectDir}/Gemfile.lock"
@@ -376,7 +386,7 @@ tasks.register("artifactAll", Exec) {
     workingDir projectDir
     environment 'GEM_HOME', "${projectDir}/vendor/bundle/jruby/3.1.0"
     environment 'GEM_PATH', "${projectDir}/vendor/bundle/jruby/3.1.0"
-    commandLine "${projectDir}/vendor/bundle/jruby/3.1.0/bin/rake", "artifact:all"
+    commandLine "${projectDir}/vendor/jruby/bin/jruby", "-S", "rake", "artifact:all"
 }
 
 tasks.register("artifactDeb", Exec) {
@@ -387,7 +397,7 @@ tasks.register("artifactDeb", Exec) {
     environment 'ARCH', System.getenv("ARCH") ?: "x86_64"
     environment 'GEM_HOME', "${projectDir}/vendor/bundle/jruby/3.1.0"
     environment 'GEM_PATH', "${projectDir}/vendor/bundle/jruby/3.1.0"
-    commandLine "${projectDir}/vendor/bundle/jruby/3.1.0/bin/rake", "artifact:deb"
+    commandLine "${projectDir}/vendor/jruby/bin/jruby", "-S", "rake", "artifact:deb"
 }
 
 tasks.register("artifactRpm", Exec) {
@@ -398,7 +408,7 @@ tasks.register("artifactRpm", Exec) {
     environment 'ARCH', System.getenv("ARCH") ?: "x86_64"
     environment 'GEM_HOME', "${projectDir}/vendor/bundle/jruby/3.1.0"
     environment 'GEM_PATH', "${projectDir}/vendor/bundle/jruby/3.1.0"
-    commandLine "${projectDir}/vendor/bundle/jruby/3.1.0/bin/rake", "artifact:rpm"
+    commandLine "${projectDir}/vendor/jruby/bin/jruby", "-S", "rake", "artifact:rpm"
 }
 
 tasks.register("compileGrammar") {

--- a/ci/observabilitySREacceptance_tests.sh
+++ b/ci/observabilitySREacceptance_tests.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-# Look up corresponding LOGSTASH_RELEASE_TRACK from versions.yml
-LOGSTASH_RELEASE_TRACK=$(ruby -ryaml -e "puts YAML.load_file('versions.yml')['logstash-release-track']")
-# Use logstash stream to find the corresponding stack verstion from logstash-versions.yml
-STACK_VERSION=$(ruby -ryaml -ropen-uri -e "puts YAML.load(URI.open('https://raw.githubusercontent.com/logstash-plugins/.ci/1.x/logstash-versions.yml'))['snapshots']['${LOGSTASH_RELEASE_TRACK}']")
+STACK_VERSION=$(./gradlew -q printStackVersion)
 export OBSERVABILITY_SRE_IMAGE_VERSION="${OBSERVABILITY_SRE_IMAGE_VERSION:-$STACK_VERSION}"
 export ELASTICSEARCH_IMAGE_VERSION="${ELASTICSEARCH_IMAGE_VERSION:-$STACK_VERSION}"
 export FILEBEAT_IMAGE_VERSION="${FILEBEAT_IMAGE_VERSION:-$STACK_VERSION}"

--- a/ci/observabilitySREsmoke_tests.sh
+++ b/ci/observabilitySREsmoke_tests.sh
@@ -3,10 +3,7 @@
 set -e
 
 QUALIFIED_VERSION="$(.buildkite/scripts/common/qualified-version.sh)"
-# Look up corresponding LOGSTASH_RELEASE_TRACK from versions.yml
-LOGSTASH_RELEASE_TRACK=$(ruby -ryaml -e "puts YAML.load_file('versions.yml')['logstash-release-track']")
-# Use logstash stream to find the corresponding stack verstion from logstash-versions.yml
-STACK_VERSION=$(ruby -ryaml -ropen-uri -e "puts YAML.load(URI.open('https://raw.githubusercontent.com/logstash-plugins/.ci/1.x/logstash-versions.yml'))['snapshots']['${LOGSTASH_RELEASE_TRACK}']")
+STACK_VERSION=$(./gradlew -q printStackVersion)
 export ELASTICSEARCH_IMAGE_VERSION="${ELASTICSEARCH_IMAGE_VERSION:-$STACK_VERSION}"
 export FILEBEAT_IMAGE_VERSION="${FILEBEAT_IMAGE_VERSION:-$STACK_VERSION}"
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

This commit addresses a few places where an external jruby was used rather than the one managed with gradle. Specifically for parsing yaml (this is now done with gradle) and building packages (unintended pickup of a ruby interpreter in a shell script). With this change all PR and exhaustive tests run without an external jruby!
