### PR TITLE
ci: add mergify backport rule for 9.4 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -141,6 +141,16 @@ pull_request_rules:
         branches:
           - "9.3"
 
+  - name: backport patches to 9.4 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-9.4
+    actions:
+      backport:
+        branches:
+          - "9.4"
+
   - name: forwardport docs changes to main
     conditions:
       - merged


### PR DESCRIPTION
This PR just adds `9.4` to mergify so that PRs labeled `backport-9.4` can auto-create a backport PR. 