### PR TITLE
docs(style): correct 'occured' -> 'occurred' in STYLE.md logger.info examples

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -10,11 +10,11 @@ We support logging structured data, so please do that.
 
 Rather than this:
 
-    @logger.info("Some error occured in request #{request} on input #{input} from client #{ip}")
+    @logger.info("Some error occurred in request #{request} on input #{input} from client #{ip}")
 
 Do this:
     
-    @logger.info("Some error occured in this request", :request => request, :input => input, :client => ip)
+    @logger.info("Some error occurred in this request", :request => request, :input => input, :client => ip)
 
 ## Code Style
 


### PR DESCRIPTION
`STYLE.md` uses `Some error occured ...` in two example `logger.info` invocations (lines 13 and 17). Doc-only fix in the Logstash style guide so the recommended logging patterns don't propagate the misspelling. Source verified against current `main`.