### PR TITLE
Fix Bundler platform genericization for JRuby 10

### DIFF
--- a/lib/bootstrap/bundler.rb
+++ b/lib/bootstrap/bundler.rb
@@ -231,12 +231,14 @@ module LogStash
     end
 
     def specific_platforms(platforms = ::Gem.platforms)
-      platforms.find_all {|plat| plat.is_a?(::Gem::Platform) && plat.os == 'java' && !plat.cpu.nil? && !plat.version.nil?}
+      # Keep generic `java` in lockfiles and remove more specific java variants.
+      # On JRuby 10, `universal-java` has nil version, so version is not a reliable discriminator.
+      platforms.find_all {|plat| plat.is_a?(::Gem::Platform) && plat.os == 'java' && !plat.cpu.nil?}
     end
 
     def genericize_platform
       output = LogStash::Bundler.invoke!({:add_platform => 'java'})
-      specific_platforms.each do |platform|
+      specific_platforms(::Bundler.definition.platforms).each do |platform|
         begin
           output << LogStash::Bundler.invoke!({:remove_platform => platform.to_s})
         rescue => e

--- a/spec/unit/bootstrap/bundler_spec.rb
+++ b/spec/unit/bootstrap/bundler_spec.rb
@@ -216,4 +216,44 @@ describe LogStash::Bundler do
       end
     end
   end
+
+  context "specific_platforms" do
+    it "includes universal-java with nil version and excludes generic java" do
+      platforms = [
+        Gem::Platform.new("java"),
+        Gem::Platform.new("universal-java"),
+        Gem::Platform.new("universal-java-21")
+      ]
+
+      specific = LogStash::Bundler.specific_platforms(platforms).map(&:to_s)
+      expect(specific).to include("universal-java", "universal-java-21")
+      expect(specific).not_to include("java")
+    end
+
+    it "returns java-specific variants from runtime Gem.platforms on JRuby" do
+      specific = LogStash::Bundler.specific_platforms(::Gem.platforms).map(&:to_s)
+      expect(specific).to include(a_string_matching(/universal-java/))
+      expect(specific).not_to include("java")
+    end
+  end
+
+  context "genericize_platform" do
+    it "does not attempt to remove universal-java when lockfile only has generic java" do
+      lock_definition = double("bundler_definition", :platforms => [Gem::Platform.new("java")])
+      allow(::Bundler).to receive(:definition).and_return(lock_definition)
+      expect(LogStash::Bundler).to receive(:invoke!).with(hash_including(:add_platform => "java")).and_return("")
+      expect(LogStash::Bundler).not_to receive(:invoke!).with(hash_including(:remove_platform))
+
+      LogStash::Bundler.genericize_platform
+    end
+
+    it "removes universal-java variants when present in lockfile platforms" do
+      lock_definition = double("bundler_definition", :platforms => [Gem::Platform.new("java"), Gem::Platform.new("universal-java")])
+      allow(::Bundler).to receive(:definition).and_return(lock_definition)
+      expect(LogStash::Bundler).to receive(:invoke!).with(hash_including(:add_platform => "java")).ordered.and_return("")
+      expect(LogStash::Bundler).to receive(:invoke!).with(hash_including(:remove_platform => "universal-java")).ordered.and_return("")
+
+      LogStash::Bundler.genericize_platform
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Fixes Bundler platform genericization on JRuby 10 so `universal-java` is treated as a specific platform and lockfiles normalize back to generic `java`.
- Limits platform removals to platforms present in `Bundler.definition.platforms`, avoiding repeated `remove_platform universal-java` retries when lockfiles are already `java`-only.
- Adds regression coverage in `spec/unit/bootstrap/bundler_spec.rb` for JRuby 10 (`universal-java` with nil version) and for `genericize_platform` removal behavior.

## Why

On JRuby 10, `Gem.platforms` includes `universal-java` with `version=nil`. The previous `specific_platforms` filter required `!plat.version.nil?`, which excluded `universal-java`. This prevented cleanup of Java-specific platforms in plugin-manager lockfile flows, creating lockfile platform drift (`java + universal-java`) instead of normalized `java`.

## Behavioral Change

- `LogStash::Bundler.specific_platforms` now includes Java-specific variants regardless of `version` presence.
- `LogStash::Bundler.genericize_platform` now evaluates removable platforms from lockfile definition platforms, reducing noisy and unnecessary retries.

## Validation

- Reproduced the pre-fix divergence:
  - `main` kept `PLATFORMS: java, universal-java` after plugin-manager/offline-pack workflows.
  - `v9.3.1` normalized to `PLATFORMS: java`.
- Verified post-fix behavior:
  - `specific_platforms` includes `universal-java` on JRuby 10.
  - normalization simulation moves `java,universal-java` -> `java`.