### PR TITLE
Add known issues running 9.2.5 on aarch64 architectures (#18731)

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -100,6 +100,15 @@ Related:
 
 ## 9.2.5 [logstash-9.2.5-release-notes]
 
+
+::::{important}
+
+Do not upgrade to Logstash 9.2.5 if you need to run Logstash on `aarch64` architectures using the bundled JDK, and are
+not running on Docker.
+For more details please see the associated [known issue](/release-notes/known-issues.md#logstash-ki-9.2.5).
+
+::::
+
 ### Features and enhancements [logstash-9.2.5-features-enhancements]
 
 No user-facing changes in Logstash core.

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -23,6 +23,21 @@ Using a JDK provided via `LS_JAVA_HOME` works as expected. Docker images and non
 
 ::::
 
+## 9.2.5 [logstash-ki-9.2.5]
+
+**Logstash will not start with bundled JDK on aarch64 downloaded artifacts**
+
+Applies to: {{ls}} 9.2.5
+
+::::{dropdown} Details
+
+On `aarch64`,{{ls}} 9.2.5 fails to start when installed from .deb, .rpm, or .tar packages and using the bundled JDK.
+This is due to an incorrect JDK version being included in those packages.
+
+Using a JDK provided via `LS_JAVA_HOME` works as expected. Docker images and non-`aarch64` architectures are not affected.
+
+::::
+
 ## 9.2.0 [logstash-ki-9.2.0]
 
 **Logstash will not start if a Persistent Queue has been defined with a size greater than 2 GiB**


### PR DESCRIPTION
* Add known issues running 9.2.5 on aarch64 architectures
