### PR TITLE
Fix obserbabilitySRE DRA jobs after docker update on runners

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -71,7 +71,7 @@ build-from-local-observability-sre-artifacts: dockerfile
 	           -p 8000:8000 --expose=8000 -v $(ARTIFACTS_DIR):/mnt \
 	           python:3 bash -c 'cd /mnt && python3 -m http.server'
 	timeout 120 bash -c 'until curl -s localhost:8000 > /dev/null; do sleep 1; done'
-	docker build --progress=plain --network=host -t $(IMAGE_TAG)-observability-sre:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-observability-sre data/logstash || \
+	docker build --progress=plain --provenance=false --network=host -t $(IMAGE_TAG)-observability-sre:$(VERSION_TAG) -f $(ARTIFACTS_DIR)/Dockerfile-observability-sre data/logstash || \
 	  (docker kill $(HTTPD); false);
 	-docker kill $(HTTPD)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

After a Docker upgrade on CI runners (from pre-24.0 to 24.0+), the ObservabilitySRE multi-architecture container build started failing with the error:

```
docker.elastic.co/logstash/logstash-observability-sre:9.2.5-344069c40-x86_64 is a manifest list
```

Docker 24.0+ enables "provenance attestations" by default via BuildKit. This wraps single-architecture images in an OCI image index (manifest list) containing both the image and a provenance attestation with `platform: unknown/unknown`.

When `docker manifest create` attempts to combine these into a multi-arch manifest, it fails because the source images are already manifest lists, not single-arch images.

**evidence**
The pushed image shows provenance attestation as `unknown/unknown`:

```bash
$ docker manifest inspect docker.elastic.co/logstash/logstash-observability-sre:9.2.5-344069c40-SNAPSHOT-x86_64
```
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:7b9f32acec806758deeb1efa7fe42fe4e823ebcf94cc566864b1146d92d86cee",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:a8c88d76d3dbf908b32a743b9b36f800d7f9d6c5cb1afbfad518d07e4589a2b3",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

**Local testing**

Without `--provenance=false` (manifest list with attestation):
```json
{
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    { "platform": { "architecture": "arm64", "os": "linux" } },
    { 
      "annotations": { "vnd.docker.reference.type": "attestation-manifest" },
      "platform": { "architecture": "unknown", "os": "unknown" }
    }
  ]
}
```

With `--provenance=false` (single image manifest):
```json
{
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": { "digest": "sha256:789478..." },
  "layers": [...]
}
```

### References

- Docker BuildKit Provenance: https://docs.docker.com/build/attestations/slsa-provenance/
- Docker 24.0 Release Notes: Provenance attestations enabled by default