### PR TITLE
Doc: Update svrless docs to use endpoint url 8.19

### DIFF
--- a/docs/static/ls-to-serverless.asciidoc
+++ b/docs/static/ls-to-serverless.asciidoc
@@ -36,7 +36,7 @@ The value of the link:https://www.elastic.co/guide/en/logstash/8.19/plugins-outp
 1. Log in to https://cloud.elastic.co/[Elastic Cloud].
 2. Find your **{es} endpoint URL**:
 
-* Select **Manage** next to your project. Then find the {{es}} endpoint under **Application endpoints, cluster and component IDs**. 
+* Select **Manage** next to your project. Then find the {es} endpoint under **Application endpoints, cluster and component IDs**. 
 * Alternatively, open your project, select the help icon, then select **Connection details**.
 
 [[api-key-serverless]]


### PR DESCRIPTION
Doc: Use **Elastic endpoint URL** and an **API key** to establish the connection from Logstash to Serverless. Cloud ID is not viewable in the Cloud console. 

Issue: #18769 
Parent issue: https://github.com/elastic/docs-content-internal/issues/777 

Heavily refactored "backport" of #18773 

**PREVIEW:** https://logstash_bk_18804.docs-preview.app.elstc.co/guide/en/logstash/8.19/logstash-to-elasticsearch-serverless.html