### PR TITLE
Revert "Allow exhaustive tests to be triggered by org members"

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -607,7 +607,7 @@ spec:
         build_tags: false
         filter_enabled: true
         filter_condition: >-
-          build.pull_request.id != null
+          build.creator.name == 'elasticmachine' && build.pull_request.id != null
       cancel_intermediate_builds: true
       skip_intermediate_builds: true
       teams:


### PR DESCRIPTION
Reverts elastic/logstash#18616

### Why


I can see `GITHUB_PR_TRIGGER_COMMENT="Run exhaustive tests"` in https://buildkite.com/elastic/logstash-smart-exhaustive-tests-pipeline/builds/362, that matches the comment https://github.com/elastic/logstash/pull/18609#issuecomment-3775638219

But its condition is in lowercase: https://github.com/elastic/logstash/blob/main/.buildkite/smart_exhaustive_tests_pipeline.yml#L26

That's the reason it didn't run

### Further details

The Buildkite PR bot is the one responsible for triggering PR builds in Buildkite when:

- A PR is opened
- A PR is updated via commit
- or a comment is present with a customizable trigger phrase.

It acts as a proxy, and we don't use the default Buildkite GitHub integration for the exhausted pipeline.

The [exhausted BK Pipeline](https://github.com/elastic/logstash/blob/main/.buildkite/smart_exhaustive_tests_pipeline.yml) runs in two different cases:
- if GitHub comment `run exhaustive tests`.
- if match any files in the changelist.
