### PR TITLE
Pin image used to source filebeat for observabilitySRE testing

### DIFF
--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -242,6 +242,8 @@ def fips_test_runner_step() -> dict[str, typing.Any]:
         "command": LiteralScalarString("""#!/usr/bin/env bash
 set -euo pipefail
 source .buildkite/scripts/common/vm-agent.sh
+# TODO: remove this beats fips pin once https://github.com/elastic/beats/issues/50175 is resolvd
+export FILEBEAT_IMAGE_VERSION=8.19.14
 ./ci/observabilitySREacceptance_tests.sh
 """),
     }


### PR DESCRIPTION
This commit pins the filebeat image to the last release for acceptance tests while we wait for a resolution to https://github.com/elastic/beats/issues/50175

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add  to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

The observabilitySRE acceptance tests will continue to fail until this is resolved. Pin temporarily as the upstream go version has not been released with the patch. Reduce test failure noise in the mean time. 