### PR TITLE
fix forced-shutdown (double SIGINT) behaviour for JRuby 10

### DIFF
--- a/logstash-core/src/main/java/org/logstash/Logstash.java
+++ b/logstash-core/src/main/java/org/logstash/Logstash.java
@@ -117,7 +117,9 @@ public final class Logstash implements Runnable, AutoCloseable {
 
     private static void installGlobalUncaughtExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler((thread, e) -> {
-            if (e instanceof Error) {
+            if (e instanceof org.jruby.exceptions.SystemExit) {
+                halt(1);
+            } else if (e instanceof Error) {
                 handleFatalError("uncaught error (in thread " + thread.getName() + ")",  e);
             } else {
                 LOGGER.error("uncaught exception (in thread " + thread.getName() + ")", e);


### PR DESCRIPTION
## Release notes

[rn:skip]

## What does this PR do?

Fixes an issue introduced with the upgrade to JRuby 10 in which a doubled-`SIGINT` does _not_ force an immediate shutdown because the `SystemExit` exception is caught and squashed by the default thread exception handler.

## Why is it important/What is the impact to the user?

Sometimes our users need to force Logstash to shut down before it has finished processing the events in-flight. The upgrade to JRuby10 inadvertently removed this functionality, and we restore it here.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. Invoke Logstash with intentional back-pressure:
   ~~~
   bin/logstash -e 'input { generator {} } filter { ruby { code => "sleep 1" } } output { sink {} }'
   ~~~
2. Wait until processing, then send _TWO_ `SIGINT` signals (`CTRL+C` in most shells)
3. Observe that the process correctly bails immediately after the second `SIGINT`.

(without this patch, Logstash keeps processing until the in-flight events are done)

## Related issues

Caused by: #18755 


## Logs

Without (note how it keeps executing after logging _"Terminating Immediately"_):

> ~~~
> [2026-04-17T15:29:58,450][INFO ][logstash.agent           ] Pipelines running {count: 1, running_pipelines: [:main], non_running_pipelines: []}
> ^C[2026-04-17T15:30:02,168][WARN ][logstash.runner          ] SIGINT received. Shutting down.
> ^C[2026-04-17T15:30:02,946][FATAL][logstash.runner          ] SIGINT received. Terminating immediately..
> [2026-04-17T15:30:02,947][ERROR][org.logstash.Logstash    ] uncaught exception (in thread SIGINT handler)
> org.jruby.exceptions.SystemExit: (SystemExit) exit
>         at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:974)
>         at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:933)
>         at org.jruby.RubyThread.kill(org/jruby/RubyThread.java:1955)
> [2026-04-17T15:30:07,184][WARN ][logstash.runner          ] Received shutdown signal, but pipeline is still waiting for in-flight events
> to be processed. Sending another ^C will force quit Logstash, but this may cause
> data loss.
> [2026-04-17T15:30:07,283][ERROR][org.logstash.execution.ShutdownWatcherExt] The shutdown process appears to be stalled due to busy or blocked plugins. Check the logs for more information.
> [2026-04-17T15:30:07,283][INFO ][org.logstash.execution.ShutdownWatcherExt] The queue for pipeline main is draining before shutdown.
> ^C[2026-04-17T15:30:20,063][FATAL][logstash.runner          ] SIGINT received. Terminating immediately..
> [2026-04-17T15:30:20,064][ERROR][org.logstash.Logstash    ] uncaught exception (in thread SIGINT handler)
> org.jruby.exceptions.SystemExit: (SystemExit) exit
>         at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:974)
>         at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:933)
>         at org.jruby.RubyThread.kill(org/jruby/RubyThread.java:1955)
> ~~~

With (note how it _actually_ terminates immediately after logging _"Terminating Immediately"_):

> ~~~
> [2026-04-17T16:06:52,247][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id" => "main"}
> [2026-04-17T16:06:52,256][INFO ][logstash.agent           ] Pipelines running {count: 1, running_pipelines: [:main], non_running_pipelines: []}
> ^C[2026-04-17T16:06:57,660][WARN ][logstash.runner          ] SIGINT received. Shutting down.
> [2026-04-17T16:07:02,674][WARN ][logstash.runner          ] Received shutdown signal, but pipeline is still waiting for in-flight events
> to be processed. Sending another ^C will force quit Logstash, but this may cause
> data loss.
> [2026-04-17T16:07:02,791][ERROR][org.logstash.execution.ShutdownWatcherExt] The shutdown process appears to be stalled due to busy or blocked plugins. Check the logs for more information.
> [2026-04-17T16:07:02,792][INFO ][org.logstash.execution.ShutdownWatcherExt] The queue for pipeline main is draining before shutdown.
> ^C[2026-04-17T16:07:04,711][FATAL][logstash.runner          ] SIGINT received. Terminating immediately..
> [error: 1 (00:00:19)] 
> ~~~

