### PR TITLE
`dead_letter_queue.flush_check_interval` new config for flushing staled segment files.

### DIFF
--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -271,6 +271,14 @@
 #
 # dead_letter_queue.flush_interval: 5000
 
+# If using dead_letter_queue.enable: true, the interval in milliseconds that the DLQ scheduler checks for stale segments
+# to be flushed. A smaller value ensures faster segment rotation at the cost of CPU with more frequent scheduler runs.
+# A larger value reduces scheduler overhead but may delay segment sealing.
+# Minimum value is 1000 and cannot be greater than dead_letter_queue.flush_interval. 
+# Default is 1000.
+#
+# dead_letter_queue.flush_check_interval: 1000
+
 # If using dead_letter_queue.enable: true, controls which entries should be dropped to avoid exceeding the size limit.
 # Set the value to `drop_newer` (default) to stop accepting new events that would push the DLQ size over the limit.
 # Set the value to `drop_older` to remove queue pages containing the oldest events to make space for new ones.

--- a/docs/reference/dead-letter-queues.md
+++ b/docs/reference/dead-letter-queues.md
@@ -78,14 +78,14 @@ Note that this value cannot be set to lower than 1000ms.
 dead_letter_queue.flush_interval: 5000
 ```
 
-Dead letter queue scheduler checks are controlled by the `dead_letter_queue.flush_check_interval` setting. This setting controls how frequently the background scheduler checks for stale segments that need to be flushed. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but may delay segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
+Dead letter queue scheduler checks are controlled by the `dead_letter_queue.flush_check_interval` setting. This setting controls how frequently the background scheduler checks for stale segments that need to be flushed. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but delays segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
 
 ```yaml
 dead_letter_queue.flush_check_interval: 1000
 ```
 
 ::::{note}
-You may not use the same `dead_letter_queue` path for two different Logstash instances.
+You cannot use the same `dead_letter_queue` path for two different Logstash instances.
 ::::
 
 

--- a/docs/reference/dead-letter-queues.md
+++ b/docs/reference/dead-letter-queues.md
@@ -78,7 +78,7 @@ Note that this value cannot be set to lower than 1000ms.
 dead_letter_queue.flush_interval: 5000
 ```
 
-Dead letter queue scheduler checks are controlled by the `dead_letter_queue.flush_check_interval` setting. This setting controls how frequently the background scheduler checks for stale segments that need to be flushed. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but delays segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
+Stale segments files are periodically checked if they need to be flushed. This period is controlled by the `dead_letter_queue.flush_check_interval` setting. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but delays segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
 
 ```yaml
 dead_letter_queue.flush_check_interval: 1000

--- a/docs/reference/dead-letter-queues.md
+++ b/docs/reference/dead-letter-queues.md
@@ -78,7 +78,7 @@ Note that this value cannot be set to lower than 1000ms.
 dead_letter_queue.flush_interval: 5000
 ```
 
-Stale segments files are periodically checked if they need to be flushed. This period is controlled by the `dead_letter_queue.flush_check_interval` setting. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but delays segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
+Stale segments files are periodically checked if they need to be flushed. This period is controlled by the `dead_letter_queue.flush_check_interval` setting. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent segment checks execution. A larger value reduces checks overhead but delays segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
 
 ```yaml
 dead_letter_queue.flush_check_interval: 1000

--- a/docs/reference/dead-letter-queues.md
+++ b/docs/reference/dead-letter-queues.md
@@ -78,6 +78,12 @@ Note that this value cannot be set to lower than 1000ms.
 dead_letter_queue.flush_interval: 5000
 ```
 
+Dead letter queue scheduler checks are controlled by the `dead_letter_queue.flush_check_interval` setting. This setting controls how frequently the background scheduler checks for stale segments that need to be flushed. This setting is in milliseconds, and defaults to 1000ms. A smaller value ensures faster segment rotation when infrequent writes occur, at the cost of CPU consumption with more frequent scheduler execution. A larger value reduces scheduler overhead but may delay segment sealing, for the worst case it will be `dead_letter_queue.flush_interval` + `dead_letter_queue.flush_check_interval`. This value cannot be set to lower than 1000ms.
+
+```yaml
+dead_letter_queue.flush_check_interval: 1000
+```
+
 ::::{note}
 You may not use the same `dead_letter_queue` path for two different Logstash instances.
 ::::

--- a/logstash-core/lib/logstash/environment.rb
+++ b/logstash-core/lib/logstash/environment.rb
@@ -102,6 +102,7 @@ module LogStash
            Setting::BooleanSetting.new("dead_letter_queue.enable", false),
              Setting::BytesSetting.new("dead_letter_queue.max_bytes", "1024mb"),
            Setting::NumericSetting.new("dead_letter_queue.flush_interval", 5000),
+           Setting::NumericSetting.new("dead_letter_queue.flush_check_interval", 1000),
             Setting::StringSetting.new("dead_letter_queue.storage_policy", "drop_newer", true, ["drop_newer", "drop_older"]),
     Setting::NullableStringSetting.new("dead_letter_queue.retain.age"), # example 5d
          Setting::TimeValueSetting.new("slowlog.threshold.warn", "-1"),

--- a/logstash-core/lib/logstash/settings.rb
+++ b/logstash-core/lib/logstash/settings.rb
@@ -46,6 +46,7 @@ module LogStash
       "config.string",
       "dead_letter_queue.enable",
       "dead_letter_queue.flush_interval",
+      "dead_letter_queue.flush_check_interval",
       "dead_letter_queue.max_bytes",
       "dead_letter_queue.storage_policy",
       "dead_letter_queue.retain.age",

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -111,8 +111,7 @@ public class DeadLetterQueueFactory {
                                                    final Duration flushInterval, final Duration flushCheckInterval, final QueueStorageType storageType) {
         try {
             return DeadLetterQueueWriter
-                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
-                    .flushCheckInterval(flushCheckInterval)
+                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval, flushCheckInterval)
                     .pipelineId(id)
                     .storageType(storageType)
                     .build();
@@ -127,8 +126,7 @@ public class DeadLetterQueueFactory {
                                                    final Duration age) {
         try {
             return DeadLetterQueueWriter
-                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
-                    .flushCheckInterval(flushCheckInterval)
+                    .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval, flushCheckInterval)
                     .pipelineId(id)
                     .storageType(storageType)
                     .retentionTime(age)

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -113,6 +113,7 @@ public class DeadLetterQueueFactory {
             return DeadLetterQueueWriter
                     .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
                     .flushCheckInterval(flushCheckInterval)
+                    .pipelineId(id)
                     .storageType(storageType)
                     .build();
         } catch (IOException e) {
@@ -128,6 +129,7 @@ public class DeadLetterQueueFactory {
             return DeadLetterQueueWriter
                     .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
                     .flushCheckInterval(flushCheckInterval)
+                    .pipelineId(id)
                     .storageType(storageType)
                     .retentionTime(age)
                     .build();

--- a/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
+++ b/logstash-core/src/main/java/org/logstash/common/DeadLetterQueueFactory.java
@@ -76,15 +76,16 @@ public class DeadLetterQueueFactory {
      * @param maxQueueSize Maximum size of the dead letter queue (in bytes). No entries will be written
      *                     that would make the size of this dlq greater than this value
      * @param flushInterval Maximum duration between flushes of dead letter queue files if no data is sent.
+     * @param flushCheckInterval The interval between scheduler checks for stale segments.
      * @param storageType overwriting type in case of queue full: drop_older or drop_newer.
      * @return write manager for the specific id's dead-letter-queue context
      */
-    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, QueueStorageType storageType) {
-        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, storageType));
+    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, Duration flushCheckInterval, QueueStorageType storageType) {
+        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, flushCheckInterval, storageType));
     }
 
     /**
-     * Like {@link #getWriter(String, String, long, Duration, QueueStorageType)} but also setting the age duration
+     * Like {@link #getWriter(String, String, long, Duration, Duration, QueueStorageType)} but also setting the age duration
      * of the segments.
      *
      * @param id The identifier context for this dlq manager
@@ -93,12 +94,13 @@ public class DeadLetterQueueFactory {
      * @param maxQueueSize Maximum size of the dead letter queue (in bytes). No entries will be written
      *                     that would make the size of this dlq greater than this value
      * @param flushInterval Maximum duration between flushes of dead letter queue files if no data is sent.
+     * @param flushCheckInterval The interval between scheduler checks for stale segments.
      * @param storageType overwriting type in case of queue full: drop_older or drop_newer.
      * @param age the period that DLQ events should be considered as valid, before automatic removal.
      * @return write manager for the specific id's dead-letter-queue context
      * */
