### PR TITLE
Avoid duplicate steps in snyk artifact scanning

### DIFF
--- a/.buildkite/scripts/snyk/artifact-scan/generate-steps.py
+++ b/.buildkite/scripts/snyk/artifact-scan/generate-steps.py
@@ -36,15 +36,15 @@ def generate_extraction_step(version: str, version_type: str) -> dict:
 
 def generate_pipeline() -> dict:
     versions_data = fetch_logstash_versions()
+    seen = set()
     steps = []
 
-    if 'releases' in versions_data:
-        for version in versions_data['releases'].values():
-            steps.append(generate_extraction_step(version, 'release'))
-
-    if 'snapshots' in versions_data:
-        for version in versions_data['snapshots'].values():
-            steps.append(generate_extraction_step(version, 'snapshot'))
+    for version_type, key in [('releases', 'release'), ('snapshots', 'snapshot')]:
+        if version_type in versions_data:
+            for version in versions_data[version_type].values():
+                if version not in seen:
+                    seen.add(version)
+                    steps.append(generate_extraction_step(version, key))
 
     return {
         "agents": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

In the case where two release tracks point to the same version, we need to guard against duplicate step names. This is a rare occurance that is otherwise harmless. This commit guards against duplicate step names.

merging https://github.com/logstash-plugins/.ci/pull/110 revealed this quirk. 