### PR TITLE
bump jrjackson to 0.4.21 for jruby 10 support

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -27,6 +27,6 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.4.20
+jrjackson: 0.4.21
 jackson: 2.16.2
 jackson-databind: 2.16.2


### PR DESCRIPTION
jrjackson 0.4.21 explicitly requires bigdecimal, allowing it to work on JRuby 10 deployments. PR: https://github.com/guyboertje/jrjackson/commit/b043dfa8e1215c700d806b61dae96f120dc55eba

Example:


```
❯ bundle exec rspec
/Users/joaoduarte/.rvm/gems/jruby-10.0.4.0/gems/jrjackson-0.4.20-java/lib/jrjackson.rb:2: warning: bigdecimal was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add bigdecimal to your Gemfile or gemspec to silence this warning.

An error occurred while loading ./spec/filters/truncate_spec.rb.
Failure/Error: require "logstash/devutils/rspec/spec_helper"

LoadError:
  cannot load such file -- bigdecimal
# /Users/joaoduarte/.rvm/gems/jruby-10.0.4.0/gems/jrjackson-0.4.20-java/lib/jrjackson/jrjackson.rb:12:in '<main>'
# /Users/joaoduarte/.rvm/gems/jruby-10.0.4.0/gems/jrjackson-0.4.20-java/lib/jrjackson.rb:2:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/json.rb:19:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/api/app_helpers.rb:18:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/api/modules/base.rb:18:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/api/rack_app.rb:20:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/webserver.rb:18:in '<main>'
# /Users/joaoduarte/elastic/logstash/logstash-core/lib/logstash/agent.rb:33:in '<main>'
# /Users/joaoduarte/.rvm/gems/jruby-10.0.4.0/gems/logstash-devutils-2.6.3-java/lib/logstash/devutils/rspec/logstash_helpers.rb:1:in '<main>'
# /Users/joaoduarte/.rvm/gems/jruby-10.0.4.0/gems/logstash-devutils-2.6.3-java/lib/logstash/devutils/rspec/spec_helper.rb:3:in '<main>'
# ./spec/filters/truncate_spec.rb:3:in '<main>'
No examples found.


Finished in 0.00023 seconds (files took 1.18 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples


❯ bundle update
[DEPRECATED] Pass --all to `bundle update` to update everything
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching bigdecimal 4.0.1 (java)
Installing bigdecimal 4.0.1 (java)
Fetching jrjackson 0.4.21 (java) (was 0.4.20)
Installing jrjackson 0.4.21 (java) (was 0.4.20)
Bundle updated!

❯ bundle exec rspec
Sending Logstash logs to null which is now configured via log4j2.properties
Run options: exclude {integration: true, redis: true, socket: true, performance: true, couchdb: true, elasticsearch: true, elasticsearch_secure: true, export_cypher: true, windows: true}

Randomized with seed 54555
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 2.49 seconds (files took 1.62 seconds to load)
2857 examples, 0 failures

Randomized with seed 54555
```