### PR TITLE
Restore missing "skip windows" logic in test

### DIFF
--- a/logstash-core/src/test/java/org/logstash/settings/WritableDirectorySettingTest.java
+++ b/logstash-core/src/test/java/org/logstash/settings/WritableDirectorySettingTest.java
@@ -213,6 +213,7 @@ public class WritableDirectorySettingTest {
     @Test
     public void whenDirectoryMissingAndParentNotWritableThenValidateValueFails() throws IOException {
         // Skip on Windows where chmod doesn't work the same way
+        assumeTrue(isNotWindowsOS());
         assertFalse("Can't run as root since root can write anywhere (no real read-only files)", isRoot());
 
         Path parentDir = tempFolder.newFolder("parent").toPath();


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

There is a comment to skip on windows, but we forgot to actually skip. Skip!