### PR TITLE
pin multi_json to 1.19.1 since 1.20.0 has java variant with newer concurrent-ruby pin

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -44,4 +44,3 @@ gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default
-gem "multi_json", "~> 1.19.1" # Pin until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -44,3 +44,4 @@ gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default
+gem "multi_json", "~> 1.19.1" # Pin until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -78,6 +78,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
+  gem.add_runtime_dependency "multi_json", "~> 1.19.1" # pinned until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2
   gem.add_runtime_dependency "elasticsearch", '~> 8'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 


### PR DESCRIPTION
multi_json 1.20.0 is a very big release with drop of support for 9.4, multiple changes to its adapters and the first version that publishes java and ruby platform gems separately.

The java version introduces a concurrent-ruby pin we're not yet ready to respect, leading bundler to pick the ruby version since it doesn't have C extensions, but also doesn't carry jruby specific parts like jrjackson backend and use of java concurrency primitives.

So we pin the dependency for now at ~> 1.19.x.

Not pinning causes the ruby version to be installed, and then the orphan cleanup task removes the dependency by mistake, leading to failures in tests and potentially in runtime too.