### PR TITLE
require java 21, since jruby 10 requires it

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Logstash core will continue to exist under this repository and all related issue
 
 ### Prerequisites
 
-* Install JDK version 11 or 17. Make sure to set the `JAVA_HOME` environment variable to the path to your JDK installation directory. For example `set JAVA_HOME=<JDK_PATH>`
-* Install JRuby 9.2.x It is recommended to use a Ruby version manager such as [RVM](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv).
+* Install JDK version 21. Make sure to set the `JAVA_HOME` environment variable to the path to your JDK installation directory. For example `set JAVA_HOME=<JDK_PATH>`
+* Install JRuby 10.0.5.0 It is recommended to use a Ruby version manager such as [RVM](https://rvm.io/) or [rbenv](https://github.com/sstephenson/rbenv).
 * Install `rake` and `bundler` tool using `gem install rake` and `gem install bundler` respectively.
 
 ### RVM install (optional)

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -289,8 +289,8 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated msg
     end
 
-    if JavaVersion::CURRENT < JavaVersion::JAVA_17
-      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_17_minimum",
+    if JavaVersion::CURRENT < JavaVersion::JAVA_21
+      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_21_minimum",
                                            :java_home => java.lang.System.getProperty("java.home"))
     end
 

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -352,8 +352,8 @@ en:
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
-        version_17_minimum: >-
-          Starting from Logstash 9.0, the minimum required version of Java is Java 17;
+        version_21_minimum: >-
+          Starting from Logstash 9.4, the minimum required version of Java is Java 21;
           your Java version from `%{java_home}` does not meet this requirement.
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 public class JavaVersion implements Comparable<JavaVersion> {
 
     public static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
-    public static final JavaVersion JAVA_17 = parse("17");
     public static final JavaVersion JAVA_21 = parse("21");
 
     private final List<Integer> version;

--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JavaVersion.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JavaVersion.java
@@ -22,6 +22,7 @@ package org.logstash.launchers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Helper class to compare current version of JVM with a target version.
@@ -30,7 +31,7 @@ import java.util.Objects;
 public class JavaVersion implements Comparable<JavaVersion> {
 
     public static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));
-    public static final JavaVersion JAVA_17 = parse("17");
+    public static final JavaVersion JAVA_21 = parse("21");
     private final List<Integer> version;
 
     private JavaVersion(List<Integer> version) {
@@ -80,5 +81,10 @@ public class JavaVersion implements Comparable<JavaVersion> {
     @Override
     public int compareTo(JavaVersion other) {
         return compare(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return version.stream().map(Object::toString).collect(Collectors.joining("."));
     }
 }

--- a/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
+++ b/tools/jvm-options-parser/src/main/java/org/logstash/launchers/JvmOptionsParser.java
@@ -116,12 +116,13 @@ public class JvmOptionsParser {
     }
 
     static void bailOnOldJava() {
-        if (JavaVersion.CURRENT.compareTo(JavaVersion.JAVA_17) < 0) {
+        if (JavaVersion.CURRENT.compareTo(JavaVersion.JAVA_21) < 0) {
             final String message = String.format(
                     Locale.ROOT,
-                    "The minimum required Java version is 17; your Java version from [%s] does not meet this requirement",
-                    System.getProperty("java.home")
-            );
+                    "The minimum required Java version is 21; your Java version from [%s] is [%s] and does not meet this requirement",
+                    System.getProperty("java.home"),
+                    JavaVersion.CURRENT
+                    );
             System.err.println(message);
             System.exit(1);
         }


### PR DESCRIPTION
## Release notes

Sets the minimum version of Java to 21.

## What does this PR do?

Updates the check in the `JVMOptionsParser` to provide helpful output when logstash is invoked with a JVM that does not meet JRuby 10's minimum requirement.

## Why is it important/What is the impact to the user?

Without this, invoking Logstash on JVM 17 produces an obscure and unhelpful error message:

~~~
╭─{ rye@perhaps:~/src/elastic/logstash@main }
╰─● (jenv shell 17; bin/logstash -e '')
Using system java: /Users/rye/.jenv/shims/java
Error: Unable to initialize main class org.logstash.Logstash
Caused by: java.lang.UnsupportedClassVersionError: org/jruby/exceptions/RaiseException has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
[error: 1] 
~~~

With it, the message is helpful and clear:

~~~
╭─{ rye@perhaps:~/src/elastic/logstash@main (require-java-21 ✘) }
╰─● (jenv shell 17; bin/logstash -e '')
Using system java: /Users/rye/.jenv/shims/java
The minimum required Java version is 21; your Java version from [/opt/homebrew/Cellar/openjdk@17/17.0.15/libexec/openjdk.jdk/Contents/Home] is [17] and does not meet this requirement
[error: 1]
~~~

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

 - Build Logstash normally with Java 21
 - Launch Logstash with Java 17
   - jenv: `(jenv shell 17; bin/logstash -e "")`
   - LS_JAVA_HOME `LS_JAVA_HOME=/path/to/java17 bin/logstash -e ""`

## Related issues

 - #18755 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
