### PR TITLE
Allow to pull elasticsearch 9.x ruby client versions.

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -79,7 +79,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
   gem.add_runtime_dependency "multi_json", "~> 1.19.1" # pinned until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2
-  gem.add_runtime_dependency "elasticsearch", '~> 8'
+  gem.add_runtime_dependency "elasticsearch", '>= 8', '< 10'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 
   # xpack geoip database service


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Allows Logstash to pull `elasticsearch` 9.x ruby client version.

## What does this PR do?
Allows Logstash to pull `elasticsearch` 9.x ruby client version. This provides an opportunity to upgrade the client in the ES plugins.

## Why is it important/What is the impact to the user?
Although it is not directly user facing feature, users will get benefits of latest features and improvements with the latest `elasticsearch` ruby client.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- Closes https://github.com/elastic/logstash/issues/18983

## Use cases

## Screenshots

## Logs