### PR TITLE
Add max value for batch size windowed histograms

### DIFF
--- a/logstash-core/lib/logstash/api/commands/stats.rb
+++ b/logstash-core/lib/logstash/api/commands/stats.rb
@@ -213,6 +213,8 @@ module LogStash
                 byte_size_histogram_value = byte_size_histogram.value
                 if byte_size_histogram_value[window.to_s]
                   reshape_histogram_percentiles_for_window(:byte_size, byte_size_histogram_value, window, result)
+                  result[:byte_size][:max] ||= {}
+                  result[:byte_size][:max][window] = byte_size_histogram_value[window.to_s].max_value.round
                 end
               end
             end

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/BatchStructureMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/BatchStructureMetric.java
@@ -111,10 +111,12 @@ public class BatchStructureMetric extends AbstractMetric<Map<String, BatchStruct
         private static final long serialVersionUID = 4711735381843512566L;
         private final long percentile50;
         private final long percentile90;
+        private final long maxValue;
 
         public HistogramMetricData(ValueHistogram histogram) {
             percentile50 = histogram.getValueAtPercentile(50);
             percentile90 = histogram.getValueAtPercentile(90);
+            maxValue = histogram.getMaxValue();
         }
 
         @JsonProperty("p50")
@@ -127,11 +129,17 @@ public class BatchStructureMetric extends AbstractMetric<Map<String, BatchStruct
             return percentile90;
         }
 
+        @JsonProperty("max")
+        public long getMaxValue() {
+            return maxValue;
+        }
+
         @Override
         public String toString() {
             return "HistogramMetricData{" +
                     "percentile50=" + percentile50 +
                     ", percentile90=" + percentile90 +
+                    ", maxValue=" + maxValue +
                     '}';
         }
     }
@@ -165,8 +173,6 @@ public class BatchStructureMetric extends AbstractMetric<Map<String, BatchStruct
                 if (compareCapture == null) { return Optional.empty(); }
                 if (baselineCapture == null) { return Optional.empty(); }
 
-//                var result = compareCapture.getValueHistogram();
-//                result.subtract(baselineCapture.getValueHistogram());
                 var result = compareCapture.getValueHistogram().subtract(baselineCapture.getValueHistogram());
                 return Optional.of(result);
             });

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/histogram/LifetimeHistogramMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/histogram/LifetimeHistogramMetric.java
@@ -85,6 +85,10 @@ public class LifetimeHistogramMetric extends AbstractMetric<LifetimeHistogramMet
             return delegate.getTotalCount();
         }
 
+        public long getMaxValue() {
+            return delegate.getMaxValue();
+        }
+
         public ValueHistogram subtract(ValueHistogram other) {
             if (Objects.isNull(other) || Objects.isNull(other.delegate) || other.delegate.getTotalCount() <= 0) {
                 return this;

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/histogram/LifetimeHistogramMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/histogram/LifetimeHistogramMetricTest.java
@@ -42,6 +42,7 @@ public class LifetimeHistogramMetricTest {
         ValueHistogram h = sut.getValue();
         assertEquals(1, h.getTotalCount());
         assertEquals(1000L, h.getValueAtPercentile(90));
+        assertEquals(1000L, h.getMaxValue());
     }
 
     @Test
@@ -56,14 +57,24 @@ public class LifetimeHistogramMetricTest {
         ValueHistogram afterFirst = sut.getValue();
         long p90AfterFirst = afterFirst.getValueAtPercentile(90);
         assertEquals(100L, p90AfterFirst);
+        assertEquals(100L, afterFirst.getMaxValue());
 
         sut.recordValue(1000);
         ValueHistogram afterSecond = sut.getValue();
         long p90AfterSecond = afterSecond.getValueAtPercentile(90);
         assertTrue("90th percentile should increase after recording a larger value", p90AfterSecond > p90AfterFirst);
         assertEquals(1000L, p90AfterSecond);
+        assertEquals(1000L, afterSecond.getMaxValue());
 
         long p50AfterSecond = afterSecond.getValueAtPercentile(50);
         assertEquals("previous 90th percentile value (100) should now be at 50th percentile", 100L, p50AfterSecond);
+    }
+
+    @Test
+    public void givenValuesRecordedThenGetMaxValueReturnsLargestRecordedValue() {
+        sut.recordValue(100);
+        sut.recordValue(1000);
+        ValueHistogram h = sut.getValue();
+        assertEquals(1000L, h.getMaxValue());
     }
 }


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Expose the max value for batch's byte_size, reported in 1,5 and 15 minutes time windows.

## What does this PR do?
Update the value class to expose HdrHistogram's max value. This is used to present such value only for batch's byte_size in the stats API.

## Why is it important/What is the impact to the user?
Let the user to know which is the max value for that metric that the pipeline faced in recent time windows.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Follow same instructions of #18770 .

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #18797
