### PR TITLE
Clarify input param to bump LS version GHA

### DIFF
--- a/.github/workflows/bump-logstash.yml
+++ b/.github/workflows/bump-logstash.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       logstash_version:
-        description: 'Logstash version (example: 9.1.4)'
+        description: 'Logstash version to update TO (example: 9.1.4)'
         required: true
         type: string
       logstash_branch:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Update the description of the input parameter to make it clear it is the version the user intends to update logstash TO (rather than the current version).