### PR TITLE
Dont run exhaustive tests on *EVERY* commmit in a branch

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -552,8 +552,8 @@ spec:
         filter_condition: >-
           build.branch !~ /^backport.*$/ && build.branch !~ /^mergify\/bp\/.*$/
         filter_enabled: true
-      cancel_intermediate_builds: false
-      skip_intermediate_builds: false
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

In the case a new branch is pushed to the elastic/logstash repo exhaustive tests are run. This happens for example when updatecli or other GHA orchestrated updates occur for automating version bumps etc. Previously *EVERY* commit in that branch had the full exhaustive test run against it. We only want one commit, therefore we configure it to cancel intermediate commits. This drastically saves testing resources.