### PR TITLE
Update march_hare gem to version 4.8.0-java in 8.19 branch

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -696,7 +696,7 @@ GEM
       net-smtp
     manticore (0.9.2-java)
       openssl_pkcs8_pure
-    march_hare (4.7.0-java)
+    march_hare (4.8.0-java)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.1.0)


### PR DESCRIPTION
Include a [bugfix](https://github.com/ruby-amqp/march_hare/blob/main/ChangeLog.md#marchharechannelqueue-ignored-x-queue-type) from march_hare that shipped in a minor release

fixes https://github.com/elastic/logstash/issues/18161