### PR TITLE
Ensure do_close failures don't halt pipeline shutdown

### DIFF
--- a/logstash-core/lib/logstash/java_pipeline.rb
+++ b/logstash-core/lib/logstash/java_pipeline.rb
@@ -255,7 +255,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
       registered << plugin
     end
   rescue => e
-    registered.each(&:do_close)
+    registered.each { |plugin| close_plugin_and_ignore(plugin) }
     raise e
   end
 
@@ -523,8 +523,8 @@ module LogStash; class JavaPipeline < AbstractPipeline
       t.join
     end
 
-    filters.each(&:do_close)
-    outputs.each(&:do_close)
+    filters.each { |plugin| close_plugin_and_ignore(plugin) }
+    outputs.each { |plugin| close_plugin_and_ignore(plugin) }
   end
 
   # for backward compatibility in devutils for the rspec helpers, this method is not used
@@ -618,7 +618,7 @@ module LogStash; class JavaPipeline < AbstractPipeline
     rescue => e
       @logger.warn(
         "plugin raised exception while closing, ignoring",
-        exception_logging_keys(e, :plugin => plugin.class.config_name))
+        exception_logging_keys(e, :plugin => plugin.config_name))
     end
   end
 

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -821,9 +821,10 @@ describe LogStash::JavaPipeline do
         # Input close runs on a separate path (inputworker#ensure);
         # asserted here as a regression guard against future coupling.
         expect(input).to receive(:do_close).once
+        allow(pipeline.logger).to receive(:warn)
         expect(pipeline.logger).to receive(:warn).with(
           "plugin raised exception while closing, ignoring",
-          hash_including(:plugin => "dummyfilter"))
+          hash_including(:plugin => raising_filter.config_name))
 
         pipeline.start
         pipeline.shutdown
@@ -859,9 +860,10 @@ describe LogStash::JavaPipeline do
         # Input close runs on a separate path (inputworker#ensure);
         # asserted here as a regression guard against future coupling.
         expect(input).to receive(:do_close).once
+        allow(pipeline.logger).to receive(:warn)
         expect(pipeline.logger).to receive(:warn).with(
           "plugin raised exception while closing, ignoring",
-          hash_including(:plugin => "dummyoutput"))
+          hash_including(:plugin => raising_output.config_name))
 
         pipeline.start
         pipeline.shutdown

--- a/logstash-core/spec/logstash/java_pipeline_spec.rb
+++ b/logstash-core/spec/logstash/java_pipeline_spec.rb
@@ -790,6 +790,106 @@ describe LogStash::JavaPipeline do
         expect(pipeline.crashed?).to be false
       end
     end
+
+    context "when a filter raises during do_close" do
+      before(:each) do
+        allow(LogStash::Plugin).to receive(:lookup).with("filter", "dummyfilter").and_return(DummyFilter)
+      end
+
+      let(:test_config_with_two_filters) {
+        <<-eos
+        input { dummyinput {} }
+        filter {
+          dummyfilter { id => "filter_1" }
+          dummyfilter { id => "filter_2" }
+        }
+        output { dummyoutput {} }
+        eos
+      }
+      let(:pipeline)         { mock_java_pipeline_from_string(test_config_with_two_filters, mock_settings("pipeline.batch.metrics.sampling_mode" => batch_sampling_mode)) }
+      let(:raising_filter)   { pipeline.filters.first }
+      let(:remaining_filter) { pipeline.filters.last }
+      let(:output)           { pipeline.outputs.first }
+      let(:input)            { pipeline.inputs.first }
+
+      before { allow(raising_filter).to receive(:do_close).and_raise("boom from filter_1 do_close") }
+
+      it "still closes the remaining filter and the output" do
+        # Core assertion: shutdown_workers must keep iterating past the raise.
+        expect(remaining_filter).to receive(:do_close).once
+        expect(output).to receive(:do_close).once
+        # Input close runs on a separate path (inputworker#ensure);
+        # asserted here as a regression guard against future coupling.
+        expect(input).to receive(:do_close).once
+        expect(pipeline.logger).to receive(:warn).with(
+          "plugin raised exception while closing, ignoring",
+          hash_including(:plugin => "dummyfilter"))
+
+        pipeline.start
+        pipeline.shutdown
+
+        expect(pipeline.crashed?).to be false
+      end
+    end
+
+    context "when an output raises during do_close" do
+      before(:each) do
+        allow(LogStash::Plugin).to receive(:lookup).with("output", "dummyoutputmore").and_return(DummyOutputMore)
+      end
+
+      let(:test_config_with_two_outputs) {
+        <<-eos
+        input { dummyinput {} }
+        output {
+          dummyoutput {}
+          dummyoutputmore {}
+        }
+        eos
+      }
+      let(:pipeline)         { mock_java_pipeline_from_string(test_config_with_two_outputs, mock_settings("pipeline.batch.metrics.sampling_mode" => batch_sampling_mode)) }
+      let(:raising_output)   { pipeline.outputs.first }
+      let(:remaining_output) { pipeline.outputs.last }
+      let(:input)            { pipeline.inputs.first }
+
+      before { allow(raising_output).to receive(:do_close).and_raise("boom from first output do_close") }
+
+      it "still closes the remaining output" do
+        # Core assertion: shutdown_workers must keep iterating past the raise.
+        expect(remaining_output).to receive(:do_close).once
+        # Input close runs on a separate path (inputworker#ensure);
+        # asserted here as a regression guard against future coupling.
+        expect(input).to receive(:do_close).once
+        expect(pipeline.logger).to receive(:warn).with(
+          "plugin raised exception while closing, ignoring",
+          hash_including(:plugin => "dummyoutput"))
+
+        pipeline.start
+        pipeline.shutdown
+
+        expect(pipeline.crashed?).to be false
+      end
+    end
+
+    context "when register_plugins rolls back and a registered plugin's do_close raises" do
+      let(:pipeline) { mock_java_pipeline_from_string(test_config_without_output_workers, mock_settings("pipeline.batch.metrics.sampling_mode" => batch_sampling_mode)) }
+
+      after { pipeline.close rescue nil }
+
+      it "closes every already-registered plugin and re-raises the original register error" do
+        good = ::LogStash::Outputs::DummyOutput.new
+        bad_close = ::LogStash::Outputs::DummyOutput.new
+        failing_register = ::LogStash::Outputs::DummyOutput.new
+        register_error = RuntimeError.new("register failed")
+
+        allow(failing_register).to receive(:register).and_raise(register_error)
+        expect(bad_close).to receive(:do_close).and_raise("boom from do_close")
+        expect(good).to receive(:do_close).and_call_original
+
+        expect {
+          pipeline.register_plugins([good, bad_close, failing_register])
+        }.to raise_error(register_error)
+      end
+    end
   end
 
   context "with no explicit ids declared" do


