### PR TITLE
Use redhat ubi-8 instead of elastic hosted

### DIFF
--- a/docker/templates/Dockerfile.erb
+++ b/docker/templates/Dockerfile.erb
@@ -64,7 +64,7 @@ COPY --chmod=0755 scripts/env2yaml/env2yaml /usr/local/bin/env2yaml
     <%   license = 'Elastic License' -%>
   <% end -%>
   <% if image_flavor == 'ubi8' %>
-    <%   base_image = 'docker.elastic.co/ubi8/ubi-minimal' -%>
+    <%   base_image = 'redhat/ubi8-minimal:latest' -%>
     <%   package_manager = 'microdnf' -%>
     <%   arch_command = 'uname -m' -%>
     # Minimal distributions do not ship with en language packs.


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Use the redhat registry for the ubi8 base image instead of the elastic registry