-    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, QueueStorageType storageType, Duration age) {
-        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, storageType, age));
+    public static DeadLetterQueueWriter getWriter(String id, String dlqPath, long maxQueueSize, Duration flushInterval, Duration flushCheckInterval, QueueStorageType storageType, Duration age) {
+        return REGISTRY.computeIfAbsent(id, key -> newWriter(key, dlqPath, maxQueueSize, flushInterval, flushCheckInterval, storageType, age));
     }
 
     public static DeadLetterQueueWriter release(String id) {
@@ -106,10 +108,11 @@ public class DeadLetterQueueFactory {
     }
 
     private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize,
-                                                   final Duration flushInterval, final QueueStorageType storageType) {
+                                                   final Duration flushInterval, final Duration flushCheckInterval, final QueueStorageType storageType) {
         try {
             return DeadLetterQueueWriter
                     .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
+                    .flushCheckInterval(flushCheckInterval)
                     .storageType(storageType)
                     .build();
         } catch (IOException e) {
@@ -119,11 +122,12 @@ public class DeadLetterQueueFactory {
     }
 
     private static DeadLetterQueueWriter newWriter(final String id, final String dlqPath, final long maxQueueSize,
-                                                   final Duration flushInterval, final QueueStorageType storageType,
+                                                   final Duration flushInterval, final Duration flushCheckInterval, final QueueStorageType storageType,
                                                    final Duration age) {
         try {
             return DeadLetterQueueWriter
                     .newBuilder(Paths.get(dlqPath, id), MAX_SEGMENT_SIZE_BYTES, maxQueueSize, flushInterval)
+                    .flushCheckInterval(flushCheckInterval)
                     .storageType(storageType)
                     .retentionTime(age)
                     .build();

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -177,13 +177,13 @@ public final class DeadLetterQueueWriter implements Closeable {
     private static class FixedRateScheduler implements SchedulerService {
 
         private final ScheduledExecutorService scheduledExecutor;
-        private final long checkIntervalMs;
+        private final Duration flushCheckInterval;
 
-        FixedRateScheduler(final long flushCheckInterval, final String pipelineId) {
+        FixedRateScheduler(final Duration flushCheckInterval, final String pipelineId) {
             //Set the name with pipeline ID for better visibility
             final String threadName = pipelineId != null ? "dlq-flush-check[" + pipelineId + "]" : "dlq-flush-check";
             
-            this.checkIntervalMs = flushCheckInterval;
+            this.flushCheckInterval = flushCheckInterval;
             scheduledExecutor = Executors.newScheduledThreadPool(1, r -> {
                 Thread t = new Thread(r);
                 //Allow this thread to die when the JVM dies
@@ -195,7 +195,7 @@ public final class DeadLetterQueueWriter implements Closeable {
 
         @Override
         public void repeatedAction(Runnable action) {
-            scheduledExecutor.scheduleAtFixedRate(action, checkIntervalMs, checkIntervalMs, TimeUnit.MILLISECONDS);
+            scheduledExecutor.scheduleAtFixedRate(action, flushCheckInterval.toMillis(), flushCheckInterval.toMillis(), TimeUnit.MILLISECONDS);
         }
 
         @Override
@@ -283,7 +283,7 @@ public final class DeadLetterQueueWriter implements Closeable {
             } else {
                 if (startScheduledFlusher) {
                     final Duration normalizedFlushCheckInterval = normalizeFlushCheckInterval(flushCheckInterval, normalizedFlushInterval);
-                    schedulerService = new FixedRateScheduler(normalizedFlushCheckInterval.toMillis(), pipelineId);
+                    schedulerService = new FixedRateScheduler(normalizedFlushCheckInterval, pipelineId);
                 } else {
                     schedulerService = new NoopScheduler();
                 }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -145,7 +145,6 @@ public final class DeadLetterQueueWriter implements Closeable {
     private volatile int currentSegmentIndex;
     private volatile Timestamp lastEntryTimestamp;
     private final Duration flushInterval;
-    private final Duration flushCheckInterval;
     private final AtomicBoolean open = new AtomicBoolean(true);
     private final LongAdder droppedEvents = new LongAdder();
     private final LongAdder expiredEvents = new LongAdder();
@@ -180,11 +179,11 @@ public final class DeadLetterQueueWriter implements Closeable {
         private final ScheduledExecutorService scheduledExecutor;
         private final long checkIntervalMs;
 
-        FixedRateScheduler(final Duration flushCheckInterval, final String pipelineId) {
+        FixedRateScheduler(final long flushCheckInterval, final String pipelineId) {
             //Set the name with pipeline ID for better visibility
             final String threadName = pipelineId != null ? "dlq-flush-check[" + pipelineId + "]" : "dlq-flush-check";
             
-            this.checkIntervalMs = Math.max(flushCheckInterval.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis());
+            this.checkIntervalMs = flushCheckInterval;
             scheduledExecutor = Executors.newScheduledThreadPool(1, r -> {
                 Thread t = new Thread(r);
                 //Allow this thread to die when the JVM dies
@@ -223,23 +222,24 @@ public final class DeadLetterQueueWriter implements Closeable {
         private final long maxSegmentSize;
         private final long maxQueueSize;
         private final Duration flushInterval;
+        private final Duration flushCheckInterval;
         private boolean startScheduledFlusher;
         private QueueStorageType storageType = QueueStorageType.DROP_NEWER;
         private Duration retentionTime = null;
-        private Duration flushCheckInterval = Duration.ofMillis(1000);
         private Clock clock = Clock.systemDefaultZone();
         private SchedulerService customSchedulerService = null;
         private String pipelineId;
 
-        private Builder(Path queuePath, long maxSegmentSize, long maxQueueSize, Duration flushInterval) {
-            this(queuePath, maxSegmentSize, maxQueueSize, flushInterval, true);
+        private Builder(Path queuePath, long maxSegmentSize, long maxQueueSize, final Duration flushInterval, final Duration flushCheckInterval) {
+            this(queuePath, maxSegmentSize, maxQueueSize, flushInterval, flushCheckInterval, true);
         }
 
-        private Builder(Path queuePath, long maxSegmentSize, long maxQueueSize, Duration flushInterval, boolean startScheduledFlusher) {
+        private Builder(Path queuePath, long maxSegmentSize, long maxQueueSize, final Duration flushInterval, final Duration flushCheckInterval, boolean startScheduledFlusher) {
             this.queuePath = queuePath;
             this.maxSegmentSize = maxSegmentSize;
             this.maxQueueSize = maxQueueSize;
             this.flushInterval = flushInterval;
+            this.flushCheckInterval = flushCheckInterval;
             this.startScheduledFlusher = startScheduledFlusher;
         }
 
@@ -250,11 +250,6 @@ public final class DeadLetterQueueWriter implements Closeable {
 
         public Builder retentionTime(Duration retentionTime) {
             this.retentionTime = retentionTime;
-            return this;
-        }
-
-        public Builder flushCheckInterval(final Duration interval) {
-            this.flushCheckInterval = interval;
             return this;
         }
 
@@ -280,56 +275,67 @@ public final class DeadLetterQueueWriter implements Closeable {
                 throw new IllegalArgumentException("Both default scheduler and custom scheduler were defined, ");
             }
 
-            Duration effectiveFlushInterval = flushInterval;
-            if (startScheduledFlusher && flushInterval.compareTo(MIN_FLUSH_PERIOD) < 0) {
-                logger.warn("dead_letter_queue.flush_interval ({} ms) is below the minimum of {} ms; using {} ms",
-                        flushInterval.toMillis(), MIN_FLUSH_PERIOD.toMillis(), MIN_FLUSH_PERIOD.toMillis());
-                effectiveFlushInterval = MIN_FLUSH_PERIOD;
-            }
-
-            Duration effectiveFlushCheckInterval = flushCheckInterval;
-            if (startScheduledFlusher) {
-                // Clamp to maximum (can't exceed flush interval)
-                if (effectiveFlushCheckInterval.compareTo(effectiveFlushInterval) > 0) {
-                    logger.warn("dead_letter_queue.flush_check_interval ({} ms) cannot be greater than dead_letter_queue.flush_interval ({} ms); using {} ms",
-                            effectiveFlushCheckInterval.toMillis(), effectiveFlushInterval.toMillis(), effectiveFlushInterval.toMillis());
-                    effectiveFlushCheckInterval = effectiveFlushInterval;
-                }
-                // Clamp to minimum (for scheduler only, don't change stored value)
-                if (effectiveFlushCheckInterval.compareTo(MIN_FLUSH_CHECK_INTERVAL) < 0) {
-                    logger.warn("dead_letter_queue.flush_check_interval ({} ms) is below the minimum of {} ms; using {} ms for the scheduler",
-                            effectiveFlushCheckInterval.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis());
-                }
-            }
+            final Duration normalizedFlushInterval = normalizeFlushInterval(flushInterval);
 
             SchedulerService schedulerService;
             if (customSchedulerService != null) {
                 schedulerService = customSchedulerService;
             } else {
                 if (startScheduledFlusher) {
-                    // Use clamped-to-max value for scheduler (which will further clamp to MIN in FixedRateScheduler)
-                    schedulerService = new FixedRateScheduler(effectiveFlushCheckInterval, pipelineId);
+                    final Duration normalizedFlushCheckInterval = normalizeFlushCheckInterval(flushCheckInterval, normalizedFlushInterval);
+                    schedulerService = new FixedRateScheduler(normalizedFlushCheckInterval.toMillis(), pipelineId);
                 } else {
                     schedulerService = new NoopScheduler();
                 }
             }
 
-            return new DeadLetterQueueWriter(queuePath, maxSegmentSize, maxQueueSize, effectiveFlushInterval, effectiveFlushCheckInterval, storageType, retentionTime, clock, schedulerService);
+            return new DeadLetterQueueWriter(queuePath, maxSegmentSize, maxQueueSize, normalizedFlushInterval, storageType, retentionTime, clock, schedulerService);
+        }
+
+        @VisibleForTesting
+        Duration normalizeFlushInterval(final Duration flushInterval) {
+            if (!startScheduledFlusher) return flushInterval;
+
+            Duration effectiveFlushInterval = flushInterval;
+            if (flushInterval.compareTo(MIN_FLUSH_PERIOD) < 0) {
+                logger.warn("dead_letter_queue.flush_interval ({} ms) is below the minimum of {} ms; using {} ms",
+                        flushInterval.toMillis(), MIN_FLUSH_PERIOD.toMillis(), MIN_FLUSH_PERIOD.toMillis());
+                effectiveFlushInterval = MIN_FLUSH_PERIOD;
+            }
+            return effectiveFlushInterval;
+        }
+
+        @VisibleForTesting
+        Duration normalizeFlushCheckInterval(final Duration flushCheckInterval, final Duration effectiveFlushInterval) {
+            Duration effectiveFlushCheckInterval = flushCheckInterval;
+            // can't exceed flush interval
+            if (effectiveFlushCheckInterval.compareTo(effectiveFlushInterval) > 0) {
+                logger.warn("dead_letter_queue.flush_check_interval ({} ms) cannot be greater than dead_letter_queue.flush_interval ({} ms); using {} ms",
+                        effectiveFlushCheckInterval.toMillis(), effectiveFlushInterval.toMillis(), effectiveFlushInterval.toMillis());
+                effectiveFlushCheckInterval = effectiveFlushInterval;
+            }
+            // can't be less than 1s
+            if (effectiveFlushCheckInterval.compareTo(MIN_FLUSH_CHECK_INTERVAL) < 0) {
+                logger.warn("dead_letter_queue.flush_check_interval ({} ms) is below the minimum of {} ms; using {} ms for the flush check interval",
+                        effectiveFlushCheckInterval.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis());
+                effectiveFlushCheckInterval = MIN_FLUSH_CHECK_INTERVAL;
+            }
+            return effectiveFlushCheckInterval;
         }
     }
 
     public static Builder newBuilder(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,
-                                     final Duration flushInterval) {
-        return new Builder(queuePath, maxSegmentSize, maxQueueSize, flushInterval);
+                                     final Duration flushInterval, final Duration flushCheckInterval) {
+        return new Builder(queuePath, maxSegmentSize, maxQueueSize, flushInterval, flushCheckInterval);
     }
 
     @VisibleForTesting
     static Builder newBuilderWithoutFlusher(final Path queuePath, final long maxSegmentSize, final long maxQueueSize) {
-        return new Builder(queuePath, maxSegmentSize, maxQueueSize, Duration.ZERO, false);
+        return new Builder(queuePath, maxSegmentSize, maxQueueSize, Duration.ZERO, Duration.ZERO, false);
     }
 
     private DeadLetterQueueWriter(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,
-                                  final Duration flushInterval, final Duration flushCheckInterval, final QueueStorageType storageType, final Duration retentionTime,
+                                  final Duration flushInterval, final QueueStorageType storageType, final Duration retentionTime,
                                   final Clock clock, SchedulerService flusherService) throws IOException {
         this.clock = clock;
 
@@ -339,7 +345,6 @@ public final class DeadLetterQueueWriter implements Closeable {
         this.maxQueueSize = maxQueueSize;
         this.storageType = storageType;
         this.flushInterval = flushInterval;
-        this.flushCheckInterval = flushCheckInterval;
         this.currentQueueSize = new AtomicLong(computeQueueSize());
         this.retentionTime = retentionTime;
 
@@ -415,11 +420,6 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     public long getCurrentQueueSize() {
         return currentQueueSize.longValue();
-    }
-
-    @VisibleForTesting
-    public Duration flushCheckInterval() {
-        return flushCheckInterval;
     }
 
     public String getStoragePolicy() {

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -124,6 +124,8 @@ public final class DeadLetterQueueWriter implements Closeable {
         }
     }
 
+    static final Duration MIN_FLUSH_INTERVAL = Duration.ofMillis(1000);
+
     @VisibleForTesting
     static final String SEGMENT_FILE_PATTERN = "%d.log";
     private static final Logger logger = LogManager.getLogger(DeadLetterQueueWriter.class);
@@ -142,6 +144,7 @@ public final class DeadLetterQueueWriter implements Closeable {
     private volatile int currentSegmentIndex;
     private volatile Timestamp lastEntryTimestamp;
     private final Duration flushInterval;
+    private final Duration flushCheckInterval;
     private final AtomicBoolean open = new AtomicBoolean(true);
     private final LongAdder droppedEvents = new LongAdder();
     private final LongAdder expiredEvents = new LongAdder();
@@ -173,9 +176,12 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     private static class FixedRateScheduler implements SchedulerService {
 
+        private static final long MIN_CHECK_INTERVAL_MS = 1000L;
         private final ScheduledExecutorService scheduledExecutor;
+        private final long checkIntervalMs;
 
-        FixedRateScheduler() {
+        FixedRateScheduler(final Duration flushCheckInterval) {
+            this.checkIntervalMs = Math.max(flushCheckInterval.toMillis(), MIN_CHECK_INTERVAL_MS);
             scheduledExecutor = Executors.newScheduledThreadPool(1, r -> {
                 Thread t = new Thread(r);
                 //Allow this thread to die when the JVM dies
@@ -188,7 +194,7 @@ public final class DeadLetterQueueWriter implements Closeable {
 
         @Override
         public void repeatedAction(Runnable action) {
-            scheduledExecutor.scheduleAtFixedRate(action, 1L, 1L, TimeUnit.SECONDS);
+            scheduledExecutor.scheduleAtFixedRate(action, checkIntervalMs, checkIntervalMs, TimeUnit.MILLISECONDS);
         }
 
         @Override
@@ -218,6 +224,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         private boolean startScheduledFlusher;
         private QueueStorageType storageType = QueueStorageType.DROP_NEWER;
         private Duration retentionTime = null;
+        private Duration flushCheckInterval = Duration.ofMillis(1000);
         private Clock clock = Clock.systemDefaultZone();
         private SchedulerService customSchedulerService = null;
 
@@ -243,6 +250,11 @@ public final class DeadLetterQueueWriter implements Closeable {
             return this;
         }
 
+        public Builder flushCheckInterval(final Duration interval) {
+            this.flushCheckInterval = interval;
+            return this;
+        }
+
         @VisibleForTesting
         Builder clock(Clock clock) {
             this.clock = clock;
@@ -259,18 +271,33 @@ public final class DeadLetterQueueWriter implements Closeable {
             if (customSchedulerService != null && startScheduledFlusher) {
                 throw new IllegalArgumentException("Both default scheduler and custom scheduler were defined, ");
             }
+
+            Duration effectiveFlushInterval = flushInterval;
+            if (startScheduledFlusher && flushInterval.compareTo(MIN_FLUSH_INTERVAL) < 0) {
+                logger.warn("dead_letter_queue.flush_interval ({} ms) is below the minimum of {} ms; using {} ms",
+                        flushInterval.toMillis(), MIN_FLUSH_INTERVAL.toMillis(), MIN_FLUSH_INTERVAL.toMillis());
+                effectiveFlushInterval = MIN_FLUSH_INTERVAL;
+            }
+
+            Duration effectiveFlushCheckInterval = flushCheckInterval;
+            if (startScheduledFlusher && flushCheckInterval.compareTo(effectiveFlushInterval) > 0) {
+                logger.warn("dead_letter_queue.flush_check_interval ({} ms) cannot be greater than dead_letter_queue.flush_interval ({} ms); using {} ms",
+                        flushCheckInterval.toMillis(), effectiveFlushInterval.toMillis(), effectiveFlushInterval.toMillis());
+                effectiveFlushCheckInterval = effectiveFlushInterval;
+            }
+
             SchedulerService schedulerService;
             if (customSchedulerService != null) {
                 schedulerService = customSchedulerService;
             } else {
                 if (startScheduledFlusher) {
-                    schedulerService = new FixedRateScheduler();
+                    schedulerService = new FixedRateScheduler(effectiveFlushCheckInterval);
                 } else {
                     schedulerService = new NoopScheduler();
                 }
             }
 
-            return new DeadLetterQueueWriter(queuePath, maxSegmentSize, maxQueueSize, flushInterval, storageType, retentionTime, clock, schedulerService);
+            return new DeadLetterQueueWriter(queuePath, maxSegmentSize, maxQueueSize, effectiveFlushInterval, effectiveFlushCheckInterval, storageType, retentionTime, clock, schedulerService);
         }
     }
 
@@ -285,7 +312,7 @@ public final class DeadLetterQueueWriter implements Closeable {
     }
 
     private DeadLetterQueueWriter(final Path queuePath, final long maxSegmentSize, final long maxQueueSize,
-                                  final Duration flushInterval, final QueueStorageType storageType, final Duration retentionTime,
+                                  final Duration flushInterval, final Duration flushCheckInterval, final QueueStorageType storageType, final Duration retentionTime,
                                   final Clock clock, SchedulerService flusherService) throws IOException {
         this.clock = clock;
 
@@ -295,6 +322,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         this.maxQueueSize = maxQueueSize;
         this.storageType = storageType;
         this.flushInterval = flushInterval;
+        this.flushCheckInterval = flushCheckInterval;
         this.currentQueueSize = new AtomicLong(computeQueueSize());
         this.retentionTime = retentionTime;
 
@@ -370,6 +398,11 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     public long getCurrentQueueSize() {
         return currentQueueSize.longValue();
+    }
+
+    @VisibleForTesting
+    public Duration flushCheckInterval() {
+        return flushCheckInterval;
     }
 
     public String getStoragePolicy() {
@@ -645,6 +678,11 @@ public final class DeadLetterQueueWriter implements Closeable {
      */
     private static boolean alreadyProcessed(final Event event) {
         return event.includes(DEAD_LETTER_QUEUE_METADATA_KEY);
+    }
+
+    @VisibleForTesting
+    public void runScheduledFlushCheck() {
+        scheduledFlushCheck();
     }
 
     // main method for flush scheduler

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -124,7 +124,8 @@ public final class DeadLetterQueueWriter implements Closeable {
         }
     }
 
-    static final Duration MIN_FLUSH_INTERVAL = Duration.ofMillis(1000);
+    static final Duration MIN_FLUSH_PERIOD = Duration.ofMillis(1000);
+    static final Duration MIN_FLUSH_CHECK_INTERVAL = Duration.ofMillis(1000);
 
     @VisibleForTesting
     static final String SEGMENT_FILE_PATTERN = "%d.log";
@@ -176,18 +177,19 @@ public final class DeadLetterQueueWriter implements Closeable {
 
     private static class FixedRateScheduler implements SchedulerService {
 
-        private static final long MIN_CHECK_INTERVAL_MS = 1000L;
         private final ScheduledExecutorService scheduledExecutor;
         private final long checkIntervalMs;
 
-        FixedRateScheduler(final Duration flushCheckInterval) {
-            this.checkIntervalMs = Math.max(flushCheckInterval.toMillis(), MIN_CHECK_INTERVAL_MS);
+        FixedRateScheduler(final Duration flushCheckInterval, final String pipelineId) {
+            //Set the name with pipeline ID for better visibility
+            final String threadName = pipelineId != null ? "dlq-flush-check[" + pipelineId + "]" : "dlq-flush-check";
+            
+            this.checkIntervalMs = Math.max(flushCheckInterval.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis());
             scheduledExecutor = Executors.newScheduledThreadPool(1, r -> {
                 Thread t = new Thread(r);
                 //Allow this thread to die when the JVM dies
                 t.setDaemon(true);
-                //Set the name
-                t.setName("dlq-flush-check");
+                t.setName(threadName);
                 return t;
             });
         }
@@ -227,6 +229,7 @@ public final class DeadLetterQueueWriter implements Closeable {
         private Duration flushCheckInterval = Duration.ofMillis(1000);
         private Clock clock = Clock.systemDefaultZone();
         private SchedulerService customSchedulerService = null;
+        private String pipelineId;
 
         private Builder(Path queuePath, long maxSegmentSize, long maxQueueSize, Duration flushInterval) {
             this(queuePath, maxSegmentSize, maxQueueSize, flushInterval, true);
@@ -255,6 +258,11 @@ public final class DeadLetterQueueWriter implements Closeable {
             return this;
         }
 
+        public Builder pipelineId(final String pipelineId) {
+            this.pipelineId = pipelineId;
+            return this;
+        }
+
         @VisibleForTesting
         Builder clock(Clock clock) {
             this.clock = clock;
@@ -273,17 +281,25 @@ public final class DeadLetterQueueWriter implements Closeable {
             }
 
             Duration effectiveFlushInterval = flushInterval;
-            if (startScheduledFlusher && flushInterval.compareTo(MIN_FLUSH_INTERVAL) < 0) {
+            if (startScheduledFlusher && flushInterval.compareTo(MIN_FLUSH_PERIOD) < 0) {
                 logger.warn("dead_letter_queue.flush_interval ({} ms) is below the minimum of {} ms; using {} ms",
-                        flushInterval.toMillis(), MIN_FLUSH_INTERVAL.toMillis(), MIN_FLUSH_INTERVAL.toMillis());
-                effectiveFlushInterval = MIN_FLUSH_INTERVAL;
+                        flushInterval.toMillis(), MIN_FLUSH_PERIOD.toMillis(), MIN_FLUSH_PERIOD.toMillis());
+                effectiveFlushInterval = MIN_FLUSH_PERIOD;
             }
 
             Duration effectiveFlushCheckInterval = flushCheckInterval;
-            if (startScheduledFlusher && flushCheckInterval.compareTo(effectiveFlushInterval) > 0) {
-                logger.warn("dead_letter_queue.flush_check_interval ({} ms) cannot be greater than dead_letter_queue.flush_interval ({} ms); using {} ms",
-                        flushCheckInterval.toMillis(), effectiveFlushInterval.toMillis(), effectiveFlushInterval.toMillis());
-                effectiveFlushCheckInterval = effectiveFlushInterval;
+            if (startScheduledFlusher) {
+                // Clamp to maximum (can't exceed flush interval)
+                if (effectiveFlushCheckInterval.compareTo(effectiveFlushInterval) > 0) {
+                    logger.warn("dead_letter_queue.flush_check_interval ({} ms) cannot be greater than dead_letter_queue.flush_interval ({} ms); using {} ms",
+                            effectiveFlushCheckInterval.toMillis(), effectiveFlushInterval.toMillis(), effectiveFlushInterval.toMillis());
+                    effectiveFlushCheckInterval = effectiveFlushInterval;
+                }
+                // Clamp to minimum (for scheduler only, don't change stored value)
+                if (effectiveFlushCheckInterval.compareTo(MIN_FLUSH_CHECK_INTERVAL) < 0) {
+                    logger.warn("dead_letter_queue.flush_check_interval ({} ms) is below the minimum of {} ms; using {} ms for the scheduler",
+                            effectiveFlushCheckInterval.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis(), MIN_FLUSH_CHECK_INTERVAL.toMillis());
+                }
             }
 
             SchedulerService schedulerService;
@@ -291,7 +307,8 @@ public final class DeadLetterQueueWriter implements Closeable {
                 schedulerService = customSchedulerService;
             } else {
                 if (startScheduledFlusher) {
-                    schedulerService = new FixedRateScheduler(effectiveFlushCheckInterval);
+                    // Use clamped-to-max value for scheduler (which will further clamp to MIN in FixedRateScheduler)
+                    schedulerService = new FixedRateScheduler(effectiveFlushCheckInterval, pipelineId);
                 } else {
                     schedulerService = new NoopScheduler();
                 }

--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueWriter.java
@@ -697,11 +697,6 @@ public final class DeadLetterQueueWriter implements Closeable {
         return event.includes(DEAD_LETTER_QUEUE_METADATA_KEY);
     }
 
-    @VisibleForTesting
-    public void runScheduledFlushCheck() {
-        scheduledFlushCheck();
-    }
-
     // main method for flush scheduler
     private void scheduledFlushCheck() {
         logger.trace("Running scheduled check");

--- a/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/RecordIOWriter.java
@@ -173,7 +173,7 @@ public final class RecordIOWriter implements Closeable {
         return lastWrite != null;
     }
 
-    public boolean isStale(Duration flushPeriod){
+    public boolean isStale(final Duration flushPeriod) {
         return hasWritten() && Instant.now().minus(flushPeriod).isAfter(lastWrite);
     }
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -466,15 +466,16 @@ public class AbstractPipelineExt extends RubyBasicObject {
         String dlqPath = getSetting(context, "path.dead_letter_queue").asJavaString();
         long dlqMaxBytes = org.jruby.RubyNumeric.num2long(getSetting(context, "dead_letter_queue.max_bytes").convertToInteger());
         Duration dlqFlushInterval = Duration.ofMillis(org.jruby.RubyNumeric.num2long(getSetting(context, "dead_letter_queue.flush_interval").convertToInteger()));
+        Duration dlqFlushCheckInterval = Duration.ofMillis(org.jruby.RubyNumeric.num2long(getSetting(context, "dead_letter_queue.flush_check_interval").convertToInteger()));
 
         if (hasSetting(context, "dead_letter_queue.retain.age") && !getSetting(context, "dead_letter_queue.retain.age").isNil()) {
             // convert to Duration
             final Duration age = parseToDuration(getSetting(context, "dead_letter_queue.retain.age").convertToString().toString());
             return DeadLetterQueueFactory.getWriter(pipelineId.asJavaString(), dlqPath, dlqMaxBytes,
-                    dlqFlushInterval, storageType, age);
+                    dlqFlushInterval, dlqFlushCheckInterval, storageType, age);
         }
 
-        return DeadLetterQueueFactory.getWriter(pipelineId.asJavaString(), dlqPath, dlqMaxBytes, dlqFlushInterval, storageType);
+        return DeadLetterQueueFactory.getWriter(pipelineId.asJavaString(), dlqPath, dlqMaxBytes, dlqFlushInterval, dlqFlushCheckInterval, storageType);
     }
 
     /**

--- a/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/AbstractDeadLetterQueueWriterExtTest.java
@@ -60,7 +60,7 @@ public class AbstractDeadLetterQueueWriterExtTest extends RubyTestBase {
         RubyString id = RubyString.newString(RubyUtil.RUBY, pluginId);
         RubyString classConfigName = RubyString.newString(RubyUtil.RUBY, pluginType);
 
-        final DeadLetterQueueWriter javaDlqWriter = DeadLetterQueueFactory.getWriter(dlqName, dlqPath.toString(), 1024 * 1024, Duration.ofHours(1), QueueStorageType.DROP_NEWER);
+        final DeadLetterQueueWriter javaDlqWriter = DeadLetterQueueFactory.getWriter(dlqName, dlqPath.toString(), 1024 * 1024, Duration.ofHours(1), Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
         IRubyObject dlqWriter = JavaUtil.convertJavaToUsableRubyObject(context.runtime, javaDlqWriter);
 
         final AbstractDeadLetterQueueWriterExt dlqWriterForInstance = new AbstractDeadLetterQueueWriterExt.PluginDeadLetterQueueWriterExt(

--- a/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/DeadLetterQueueFactoryTest.java
@@ -69,9 +69,9 @@ public class DeadLetterQueueFactoryTest {
     public void testSameBeforeRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
             assertTrue(writer.isOpen());
-            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
+            DeadLetterQueueWriter writer2 = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
             assertSame(writer, writer2);
             writer.close();
         } finally {
@@ -83,11 +83,11 @@ public class DeadLetterQueueFactoryTest {
     public void testOpenableAfterRelease() throws IOException {
         try {
             Path pipelineA = dir.resolve(PIPELINE_NAME);
-            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
+            DeadLetterQueueWriter writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
             assertTrue(writer.isOpen());
             writer.close();
             DeadLetterQueueFactory.release(PIPELINE_NAME);
-            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
+            writer = DeadLetterQueueFactory.getWriter(PIPELINE_NAME, pipelineA.toString(), 10000, Duration.ofSeconds(1), Duration.ofSeconds(1), QueueStorageType.DROP_NEWER);
             assertTrue(writer.isOpen());
             writer.close();
         }finally{

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueReaderTest.java
@@ -157,7 +157,7 @@ public class DeadLetterQueueReaderTest {
         long startTime = System.currentTimeMillis();
         int messageSize = 0;
         try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", String.valueOf(i), constantSerializationLengthTimestamp(startTime++));
@@ -214,7 +214,7 @@ public class DeadLetterQueueReaderTest {
         DLQEntry templateEntry = new DLQEntry(event, "1", "1", String.valueOf(0), constantSerializationLengthTimestamp(startTime));
         int size = templateEntry.serialize().length + RecordIOWriter.RECORD_HEADER_SIZE + VERSION_SIZE;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, size, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, size, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 1; i <= count; i++) {
                 writeManager.writeEntry(new DLQEntry(event, "1", "1", String.valueOf(i), constantSerializationLengthTimestamp(startTime++)));
@@ -248,7 +248,7 @@ public class DeadLetterQueueReaderTest {
         Timestamp timestamp = constantSerializationLengthTimestamp();
 
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", timestamp);
@@ -273,7 +273,7 @@ public class DeadLetterQueueReaderTest {
         long startTime = System.currentTimeMillis();
         int messageSize = 0;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 1; i <= 5; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", constantSerializationLengthTimestamp(startTime++));
@@ -298,7 +298,7 @@ public class DeadLetterQueueReaderTest {
         Timestamp timestamp = new Timestamp();
 
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < 6; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
@@ -320,7 +320,7 @@ public class DeadLetterQueueReaderTest {
         event.setField("T", generateMessageContent(PAD_FOR_BLOCK_SIZE_EVENT));
         Timestamp timestamp = new Timestamp();
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE * EVENTS_BEFORE_FLUSH, defaultDlqSize, Duration.ofHours(1))
+                .newBuilder(dir, BLOCK_SIZE * EVENTS_BEFORE_FLUSH, defaultDlqSize, Duration.ofHours(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 1; i < EVENTS_BEFORE_FLUSH; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
@@ -355,7 +355,7 @@ public class DeadLetterQueueReaderTest {
         Timestamp timestamp = new Timestamp();
 
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE * eventsInSegment, defaultDlqSize, Duration.ofHours(1))
+                .newBuilder(dir, BLOCK_SIZE * eventsInSegment, defaultDlqSize, Duration.ofHours(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 1; i < totalEventsToWrite; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
@@ -398,7 +398,7 @@ public class DeadLetterQueueReaderTest {
         System.out.println("events per block= " + eventsPerBlock);
 
         try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(2))
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(2), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 1; i < eventsToWrite; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", Integer.toString(i), timestamp);
@@ -432,7 +432,7 @@ public class DeadLetterQueueReaderTest {
         Timestamp timestamp = constantSerializationLengthTimestamp();
 
         try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, BLOCK_SIZE, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < 2; i++) {
                 DLQEntry entry = new DLQEntry(event, "", "", "", timestamp);
@@ -455,7 +455,7 @@ public class DeadLetterQueueReaderTest {
         long startTime = System.currentTimeMillis();
 
         try(DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < eventCount; i++) {
                 event.setField("message", generateMessageContent((int)(Math.random() * (maxEventSize))));
@@ -575,7 +575,7 @@ public class DeadLetterQueueReaderTest {
                 final Event event = new Event();
                 long startTime = System.currentTimeMillis();
                 try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                        .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(10))
+                        .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(10), Duration.ofSeconds(1))
                         .build()) {
                     for (int i = 0; i < eventCount; i++) {
                         event.setField(
@@ -920,7 +920,7 @@ public class DeadLetterQueueReaderTest {
 
     private void writeEntries(final Event event, int offset, final int numberOfEvents, long startTime) throws IOException {
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * 1024 * 1024, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             for (int i = offset; i <= offset + numberOfEvents; i++) {
                 DLQEntry entry = new DLQEntry(event, "foo", "bar", String.valueOf(i), new Timestamp(startTime++));
@@ -943,7 +943,7 @@ public class DeadLetterQueueReaderTest {
         final int maxSegmentSize = 10 * MB;
         final int loopPerSegment = (int) Math.floor((maxSegmentSize - 1.0) / BLOCK_SIZE);
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, maxSegmentSize, defaultDlqSize, Duration.ofSeconds(1))
+                .newBuilder(dir, maxSegmentSize, defaultDlqSize, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             final int loops = loopPerSegment * segments;
             for (int i = 0; i < loops; i++) {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -66,11 +66,19 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
     private SynchronizedScheduledService synchScheduler;
 
+    private static final long MAX_SEGMENT_SIZE = 10 * MB;
+    private static final long MAX_QUEUE_SIZE = 1 * GB;
+
     @Before
     public void setUp() throws Exception {
         dir = temporaryFolder.newFolder().toPath();
         fakeClock = new ManualAdvanceClock(Instant.parse("2022-02-22T10:20:30.00Z"), ZoneId.of("Europe/Rome"));
         synchScheduler = new SynchronizedScheduledService();
+    }
+
+    private static DeadLetterQueueWriter.Builder newBuilder(final Path queuePath) {
+        return DeadLetterQueueWriter
+                .newBuilder(queuePath, MAX_SEGMENT_SIZE, MAX_QUEUE_SIZE, Duration.ofSeconds(1), Duration.ofSeconds(1));
     }
 
     @Test
@@ -85,8 +93,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         // Exercise
         final long prevQueueSize;
         final long beheadedQueueSize;
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir)
                 .retentionTime(Duration.ofDays(2))
                 .clock(fakeClock)
                 .build()) {
@@ -109,8 +116,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final Duration littleMoreThanRetainedPeriod = retainedPeriod.plusMinutes(1);
         long startTime = fakeClock.instant().minus(littleMoreThanRetainedPeriod).toEpochMilli();
         int messageSize = 0;
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {
@@ -136,8 +142,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         int messageSize = 0;
 
         final Duration retention = Duration.ofDays(2);
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir)
                 .retentionTime(retention)
                 .clock(fakeClock)
                 .build()) {
@@ -179,8 +184,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         int messageSize = 0;
 
         final Duration retention = Duration.ofDays(2);
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir)
                 .retentionTime(retention)
                 .clock(fakeClock)
                 .build()) {
@@ -272,8 +276,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final ManualAdvanceClock fakeClock = new ManualAdvanceClock(ZoneId.of("Europe/Rome"));
 
         Duration retainedPeriod = Duration.ofDays(1);
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir)
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterAgeRetentionTest.java
@@ -86,7 +86,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final long prevQueueSize;
         final long beheadedQueueSize;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .retentionTime(Duration.ofDays(2))
                 .clock(fakeClock)
                 .build()) {
@@ -110,7 +110,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         long startTime = fakeClock.instant().minus(littleMoreThanRetainedPeriod).toEpochMilli();
         int messageSize = 0;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {
@@ -137,7 +137,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
         final Duration retention = Duration.ofDays(2);
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .retentionTime(retention)
                 .clock(fakeClock)
                 .build()) {
@@ -180,7 +180,7 @@ public class DeadLetterQueueWriterAgeRetentionTest {
 
         final Duration retention = Duration.ofDays(2);
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .retentionTime(retention)
                 .clock(fakeClock)
                 .build()) {
@@ -272,9 +272,8 @@ public class DeadLetterQueueWriterAgeRetentionTest {
         final ManualAdvanceClock fakeClock = new ManualAdvanceClock(ZoneId.of("Europe/Rome"));
 
         Duration retainedPeriod = Duration.ofDays(1);
-        Duration flushInterval = Duration.ofSeconds(1);
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 1 * GB, flushInterval)
+                .newBuilder(dir, 10 * MB, 1 * GB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .retentionTime(retainedPeriod)
                 .clock(fakeClock)
                 .build()) {

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -72,11 +72,26 @@ public class DeadLetterQueueWriterTest {
 
     private static long EMPTY_DLQ = VERSION_SIZE; // Only the version field has been written
 
+    private static final long DEFAULT_MAX_SEGMENT_SIZE = 1_000;
+    private static final long DEFAULT_MAX_QUEUE_SIZE = 100_000;
+
+    private static DeadLetterQueueWriter.Builder newBuilder(final Path queuePath) {
+        return newBuilder(queuePath, DEFAULT_MAX_SEGMENT_SIZE, DEFAULT_MAX_QUEUE_SIZE);
+    }
+
+    private static DeadLetterQueueWriter.Builder newBuilder(final Path queuePath, final long maxSegmentSize, final long maxQueueSize) {
+        return newBuilder(queuePath, maxSegmentSize, maxQueueSize, Duration.ofSeconds(1));
+    }
+
+    private static DeadLetterQueueWriter.Builder newBuilder(final Path queuePath, final long maxSegmentSize, final long maxQueueSize, final Duration flushInterval) {
+        return DeadLetterQueueWriter
+                .newBuilder(queuePath, maxSegmentSize, maxQueueSize, flushInterval, Duration.ofSeconds(1));
+    }
+
     @Test
     public void testLockFileManagement() throws Exception {
         Path lockFile = dir.resolve(".lock");
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        DeadLetterQueueWriter writer = newBuilder(dir)
                 .build();
         assertTrue(Files.exists(lockFile));
         writer.close();
@@ -85,12 +100,10 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testFileLocking() throws Exception {
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        DeadLetterQueueWriter writer = newBuilder(dir)
                 .build();
         try {
-            DeadLetterQueueWriter
-                    .newBuilder(dir, 100, 1_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+            newBuilder(dir, 100, 1_000)
                     .build();
             fail();
         } catch (LockException e) {
@@ -103,8 +116,7 @@ public class DeadLetterQueueWriterTest {
     public void testUncleanCloseOfPreviousWriter() throws Exception {
         Path lockFilePath = dir.resolve(".lock");
         boolean created = lockFilePath.toFile().createNewFile();
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        DeadLetterQueueWriter writer = newBuilder(dir)
                 .build();
 
         FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
@@ -120,8 +132,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testWrite() throws Exception {
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        DeadLetterQueueWriter writer = newBuilder(dir)
                 .build();
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         writer.writeEntry(entry);
@@ -135,8 +146,7 @@ public class DeadLetterQueueWriterTest {
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         DLQEntry dlqEntry = new DLQEntry(dlqEvent, "type", "id", "reason");
 
-        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writer = newBuilder(dir)
                 .build()) {
             writer.writeEntry(entry);
             long dlqLengthAfterEvent = dlqLength();
@@ -156,8 +166,7 @@ public class DeadLetterQueueWriterTest {
         long MAX_QUEUE_LENGTH = payloadLength * MESSAGE_COUNT;
 
 
-        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, payloadLength, MAX_QUEUE_LENGTH, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writer = newBuilder(dir, payloadLength, MAX_QUEUE_LENGTH)
                 .build()) {
 
             for (int i = 0; i < MESSAGE_COUNT; i++)
@@ -174,8 +183,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testSlowFlush() throws Exception {
-        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 1_000_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writer = newBuilder(dir, 1_000, 1_000_000)
                 .build()) {
             DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
             writer.writeEntry(entry);
@@ -196,8 +204,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testNotFlushed() throws Exception {
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE, 1_000_000_000, Duration.ofSeconds(5), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir, BLOCK_SIZE, 1_000_000_000, Duration.ofSeconds(5))
                 .build()) {
             for (int i = 0; i < 4; i++) {
                 DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
@@ -219,8 +226,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testCloseFlush() throws Exception {
-        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 1_000_000, Duration.ofHours(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writer = newBuilder(dir, 1_000, 1_000_000, Duration.ofHours(1))
                 .build()) {
             DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
             writer.writeEntry(entry);
@@ -255,8 +261,7 @@ public class DeadLetterQueueWriterTest {
         long startTime = System.currentTimeMillis();
 
         int messageSize = 0;
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir, 10 * MB, 20 * MB)
                 .build()) {
 
             // 320 generates 10 Mb of data
@@ -287,8 +292,7 @@ public class DeadLetterQueueWriterTest {
         final long prevQueueSize;
         final long beheadedQueueSize;
         long droppedEvent;
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir, 10 * MB, 20 * MB)
                 .storageType(QueueStorageType.DROP_OLDER)
                 .build()) {
             prevQueueSize = writeManager.getCurrentQueueSize();
@@ -325,8 +329,7 @@ public class DeadLetterQueueWriterTest {
 
     @Test
     public void testRemoveSegmentsOrder() throws IOException {
-        try (DeadLetterQueueWriter sut = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter sut = newBuilder(dir, 10 * MB, 20 * MB)
                 .build()) {
             // create some segments files
             Files.createFile(dir.resolve("9.log"));
@@ -495,8 +498,7 @@ public class DeadLetterQueueWriterTest {
         Event bigEvent = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         bigEvent.setField("message", DeadLetterQueueReaderTest.generateMessageContent(2 * BLOCK_SIZE));
 
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir, 10 * MB, 20 * MB)
                 .build()) {
             // enqueue a record with size smaller than BLOCK_SIZE
             DLQEntry entry = new DLQEntry(blockAlmostFullEvent, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
@@ -513,8 +515,7 @@ public class DeadLetterQueueWriterTest {
         // fill the queue to push out the segment with the 2 previous events
         Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
-        try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writeManager = newBuilder(dir, 10 * MB, 20 * MB)
                 .storageType(QueueStorageType.DROP_NEWER)
                 .build()) {
 
@@ -543,16 +544,14 @@ public class DeadLetterQueueWriterTest {
     public void testInitializeWriterWith1ByteEntry() throws Exception {
         Files.write(dir.resolve("1.log"), "1".getBytes());
 
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        DeadLetterQueueWriter writer = newBuilder(dir)
                 .build();
         writer.close();
     }
 
     @Test
     public void givenDLQWriterCreatedSomeSegmentsWhenReaderWithCleanConsumedNotifyTheDeletionOfSomeThenWriterUpdatesItsMetricsSize() throws IOException, InterruptedException {
-        try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1 * MB, 100 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
+        try (DeadLetterQueueWriter writer = newBuilder(dir, 1 * MB, 100 * MB)
                 .build()) {
 
             // fill at least 3 segments
@@ -617,22 +616,22 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void givenFlushIntervalGreatherThanMinimumWhenNormalizedThenRemainsUnmodified() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+    public void givenFlushIntervalGreaterThanMinimumWhenNormalizedThenRemainsUnmodified() {
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration result = builder.normalizeFlushInterval(Duration.ofSeconds(10));
         assertEquals("Valid flush interval should remain unchanged", Duration.ofSeconds(10), result);
     }
 
     @Test
     public void givenFlushIntervalBelowTheMinimumWhenNormalizedThenIsClampedToMinimum() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration result = builder.normalizeFlushInterval(Duration.ofMillis(100));
         assertEquals("Flush interval below 1s should be clamped to 1s", Duration.ofSeconds(1), result);
     }
 
     @Test
     public void testNormalizeFlushCheckIntervalWithinLimits() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration flushInterval = Duration.ofSeconds(5);
         Duration flushCheckInterval = Duration.ofSeconds(2);
         Duration result = builder.normalizeFlushCheckInterval(flushCheckInterval, flushInterval);
@@ -640,8 +639,8 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void testNormalizeFlushCheckIntervalBelowMinimum() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+    public void givenFlushCheckIntervalBelowMinimumWhenNormalizedThenClampedToMinimum() {
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration flushInterval = Duration.ofSeconds(5);
         Duration belowMinimum = Duration.ofMillis(500);
         Duration result = builder.normalizeFlushCheckInterval(belowMinimum, flushInterval);
@@ -649,8 +648,8 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void testNormalizeFlushCheckIntervalExceedsFlushInterval() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+    public void givenFlushCheckIntervalExceedsFlushIntervalWhenNormalizedThenClampedToFlushInterval() {
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration flushInterval = Duration.ofSeconds(3);
         Duration aboveFlushInterval = Duration.ofSeconds(5);
         Duration result = builder.normalizeFlushCheckInterval(aboveFlushInterval, flushInterval);
@@ -658,8 +657,8 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void testNormalizeFlushCheckIntervalJustBelowFlushInterval() {
-        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+    public void givenFlushCheckIntervalJustBelowFlushIntervalWhenNormalizedThenAccepted() {
+        DeadLetterQueueWriter.Builder builder = newBuilder(dir);
         Duration flushInterval = Duration.ofSeconds(5);
         Duration justBelowFlushInterval = Duration.ofMillis(4900);
         Duration result = builder.normalizeFlushCheckInterval(justBelowFlushInterval, flushInterval);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -617,14 +617,14 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void testNormalizeFlushIntervalWithValidInterval() {
+    public void givenFlushIntervalGreatherThanMinimumWhenNormalizedThenRemainsUnmodified() {
         DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
         Duration result = builder.normalizeFlushInterval(Duration.ofSeconds(10));
         assertEquals("Valid flush interval should remain unchanged", Duration.ofSeconds(10), result);
     }
 
     @Test
-    public void testNormalizeFlushIntervalBelowMinimum() {
+    public void givenFlushIntervalBelowTheMinimumWhenNormalizedThenIsClampedToMinimum() {
         DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
         Duration result = builder.normalizeFlushInterval(Duration.ofMillis(100));
         assertEquals("Flush interval below 1s should be clamped to 1s", Duration.ofSeconds(1), result);

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -76,7 +76,7 @@ public class DeadLetterQueueWriterTest {
     public void testLockFileManagement() throws Exception {
         Path lockFile = dir.resolve(".lock");
         DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build();
         assertTrue(Files.exists(lockFile));
         writer.close();
@@ -86,11 +86,11 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testFileLocking() throws Exception {
         DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build();
         try {
             DeadLetterQueueWriter
-                    .newBuilder(dir, 100, 1_000, Duration.ofSeconds(1))
+                    .newBuilder(dir, 100, 1_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                     .build();
             fail();
         } catch (LockException e) {
@@ -104,7 +104,7 @@ public class DeadLetterQueueWriterTest {
         Path lockFilePath = dir.resolve(".lock");
         boolean created = lockFilePath.toFile().createNewFile();
         DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build();
 
         FileChannel channel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE);
@@ -121,7 +121,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testWrite() throws Exception {
         DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build();
         DLQEntry entry = new DLQEntry(new Event(), "type", "id", "reason");
         writer.writeEntry(entry);
@@ -136,7 +136,7 @@ public class DeadLetterQueueWriterTest {
         DLQEntry dlqEntry = new DLQEntry(dlqEvent, "type", "id", "reason");
 
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             writer.writeEntry(entry);
             long dlqLengthAfterEvent = dlqLength();
@@ -157,7 +157,7 @@ public class DeadLetterQueueWriterTest {
 
 
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, payloadLength, MAX_QUEUE_LENGTH, Duration.ofSeconds(1))
+                .newBuilder(dir, payloadLength, MAX_QUEUE_LENGTH, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
 
             for (int i = 0; i < MESSAGE_COUNT; i++)
@@ -175,7 +175,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testSlowFlush() throws Exception {
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 1_000_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 1_000_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
             writer.writeEntry(entry);
@@ -197,7 +197,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testNotFlushed() throws Exception {
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, BLOCK_SIZE, 1_000_000_000, Duration.ofSeconds(5))
+                .newBuilder(dir, BLOCK_SIZE, 1_000_000_000, Duration.ofSeconds(5), Duration.ofSeconds(1))
                 .build()) {
             for (int i = 0; i < 4; i++) {
                 DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
@@ -220,7 +220,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testCloseFlush() throws Exception {
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 1_000_000, Duration.ofHours(1))
+                .newBuilder(dir, 1_000, 1_000_000, Duration.ofHours(1), Duration.ofSeconds(1))
                 .build()) {
             DLQEntry entry = new DLQEntry(new Event(), "type", "id", "1");
             writer.writeEntry(entry);
@@ -256,7 +256,7 @@ public class DeadLetterQueueWriterTest {
 
         int messageSize = 0;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
 
             // 320 generates 10 Mb of data
@@ -288,7 +288,7 @@ public class DeadLetterQueueWriterTest {
         final long beheadedQueueSize;
         long droppedEvent;
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .storageType(QueueStorageType.DROP_OLDER)
                 .build()) {
             prevQueueSize = writeManager.getCurrentQueueSize();
@@ -326,7 +326,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void testRemoveSegmentsOrder() throws IOException {
         try (DeadLetterQueueWriter sut = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             // create some segments files
             Files.createFile(dir.resolve("9.log"));
@@ -496,7 +496,7 @@ public class DeadLetterQueueWriterTest {
         bigEvent.setField("message", DeadLetterQueueReaderTest.generateMessageContent(2 * BLOCK_SIZE));
 
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
             // enqueue a record with size smaller than BLOCK_SIZE
             DLQEntry entry = new DLQEntry(blockAlmostFullEvent, "", "", "00001", DeadLetterQueueReaderTest.constantSerializationLengthTimestamp(System.currentTimeMillis()));
@@ -514,7 +514,7 @@ public class DeadLetterQueueWriterTest {
         Event event = DeadLetterQueueReaderTest.createEventWithConstantSerializationOverhead(Collections.emptyMap());
         event.setField("message", DeadLetterQueueReaderTest.generateMessageContent(32500));
         try (DeadLetterQueueWriter writeManager = DeadLetterQueueWriter
-                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 10 * MB, 20 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .storageType(QueueStorageType.DROP_NEWER)
                 .build()) {
 
@@ -544,7 +544,7 @@ public class DeadLetterQueueWriterTest {
         Files.write(dir.resolve("1.log"), "1".getBytes());
 
         DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1))
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build();
         writer.close();
     }
@@ -552,7 +552,7 @@ public class DeadLetterQueueWriterTest {
     @Test
     public void givenDLQWriterCreatedSomeSegmentsWhenReaderWithCleanConsumedNotifyTheDeletionOfSomeThenWriterUpdatesItsMetricsSize() throws IOException, InterruptedException {
         try (DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1 * MB, 100 * MB, Duration.ofSeconds(1))
+                .newBuilder(dir, 1 * MB, 100 * MB, Duration.ofSeconds(1), Duration.ofSeconds(1))
                 .build()) {
 
             // fill at least 3 segments
@@ -617,48 +617,52 @@ public class DeadLetterQueueWriterTest {
     }
 
     @Test
-    public void testFlushCheckIntervalIsRespected() throws IOException {
-        final Duration flushCheckInterval = Duration.ofMillis(500);
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5))
-                .flushCheckInterval(flushCheckInterval)
-                .build();
-
-        assertEquals("flushCheckInterval should be applied to the writer", flushCheckInterval.toMillis(),
-                writer.flushCheckInterval().toMillis());
-
-        writer.close();
+    public void testNormalizeFlushIntervalWithValidInterval() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration result = builder.normalizeFlushInterval(Duration.ofSeconds(10));
+        assertEquals("Valid flush interval should remain unchanged", Duration.ofSeconds(10), result);
     }
 
     @Test
-    public void testFlushCheckIntervalClampedToMinimum() throws IOException {
-        final Duration belowMinimum = Duration.ofMillis(500);
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5))
-                .flushCheckInterval(belowMinimum)
-                .build();
-
-        // The writer stores the configured value as-is; the scheduler enforces a minimum of 1000ms internally
-        assertEquals("flushCheckInterval should be stored as configured", 
-                belowMinimum.toMillis(), writer.flushCheckInterval().toMillis());
-
-        writer.close();
+    public void testNormalizeFlushIntervalBelowMinimum() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration result = builder.normalizeFlushInterval(Duration.ofMillis(100));
+        assertEquals("Flush interval below 1s should be clamped to 1s", Duration.ofSeconds(1), result);
     }
 
     @Test
-    public void testFlushCheckIntervalClampedToFlushInterval() throws IOException {
-        final Duration flushInterval = Duration.ofSeconds(3);
-        final Duration aboveFlushInterval = Duration.ofSeconds(5);
-        DeadLetterQueueWriter writer = DeadLetterQueueWriter
-                .newBuilder(dir, 1_000, 100_000, flushInterval)
-                .flushCheckInterval(aboveFlushInterval)
-                .build();
-
-        // The writer should clamp flushCheckInterval to not exceed flushInterval
-        assertTrue("flushCheckInterval should not exceed flushInterval",
-                writer.flushCheckInterval().compareTo(flushInterval) <= 0);
-
-        writer.close();
+    public void testNormalizeFlushCheckIntervalWithinLimits() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration flushInterval = Duration.ofSeconds(5);
+        Duration flushCheckInterval = Duration.ofSeconds(2);
+        Duration result = builder.normalizeFlushCheckInterval(flushCheckInterval, flushInterval);
+        assertEquals("Valid flush check interval should remain unchanged", flushCheckInterval, result);
     }
 
+    @Test
+    public void testNormalizeFlushCheckIntervalBelowMinimum() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration flushInterval = Duration.ofSeconds(5);
+        Duration belowMinimum = Duration.ofMillis(500);
+        Duration result = builder.normalizeFlushCheckInterval(belowMinimum, flushInterval);
+        assertEquals("Flush check interval below 1s should be clamped to 1s", Duration.ofSeconds(1), result);
+    }
+
+    @Test
+    public void testNormalizeFlushCheckIntervalExceedsFlushInterval() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration flushInterval = Duration.ofSeconds(3);
+        Duration aboveFlushInterval = Duration.ofSeconds(5);
+        Duration result = builder.normalizeFlushCheckInterval(aboveFlushInterval, flushInterval);
+        assertEquals("Flush check interval exceeding flush interval should be clamped to flush interval", flushInterval, result);
+    }
+
+    @Test
+    public void testNormalizeFlushCheckIntervalJustBelowFlushInterval() {
+        DeadLetterQueueWriter.Builder builder = DeadLetterQueueWriter.newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        Duration flushInterval = Duration.ofSeconds(5);
+        Duration justBelowFlushInterval = Duration.ofMillis(4900);
+        Duration result = builder.normalizeFlushCheckInterval(justBelowFlushInterval, flushInterval);
+        assertEquals("Flush check interval just below flush interval should be accepted", justBelowFlushInterval, result);
+    }
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -616,4 +616,49 @@ public class DeadLetterQueueWriterTest {
         }
     }
 
+    @Test
+    public void testFlushCheckIntervalIsRespected() throws IOException {
+        final Duration flushCheckInterval = Duration.ofMillis(500);
+        DeadLetterQueueWriter writer = DeadLetterQueueWriter
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5))
+                .flushCheckInterval(flushCheckInterval)
+                .build();
+
+        assertEquals("flushCheckInterval should be applied to the writer", flushCheckInterval.toMillis(),
+                writer.flushCheckInterval().toMillis());
+
+        writer.close();
+    }
+
+    @Test
+    public void testFlushCheckIntervalClampedToMinimum() throws IOException {
+        final Duration belowMinimum = Duration.ofMillis(500);
+        DeadLetterQueueWriter writer = DeadLetterQueueWriter
+                .newBuilder(dir, 1_000, 100_000, Duration.ofSeconds(5))
+                .flushCheckInterval(belowMinimum)
+                .build();
+
+        // The writer should enforce a minimum of 1000ms in the scheduler
+        assertTrue("flushCheckInterval below 1000ms should be clamped to 1000ms",
+                writer.flushCheckInterval().toMillis() >= 1000);
+
+        writer.close();
+    }
+
+    @Test
+    public void testFlushCheckIntervalClampedToFlushInterval() throws IOException {
+        final Duration flushInterval = Duration.ofSeconds(3);
+        final Duration aboveFlushInterval = Duration.ofSeconds(5);
+        DeadLetterQueueWriter writer = DeadLetterQueueWriter
+                .newBuilder(dir, 1_000, 100_000, flushInterval)
+                .flushCheckInterval(aboveFlushInterval)
+                .build();
+
+        // The writer should clamp flushCheckInterval to not exceed flushInterval
+        assertTrue("flushCheckInterval should not exceed flushInterval",
+                writer.flushCheckInterval().compareTo(flushInterval) <= 0);
+
+        writer.close();
+    }
+
 }

--- a/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/io/DeadLetterQueueWriterTest.java
@@ -638,9 +638,9 @@ public class DeadLetterQueueWriterTest {
                 .flushCheckInterval(belowMinimum)
                 .build();
 
-        // The writer should enforce a minimum of 1000ms in the scheduler
-        assertTrue("flushCheckInterval below 1000ms should be clamped to 1000ms",
-                writer.flushCheckInterval().toMillis() >= 1000);
+        // The writer stores the configured value as-is; the scheduler enforces a minimum of 1000ms internally
+        assertEquals("flushCheckInterval should be stored as configured", 
+                belowMinimum.toMillis(), writer.flushCheckInterval().toMillis());
 
         writer.close();
     }


### PR DESCRIPTION
## Release notes
Introduces new `dead_letter_queue.flush_check_interval` config for flushing the staled segment files scheduler which can reduce frequent check overhead.

## What does this PR do?
1. Introduces a new configurable `dead_letter_queue.flush_check_interval` param  for the segment file stale check scheduler. See the problem description - https://github.com/elastic/logstash/issues/19037
- it cannot be less than 1sec 
- it cannot be greater than `dead_letter_queue.flush_interval`
2. Validates `dead_letter_queue.flush_interval` for min 1s to keep consistency with the docs - https://www.elastic.co/docs/reference/logstash/dead-letter-queues: "Note that this value cannot be set to lower than 1000ms."

### High level results
5-pipelines runs with 1-worker (to get comparable output), their configurations:
- pipeline-1: default, `flush_interval: 5000` and `flush_check_interval: 1000`
- pipeline-2: default, `flush_interval: 5000` and `flush_check_interval: 2000`
- pipeline-3: default, `flush_interval: 5000` and `flush_check_interval: 5000`
- pipeline-4: default, `flush_interval: 10000` and `flush_check_interval: 5000`
- pipeline-5: default, `flush_interval: 10000` and `flush_check_interval: 7000`

Following is the result table which shows the efficiency:


| Configuration | Flush Interval | Check Schedule Interval | CPU time | Total CPU/min |
|---|---|---|---|---|
| **Pipeline 1 (baseline)** | 5s | 1s | ~50.67ms | ~3,040ms (5.1%) |
| **Pipeline 2** | 5s | 2s | ~50.67ms | ~1,520ms (2.5%) |
| **Pipeline 3** | 5s | 5s | ~50.67ms | ~608ms (1.0%) |
| **Pipeline 4** | 10s | 5s | ~50.67ms | ~608ms (1.0%) |
| **Pipeline 5** | 10s | 7s | ~50.67ms | ~434ms (0.7%) |


## Why is it important/What is the impact to the user?
The users who are using intensive DLQ operations (write/read), the frequent flush check scheduler might give overhead to the pipeline, means uses much CPU. Introducing configurable scheduler cadence improves the pipeline efficiency by removing frequent operations.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally
- pull this change
- create multiple pipelines with different `flush_interval` and `flush_check_interval` params, below is the example.
- run the Logstash

```
- pipeline.id: dlq-test-pipeline-1
  pipeline.workers: 1
  dead_letter_queue.enable: true
  dead_letter_queue.flush_interval: 5000
  dead_letter_queue.flush_check_interval: 1000
  dead_letter_queue.max_bytes: 14mb
  path.config: "config/tests/elasticsearch-output.conf"

- pipeline.id: dlq-test-pipeline-2
  pipeline.workers: 1
  dead_letter_queue.enable: true
  dead_letter_queue.flush_interval: 5000
  dead_letter_queue.flush_check_interval: 2000
  dead_letter_queue.max_bytes: 24mb
  path.config: "config/tests/elasticsearch-output.conf"

- pipeline.id: dlq-test-pipeline-3
  pipeline.workers: 1
  dead_letter_queue.enable: true
  dead_letter_queue.flush_interval: 5000
  dead_letter_queue.flush_check_interval: 5000
  dead_letter_queue.max_bytes: 24mb
  path.config: "config/tests/elasticsearch-output.conf"

- pipeline.id: dlq-test-pipeline-4
  pipeline.workers: 1
  dead_letter_queue.enable: true
  dead_letter_queue.flush_interval: 10000
  dead_letter_queue.flush_check_interval: 5000
  dead_letter_queue.max_bytes: 24mb
  path.config: "config/tests/elasticsearch-output.conf"

- pipeline.id: dlq-test-pipeline-5
  pipeline.workers: 1
  dead_letter_queue.enable: true
  dead_letter_queue.flush_interval: 10000
  dead_letter_queue.flush_check_interval: 7000
  dead_letter_queue.max_bytes: 24mb
  path.config: "config/tests/elasticsearch-output.conf"
```

ES configured in `config/tests/elasticsearch-output.conf` needs to reject events either 400 or 404 to be routed to the DLQ. Used the following config:
```
input {
  generator {
    id => "generator-id"
    ecs_compatibility => disabled
    count => 30000000
    threads => 2
    codec => json
    lines => [
	'{"fileset":{"module":"system","name":"auth"},"system":{"auth":{"timestamp":"May 17 05:17:00","ssh":{"source":{"ip":"123.123.123.123"}}}},"event":{"module":"cisco","data":{"User-Name":"mashhur"}},"client":{"ip":"123.123.123.123"},"DstIP":"123.123.123.123","SrcIP":"123.123.123.123","orginalClientSrcIP":"123.123.123.123","destination":{"ip":"123.123.123.123"},"source":{"ip":"123.123.123.123"},"ReferencedHost":"ip-192-168-1-2","DNSQuery":"example.com/my-path?query=value"}',
'{"fileset":{"module":"system","name":"syslog"},"system":{"auth":{"timestamp":"May 17  05:17:00","ssh":{"source":{"ip":"123.123.123.123"}}}},"event":{"module":"cisco","data":{"User-Name":"mashhur"}},"client":{"ip":"123.123.123.123"},"DstIP":"123.123.123.123","SrcIP":"123.123.123.123","orginalClientSrcIP":"123.123.123.123","destination":{"ip":"123.123.123.123"},"source":{"ip":"123.123.123.123"},"ReferencedHost":"ip-192-168-1-2","DNSQuery":"example.com/my-path?query=value"}',
'{"fileset":{"module":"system","name":"asa"},"system":{"auth":{"timestamp":"May 17  05:17:00","ssh":{"source":{"ip":"123.123.123.123"}}}},"event":{"category":"cisco-category", "type":"cisco-type", "data":{"User-Name":"mashhur"}},"client":{"ar_net":"123.123.123.123", "ongisac_ip":"123.123.123.123", "ip":"123.123.123.123"}, "destination": {"ar_net":"123.123.123.123", "ongisac_ip":"123.123.123.123"}, "source": {"ar_net":"123.123.123.123", "ongisac_ip":"123.123.123.123"}, "url":{"origin_domain": "ip-192-168-1-2"}, "DstIP":"123.123.123.123","SrcIP":"123.123.123.123","orginalClientSrcIP":"123.123.123.123","ReferencedHost":"ip-192-168-1-2", "dns":{"question": {"origin_domain":"example.com/my-path?query=value"}}}'
    ]
  }
}

output {
  elasticsearch {
    hosts => "http://127.0.0.1:9200"
    user => "elastic"
    password => "{pwd}"
    index => "test-dlq"
    action => "update"
    document_id => "nonexistent_id_12345"
    ecs_compatibility => disabled
  }
}

```

## Related issues

- 

## Use cases

## Screenshots

## Logs
