### PR TITLE
Skip fips tests that invoke logstash keystore command

### DIFF
--- a/qa/integration/specs/cli/keystore_spec.rb
+++ b/qa/integration/specs/cli/keystore_spec.rb
@@ -24,7 +24,7 @@ require "stud/temporary"
 require "fileutils"
 require "open3"
 
-describe "CLI > logstash-keystore" do
+describe "CLI > logstash-keystore", :skip_fips do
   before(:all) do
     @fixture = Fixture.new(__FILE__)
     @logstash = @fixture.get_service("logstash")

--- a/qa/integration/specs/cli/list_spec.rb
+++ b/qa/integration/specs/cli/list_spec.rb
@@ -21,7 +21,7 @@ require_relative '../../services/logstash_service'
 require_relative '../../framework/helpers'
 require "logstash/devutils/rspec/spec_helper"
 
-describe "CLI > logstash-plugin remove" do
+describe "CLI > logstash-plugin remove", :skip_fips do
   before(:all) do
     @fixture = Fixture.new(__FILE__)
     @logstash_plugin = @fixture.get_service("logstash").plugin_cli

--- a/qa/integration/specs/secret_store_spec.rb
+++ b/qa/integration/specs/secret_store_spec.rb
@@ -30,7 +30,7 @@ require "logstash/devutils/rspec/spec_helper"
 # tag2 = mytag2
 # tag3 = mytag3
 ####################################
-describe "Test that Logstash" do
+describe "Test that Logstash", :skip_fips do
   before(:all) {
     @fixture = Fixture.new(__FILE__)
   }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
The latest jruby-openssl https://github.com/jruby/jruby-openssl/issues/361 release has a new behavior where bouncycastle fips jars on the classloading path can cause issues loading openssl. The observabilitySRE artifact explicitly disables logstash keystore commands (as well as pluginmanager) because jruby-openssl is not compatible. This commit updates the fips tests to skip tests which use the keystore command. Previously this was missed because the commands still worked (even through the fips providers were not necessarily used). These should have always been skipped, so now they are.

Example failing tests: https://buildkite.com/elastic/logstash-exhaustive-tests-pipeline/builds/3799#_