### PR DESCRIPTION
Fix the shutdown code to make sure all resources are released through `#do_close` even if one fails. I caught this while reviewing https://github.com/logstash-plugins/logstash-input-beats/pull/537 

## Release notes

Fix the situation where if during pipeline shutdown a filter or output plugin failed to shut down resources may not be released.

## What does this PR do?

Ensures resources are released on pipeline shutdown even when exceptions are raised in `#close`

## Why is it important/What is the impact to the user?

Without this we may leak resources

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```bash
#!/usr/bin/env bash
set -euo pipefail

PLUGIN_DIR=/tmp/do-close-repro/logstash/filters
mkdir -p "$PLUGIN_DIR"

cat > "$PLUGIN_DIR/boom_close.rb" <<'RUBY'
require "logstash/filters/base"

class LogStash::Filters::BoomClose < LogStash::Filters::Base
  config_name "boom_close"
  def register; end
  def filter(event); end
  def close; raise "boom from do_close" end
end
RUBY

# Run from the logstash repo root
./bin/logstash \
  --path.plugins /tmp/do-close-repro \
  -e '
    input  { generator { count => 3 } }
    filter { boom_close {} }
    output { stdout { codec => dots } }
  '
```

What to look for in the output:

A WARN line: plugin raised exception while closing, ignoring with :plugin=>"boom_close" and the boom from do_close exception in the keys.
The pipeline exits cleanly — the stdout output still closes, process terminates without hanging.

Example WARN line + subsequent output:

```

[2026-04-21T16:24:06,956][INFO ][logstash.agent           ] Pipelines running {count: 1, running_pipelines: [:main], non_running_pipelines: []}
...[2026-04-21T16:24:07,119][WARN ][logstash.javapipeline    ][main] plugin raised exception while closing, ignoring {pipeline_id: "main", exception: "RuntimeError", error: "boom from do_close", stacktrace: "/private/tmp/do-close-repro/logstash/filters/boom_close.rb:7:in 'close'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/plugin.rb:98:in 'do_close'\norg/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:90:in 'do_close'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:617:in 'close_plugin_and_ignore'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:526:in 'block in shutdown_workers'\norg/jruby/RubyArray.java:2093:in 'each'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:526:in 'shutdown_workers'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:222:in 'run'\n/Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:159:in 'block in start'", plugin: "boom_close", thread: "#<Thread:0x7be163df /Users/andrewvc/projects/logstash/logstash-core/lib/logstash/java_pipeline.rb:149 run>"}
[2026-04-21T16:24:07,121][INFO ][logstash.javapipeline    ][main] Pipeline terminated {"pipeline.id" => "main"}
[2026-04-21T16:24:07,467][INFO ][logstash.pipelinesregistry] Removed pipeline from registry successfully {pipeline_id: :main}
[2026-04-21T16:24:07,477][INFO ][logstash.runner          ] Logstash shut down.
andrewvc@avcwork ~/p/logstash (fix-do-close-guarantees)>
```
