### PR TITLE
[CI] Sync acceptance test OS matrix with Linux matrix pipeline

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -10,7 +10,16 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 VM_IMAGES_FILE = ".buildkite/scripts/common/vm-images.json"
 VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 
-ACCEPTANCE_LINUX_OSES = ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004", "debian-11", "debian-12", "debian-13", "rhel-8", "oraclelinux-7", "rocky-linux-8", "opensuse-leap-15", "amazonlinux-2023"]
+ACCEPTANCE_LINUX_OSES = [
+    "ubuntu-2404", "ubuntu-2204", "ubuntu-2004",
+    "debian-11", "debian-12", "debian-13",
+    "rhel-8", "rhel-9",
+    "oraclelinux-7", "oraclelinux-8",
+    "rocky-linux-8", "rocky-linux-9",
+    "almalinux-8", "almalinux-9",
+    "opensuse-leap-15",
+    "amazonlinux-2023",
+]
 
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Supported Linux distributions list in [acceptance tests](https://github.com/elastic/logstash/blob/main/.buildkite/scripts/exhaustive-tests/generate-steps.py#L13) should be up to date with the [linux matrix pipeline list](https://github.com/elastic/logstash/blob/main/.buildkite/linux_jdk_matrix_pipeline.yml)

Missing: rhel-9, oraclelinux-8, rocky-linux-9, almalinux-8, almalinux-9

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

Pipeline passed for all distros
https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/3376
<img width="1712" height="887" alt="image" src="https://github.com/user-attachments/assets/fde0f398-ce6e-44d4-b4a2-3c9d94e6c600" />
