### PR TITLE
ci: enable use-release-branches for docs workflows

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,3 +15,5 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
       enable-vale-linting: true
+      # Backport: merge this `use-release-branches` line into release branches 9.3 and 9.4 (same two workflow files).
+      use-release-branches: true

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,5 +15,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
       enable-vale-linting: true
-      # Backport: merge this `use-release-branches` line into release branches 9.3 and 9.4 (same two workflow files).
       use-release-branches: true

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,3 +14,5 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
+      # Backport: merge this `use-release-branches` line into release branches 9.3 and 9.4 (same two workflow files).
+      use-release-branches: true

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,5 +14,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
-      # Backport: merge this `use-release-branches` line into release branches 9.3 and 9.4 (same two workflow files).
       use-release-branches: true


### PR DESCRIPTION
## Summary

Enables the **`use-release-branches`** input on the reusable **`docs-build`** and **`docs-deploy`** workflows from [elastic/docs-actions](https://github.com/elastic/docs-actions) (`@v1`).

That lets **release-line branches** (e.g. `9.4`) refresh the **shared link index** and run a docs build when needed, even if a push does not touch `docs/` (common after branch cut).

## Related

- The **`use-release-branches`** input is available on the reusable workflows behind `@v1` as of [docs-actions v1.7.9](https://github.com/elastic/docs-actions/releases/tag/1.7.9).