### PR TITLE
Doc: Add page-level applies_to tags to Logstash content (Group 2)

### DIFF
--- a/docs/reference/advanced-logstash-configurations.md
+++ b/docs/reference/advanced-logstash-configurations.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/configuration-advanced.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Advanced Logstash configurations [configuration-advanced]

--- a/docs/reference/advanced-pipeline.md
+++ b/docs/reference/advanced-pipeline.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/advanced-pipeline.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Parsing Logs with Logstash [advanced-pipeline]

--- a/docs/reference/config-examples.md
+++ b/docs/reference/config-examples.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/config-examples.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash configuration examples [config-examples]

--- a/docs/reference/config-setting-files.md
+++ b/docs/reference/config-setting-files.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/config-setting-files.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash Configuration Files [config-setting-files]

--- a/docs/reference/configuration-file-structure.md
+++ b/docs/reference/configuration-file-structure.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Structure of a pipeline [configuration-file-structure]

--- a/docs/reference/creating-logstash-pipeline.md
+++ b/docs/reference/creating-logstash-pipeline.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/configuration.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Creating a Logstash Pipeline [configuration]

--- a/docs/reference/data-deserialization.md
+++ b/docs/reference/data-deserialization.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/data-deserialization.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Deserializing Data [data-deserialization]

--- a/docs/reference/dead-letter-queues.md
+++ b/docs/reference/dead-letter-queues.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/dead-letter-queues.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Dead letter queues (DLQ) [dead-letter-queues]

--- a/docs/reference/ecs-ls.md
+++ b/docs/reference/ecs-ls.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/ecs-ls.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # ECS in Logstash [ecs-ls]

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/environment-variables.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Using environment variables [environment-variables]

--- a/docs/reference/event-api.md
+++ b/docs/reference/event-api.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/event-api.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Event API [event-api]

--- a/docs/reference/event-dependent-configuration.md
+++ b/docs/reference/event-dependent-configuration.md
@@ -2,6 +2,9 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html
   - https://www.elastic.co/guide/en/logstash/current/field-references-deepdive.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Accessing event data and fields [event-dependent-configuration]

--- a/docs/reference/execution-model.md
+++ b/docs/reference/execution-model.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/execution-model.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Execution Model [execution-model]

--- a/docs/reference/field-extraction.md
+++ b/docs/reference/field-extraction.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/field-extraction.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Extracting Fields and Wrangling Data [field-extraction]

--- a/docs/reference/glob-support.md
+++ b/docs/reference/glob-support.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/glob-support.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Glob Pattern Support [glob-support]

--- a/docs/reference/lookup-enrichment.md
+++ b/docs/reference/lookup-enrichment.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/lookup-enrichment.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Enriching Data with Lookups [lookup-enrichment]

--- a/docs/reference/memory-queue.md
+++ b/docs/reference/memory-queue.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/memory-queue.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Memory queue [memory-queue]

--- a/docs/reference/multiline.md
+++ b/docs/reference/multiline.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/multiline.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Managing Multiline Events [multiline]

--- a/docs/reference/multiple-input-output-plugins.md
+++ b/docs/reference/multiple-input-output-plugins.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/multiple-input-output-plugins.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Stitching Together Multiple Input and Output Plugins [multiple-input-output-plugins]

--- a/docs/reference/multiple-pipelines.md
+++ b/docs/reference/multiple-pipelines.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/multiple-pipelines.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Multiple Pipelines [multiple-pipelines]

--- a/docs/reference/persistent-queues.md
+++ b/docs/reference/persistent-queues.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/persistent-queues.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Persistent queues (PQ) [persistent-queues]

--- a/docs/reference/pipeline-to-pipeline.md
+++ b/docs/reference/pipeline-to-pipeline.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/pipeline-to-pipeline.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Pipeline-to-pipeline communication [pipeline-to-pipeline]

--- a/docs/reference/processing.md
+++ b/docs/reference/processing.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/processing.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Processing Details [processing]

--- a/docs/reference/queues-data-resiliency.md
+++ b/docs/reference/queues-data-resiliency.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/resiliency.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Queues and data resiliency [resiliency]

--- a/docs/reference/reloading-config.md
+++ b/docs/reference/reloading-config.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/reloading-config.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Reloading the Config File [reloading-config]

--- a/docs/reference/transforming-data.md
+++ b/docs/reference/transforming-data.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/transformation.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Transforming data [transformation]


### PR DESCRIPTION
## Summary
**Group 2:  Pipeline Configuration and Data Processing (~26 files)**
Adds `applies_to` tags to show applicability for each topic. 

<img width="491" height="237" alt="Screenshot 2026-03-13 at 3 22 36 PM" src="https://github.com/user-attachments/assets/3c2de3be-c4d1-4dd9-b197-64777ded4014" />

Related: https://github.com/elastic/docs-content-internal/issues/260

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
    Tool(s) and model(s) used: Cursor and claude-4.6-opus-high
- [ ] No  

