### PR TITLE
Fix comparison of ES SHA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -589,7 +589,7 @@ tasks.register("checkEsSHA") {
         String remoteSHA
 
         def res = SnapshotArtifactURLs.packageUrls("elasticsearch", esVersion, downloadedElasticsearchName)
-        remoteSHA = res.packageShaUrl
+        remoteSHA = res.packageShaUrl.toURL().text
 
         def localESArchive = new File("${projectDir}/build/${downloadedElasticsearchName}.tar.gz")
         if (localESArchive.exists()) {
@@ -603,6 +603,8 @@ tasks.register("checkEsSHA") {
             if (localESCalculatedSHA != remoteSHACode) {
                 println "ES package calculated fingerprint is different from remote, deleting local archive"
                 delete(localESArchive)
+            } else {
+                println "Local ES package is already the latest"
             }
         }/* else {
             mkdir project.buildDir


### PR DESCRIPTION

## Release notes
[rn:skip]

## What does this PR do?

Instead of comparing the URL pointing to the SHA file, download the content and compare that.

## Why is it important/What is the impact to the user?

As a developer I don't want that ES package is downloaded on every X-Pack integration test run, when the last version package was already downloaded locally in a previous run.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run a couple of time a task that should download the ES, the first time is downloaded while the second it's not.

Clean before
```sh
./gradlew clean
```

Run a couple of times: 
```sh
./gradlew runIntegrationTests -PrubyIntegrationSpecs=specs/multiple_pipeline_spec.rb
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
