### PR TITLE
fix error reporting when plugin uses unsupported `concurrency`

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/compiler/OutputStrategyExt.java
@@ -40,6 +40,7 @@ import org.logstash.plugins.factory.ContextualizerExt;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class OutputStrategyExt {
 
@@ -101,10 +102,12 @@ public final class OutputStrategyExt {
             if (!klass.isTrue()) {
                 throw new IllegalArgumentException(
                     String.format(
-                        "Could not find output delegator strategy of type '%s'. Value strategies: %s",
-                        type.asJavaString(),
-                        map.values(context).stream().map(v -> ((IRubyObject) v).asJavaString())
-                            .collect(Collectors.joining(", "))
+                        "Could not find output delegator strategy of type '%s'. Supported strategies: %s",
+                        type.inspect().asJavaString(),
+                        ((Stream<IRubyObject>)map.keys(context).stream())
+                                .map(IRubyObject::inspect)
+                                .map(IRubyObject::asString)
+                                .collect(Collectors.joining(", "))
                     )
                 );
             }


### PR DESCRIPTION


## Release notes

 - Fixed an issue where installing and referencing a plugin that has an unsupported concurrency type resulted in an obscure error message

## What does this PR do?

Improves the error message when a pipeline includes a plugin with an unsupported concurrency type. These types are declared in the plugin itself, not in the pipeline configuration.

## Why is it important/What is the impact to the user?

It helps us chase down the real issue, instead of a separate issue that occurs while describing the available concurrency types.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## How to test this PR locally

1. Build normally
2. Edit an output plugin in `/vendor/bundle/jruby/*/gems/logstash-output-*/ to have `concurrency :bananas` instead of one of the supported concurrency types
3. Run logstash with a pipeline configuration that includes the edited plugin
4. Observe the error message:

> ~~~
> [2026-04-22T19:41:33,116][ERROR][logstash.agent           ] Failed to execute action {action: LogStash::PipelineAction::Create/pipeline_id:main, exception: "Java::JavaLang::IllegalStateException", message: "Unable to configure plugins: Could not find output delegator strategy of type ':bananas'. Supported strategies: :shared, :legacy, :single", backtrace: ["org.logstash.config.ir.CompiledPipeline.<init>(CompiledPipeline.java:167)", "org.logstash.execution.AbstractPipelineExt.initialize(AbstractPipelineExt.java:246)", "org.logstash.execution.AbstractPipelineExt$INVOKER$i$initialize.call(AbstractPipelineExt$INVOKER$i$initialize.gen)", "org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:845)", "org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuper(IRRuntimeHelpers.java:1380)", "org.jruby.ir.instructions.InstanceSuperInstr.interpret(InstanceSuperInstr.java:128)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.RubyClass.newInstance(RubyClass.java:1050)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.ir.instructions.CallBase.interpret(CallBase.java:551)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)", "org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:797)", "Users.rye.src.elastic.logstash_at_40_main.logstash_minus_core.lib.logstash.agent.️❤ {} converge_state #0(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/agent.rb:433)", "org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)", "org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:60)", "org.jruby.runtime.Block.call(Block.java:146)", "org.jruby.RubyProc.call(RubyProc.java:394)", "org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:123)", "java.base/java.lang.Thread.run(Thread.java:1583)"], cause: {exception: Java::JavaLang::IllegalArgumentException, message: "Could not find output delegator strategy of type ':bananas'. Value strategies: :shared, :legacy, :single", backtrace: ["org.logstash.config.ir.compiler.OutputStrategyExt$OutputStrategyRegistryExt.classFor(OutputStrategyExt.java:104)", "org.logstash.config.ir.compiler.OutputDelegatorExt.initialize(OutputDelegatorExt.java:77)", "org.logstash.config.ir.compiler.OutputDelegatorExt.initialize(OutputDelegatorExt.java:56)", "org.logstash.plugins.factory.PluginFactoryExt.plugin(PluginFactoryExt.java:241)", "org.logstash.plugins.factory.PluginFactoryExt.buildOutput(PluginFactoryExt.java:136)", "org.logstash.config.ir.CompiledPipeline.lambda$setupOutputs$0(CompiledPipeline.java:224)", "java.base/java.util.ArrayList.forEach(ArrayList.java:1596)", "org.logstash.config.ir.CompiledPipeline.setupOutputs(CompiledPipeline.java:220)", "org.logstash.config.ir.CompiledPipeline.<init>(CompiledPipeline.java:165)", "org.logstash.execution.AbstractPipelineExt.initialize(AbstractPipelineExt.java:246)", "org.logstash.execution.AbstractPipelineExt$INVOKER$i$initialize.call(AbstractPipelineExt$INVOKER$i$initialize.gen)", "org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:845)", "org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuper(IRRuntimeHelpers.java:1380)", "org.jruby.ir.instructions.InstanceSuperInstr.interpret(InstanceSuperInstr.java:128)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.RubyClass.newInstance(RubyClass.java:1050)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.ir.instructions.CallBase.interpret(CallBase.java:551)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)", "org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:797)", "Users.rye.src.elastic.logstash_at_40_main.logstash_minus_core.lib.logstash.agent.️❤ {} converge_state #0(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/agent.rb:433)", "org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)", "org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:60)", "org.jruby.runtime.Block.call(Block.java:146)", "org.jruby.RubyProc.call(RubyProc.java:394)", "org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:123)", "java.base/java.lang.Thread.run(Thread.java:1583)"]}}
> ~~~

Without this patch, the error message looks like:

> ~~~
> [2026-04-22T19:44:08,521][ERROR][logstash.agent           ] Failed to execute action {action: LogStash::PipelineAction::Create/pipeline_id:main, exception: "Java::JavaLang::IllegalStateException", message: "Unable to configure plugins: (TypeError) wrong argument type LogStash::OutputDelegatorStrategies::Shared (expected String)", backtrace: ["org.logstash.config.ir.CompiledPipeline.<init>(CompiledPipeline.java:167)", "org.logstash.execution.AbstractPipelineExt.initialize(AbstractPipelineExt.java:246)", "org.logstash.execution.AbstractPipelineExt$INVOKER$i$initialize.call(AbstractPipelineExt$INVOKER$i$initialize.gen)", "org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:845)", "org.jruby.ir.runtime.IRRuntimeHelpers.instanceSuper(IRRuntimeHelpers.java:1380)", "org.jruby.ir.instructions.InstanceSuperInstr.interpret(InstanceSuperInstr.java:128)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.RubyClass.newInstance(RubyClass.java:1050)", "org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)", "org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:446)", "org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:92)", "org.jruby.ir.instructions.CallBase.interpret(CallBase.java:551)", "org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:372)", "org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:133)", "org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:120)", "org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)", "org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:797)", "Users.rye.src.elastic.logstash_at_40_main.logstash_minus_core.lib.logstash.agent.️❤ {} converge_state #0(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/agent.rb:433)", "org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)", "org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)", "org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:60)", "org.jruby.runtime.Block.call(Block.java:146)", "org.jruby.RubyProc.call(RubyProc.java:394)", "org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:123)", "java.base/java.lang.Thread.run(Thread.java:1583)"], cause: {exception: Java::OrgJrubyExceptions::TypeError, message: "(TypeError) wrong argument type LogStash::OutputDelegatorStrategies::Shared (expected String)", backtrace: ["org.logstash.config.ir.compiler.OutputDelegatorExt.initialize(org/logstash/config/ir/compiler/OutputDelegatorExt.java:77)", "org.logstash.config.ir.compiler.OutputDelegatorExt.initialize(org/logstash/config/ir/compiler/OutputDelegatorExt.java:56)", "org.logstash.plugins.factory.PluginFactoryExt.plugin(org/logstash/plugins/factory/PluginFactoryExt.java:241)", "org.logstash.execution.AbstractPipelineExt.initialize(org/logstash/execution/AbstractPipelineExt.java:246)", "RUBY.initialize(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/java_pipeline.rb:47)", "org.jruby.RubyClass.new(org/jruby/RubyClass.java:1050)", "RUBY.execute(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/pipeline_action/create.rb:50)", "Users.rye.src.elastic.logstash_at_40_main.logstash_minus_core.lib.logstash.agent.converge_state(/Users/rye/src/elastic/logstash@main/logstash-core/lib/logstash/agent.rb:433)"]}}
> ~~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
