### PR TITLE
Limit exhaustive test triggers to active branches only

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -601,7 +601,7 @@ spec:
         build_tags: false
         trigger_mode: code
         filter_condition: >-
-          build.branch !~ /^backport.*$/ && build.branch !~ /^mergify\/bp\/.*$/
+          build.branch =~ /^main$/ || build.branch =~ /^[0-9]+\.[0-9]+$/ || build.branch =~ /^[0-9]+\.x$/
         filter_enabled: true
       cancel_intermediate_builds: true
       skip_intermediate_builds: true


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The exhaustive tests pipeline was triggering on every branch push, including updatecli automation branches. Switch the filter_condition from a deny-list to an allow-list matching only main, version (X.Y), and dev (X.x) branches. Manual and scheduled runs are unaffected.

Closes https://github.com/elastic/logstash/issues/18829
