### PR TITLE
Use updated copyAllJdks task for ubi8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -370,7 +370,7 @@ tasks.register("artifactDockerIronbank") {
 tasks.register("artifactDockerUbi8") {
     description = "Build UBI8 docker image"
     dependsOn dockerBootstrap
-    dependsOn copyJdk
+    dependsOn copyAllJdks
 
     doLast {
         rake(projectDir, buildDir, 'artifact:docker_ubi8')


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
During the backport of https://github.com/elastic/logstash/pull/18748 the ubi 8 task which does not exist in 9.x/main was missed. This updates the task to use the new dependency. The rest of the tasks will do the right thing.