### PR TITLE
Exclude non-runtime dependencies for snyk scans of jar dependencies

### DIFF
--- a/.buildkite/scripts/snyk/report.sh
+++ b/.buildkite/scripts/snyk/report.sh
@@ -43,7 +43,7 @@ report() {
   # for big projects Snyk recommends pruning dependencies
   # https://support.snyk.io/hc/en-us/articles/360002061438-CLI-returns-the-error-Failed-to-get-Vulns
   GIT_HEAD=$(git rev-parse --short HEAD 2> /dev/null)
-  ./snyk monitor --prune-repeated-subdependencies --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=qa,tools,devtools,requirements.txt --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" || :
+  ./snyk monitor --prune-repeated-subdependencies --all-projects --org=logstash --remote-repo-url="$REMOTE_REPO_URL" --target-reference="$REMOTE_REPO_URL" --detection-depth=6 --exclude=qa,tools,devtools,requirements.txt --configuration-matching="^runtime" --project-tags=branch="$TARGET_BRANCH",git_head="$GIT_HEAD" || :
 }
 
 resolve_latest_branches


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The dependencies that are reported into our snyk ingestion workflows are assumed to be shipped with logstash artifacts. The task to do this report was inadvertently reporting on tests dependencies that are causing false positives in our reporting workflows. This commit ensures only runtime jars (those that ship with logstash artifacts) are reported.
