### PR TITLE
DeadLetterQueueUtils#extractSegmentId improvement: replace split with index of and substring methods.

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -37,9 +37,12 @@ class DeadLetterQueueUtils {
 
     private static final Logger logger = LogManager.getLogger(DeadLetterQueueUtils.class);
 
-    static int extractSegmentId(Path p) {
+    static int extractSegmentId(final Path p) {
         final String fileName = p.getFileName().toString();
         final int dotIndex = fileName.indexOf(".log");
+        if (dotIndex <= 0) {
+            throw new IllegalArgumentException("Invalid segment file name: " + fileName);
+        }
         return Integer.parseInt(fileName.substring(0, dotIndex));
     }
 

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -1124,4 +1124,26 @@ public class DeadLetterQueueReaderTest {
             }
         }
     }
+
+    @Test
+    public void testExtractSegmentIdWithValidFileName() {
+        Path validPath = Paths.get("123.log");
+        assertEquals(123, DeadLetterQueueUtils.extractSegmentId(validPath));
+
+        Path singleDigitPath = Paths.get("1.log");
+        assertEquals(1, DeadLetterQueueUtils.extractSegmentId(singleDigitPath));
+
+        Path largeNumberPath = Paths.get("999999.log");
+        assertEquals(999999, DeadLetterQueueUtils.extractSegmentId(largeNumberPath));
+    }
+
+    @Test
+    public void testExtractSegmentIdWithNoLogExtensionThrowsException() {
+        Path noExtensionPath = Paths.get("123.txt");
+        IllegalArgumentException exception = Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> DeadLetterQueueUtils.extractSegmentId(noExtensionPath)
+        );
+        assertThat(exception.getMessage(), containsString("Invalid segment file name"));
+    }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->


## What does this PR do?
DLQ flush operation is heavy, under the hood `DeadLetterQueueUtils#extractSegmentId` will be called. The `String#split` is also CPU intensive that internally utilizes `Pattern#compile`. Since the logic is simple, it can be replaceable with `indexOf` and `substring`. 

## Why is it important/What is the impact to the user?
A bit performance improvement when using DLQ.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally
Functionality test can be done by enabling DLQ and changing its settings, such as make size small to make DLQ full.
But performance measurement is a bit hard on powerful machines, so here is the benchmark - https://github.com/elastic/logstash/pull/18883

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
