### PR TITLE
Doc: Add page-level applies_to tags to Logstash content (Group 4)

### DIFF
--- a/docs/reference/deploying-scaling-logstash.md
+++ b/docs/reference/deploying-scaling-logstash.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/deploying-and-scaling.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Deploying and scaling Logstash [deploying-and-scaling]

--- a/docs/reference/logstash-to-logstash-communications.md
+++ b/docs/reference/logstash-to-logstash-communications.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/ls-to-ls.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash-to-Logstash communications [ls-to-ls]

--- a/docs/reference/ls-to-ls-http.md
+++ b/docs/reference/ls-to-ls-http.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/ls-to-ls-http.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash-to-Logstash: HTTP output to HTTP input [ls-to-ls-http]

--- a/docs/reference/ls-to-ls-lumberjack.md
+++ b/docs/reference/ls-to-ls-lumberjack.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/ls-to-ls-lumberjack.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash-to-Logstash: Lumberjack output to Beats input [ls-to-ls-lumberjack]

--- a/docs/reference/ls-to-ls-native.md
+++ b/docs/reference/ls-to-ls-native.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/ls-to-ls-native.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Logstash-to-Logstash: Output to Input [ls-to-ls-native]

--- a/docs/reference/offline-plugins.md
+++ b/docs/reference/offline-plugins.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/offline-plugins.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Offline Plugin Management [offline-plugins]

--- a/docs/reference/performance-troubleshooting.md
+++ b/docs/reference/performance-troubleshooting.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/performance-troubleshooting.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Performance troubleshooting [performance-troubleshooting]

--- a/docs/reference/performance-tuning.md
+++ b/docs/reference/performance-tuning.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/performance-tuning.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Performance tuning [performance-tuning]

--- a/docs/reference/plugin-concepts.md
+++ b/docs/reference/plugin-concepts.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/plugin-concepts.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Cross-plugin concepts and features [plugin-concepts]

--- a/docs/reference/plugin-generator.md
+++ b/docs/reference/plugin-generator.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/plugin-generator.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Generating plugins [plugin-generator]

--- a/docs/reference/private-rubygem.md
+++ b/docs/reference/private-rubygem.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/private-rubygem.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Private Gem Repositories [private-rubygem]

--- a/docs/reference/tips-best-practices.md
+++ b/docs/reference/tips-best-practices.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/tips.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Tips and best practices [tips]

--- a/docs/reference/tuning-logstash.md
+++ b/docs/reference/tuning-logstash.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/tuning-logstash.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Tuning and profiling logstash pipeline performance [tuning-logstash]

--- a/docs/reference/use-filebeat-modules-kafka.md
+++ b/docs/reference/use-filebeat-modules-kafka.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/use-filebeat-modules-kafka.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Example: Set up Filebeat modules to work with Kafka and Logstash [use-filebeat-modules-kafka]

--- a/docs/reference/use-ingest-pipelines.md
+++ b/docs/reference/use-ingest-pipelines.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/use-ingest-pipelines.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Use ingest pipelines for parsing [use-ingest-pipelines]

--- a/docs/reference/working-with-filebeat-modules.md
+++ b/docs/reference/working-with-filebeat-modules.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/filebeat-modules.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Working with Filebeat modules [filebeat-modules]

--- a/docs/reference/working-with-plugins.md
+++ b/docs/reference/working-with-plugins.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/working-with-plugins.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Working with plugins [working-with-plugins]

--- a/docs/reference/working-with-winlogbeat-modules.md
+++ b/docs/reference/working-with-winlogbeat-modules.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/winlogbeat-modules.html
+applies_to:
+  stack: ga
+  serverless: ga
 ---
 
 # Working with Winlogbeat modules [winlogbeat-modules]


### PR DESCRIPTION
## Summary
**Group 4: Plugins, Integrations, Performance, and Best Practices (~18 files)**
Adds `applies_to` tags to show applicability for each topic. 

<img width="491" height="237" alt="Screenshot 2026-03-13 at 3 22 36 PM" src="https://github.com/user-attachments/assets/3c2de3be-c4d1-4dd9-b197-64777ded4014" />

Related: https://github.com/elastic/docs-content-internal/issues/260

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
    Tool(s) and model(s) used: Cursor and claude-4.6-opus-high
- [ ] No  

