### PR TITLE
Retry transient curl errors when checking JDK

### DIFF
--- a/.ci/updatecli/bump-java-version.yml
+++ b/.ci/updatecli/bump-java-version.yml
@@ -56,28 +56,28 @@ conditions:
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-linux-aarch64'
+      command: curl --silent --fail --head --retry 3 --retry-delay 5 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-linux-aarch64'
 
   darwin_x86_64_available:
     name: "Check darwin-x86_64 JDK is available"
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin'
+      command: curl --silent --fail --head --retry 3 --retry-delay 5 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin'
 
   darwin_aarch64_available:
     name: "Check darwin-aarch64 JDK is available"
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin-aarch64'
+      command: curl --silent --fail --head --retry 3 --retry-delay 5 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-darwin-aarch64'
 
   windows_x86_64_available:
     name: "Check windows-x86_64 JDK is available"
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --silent --fail --head 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-windows'
+      command: curl --silent --fail --head --retry 3 --retry-delay 5 'https://jvm-catalog.elastic.co/jdk/adoptiumjdk-{{ source "latest_jdk_version" }}+{{ source "latest_jdk_build" }}-windows'
 
 targets:
   update_jdk_revision:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

This commit updates the curl commands to check if JDK artifacts are ready with a retry. Recently an update was missed due to a 504 gateway timeout when an artifact was ready. This resulted in one of the branches not getting the update while the others did. For transient errors, curl should retry. 

Example of the issue: https://github.com/elastic/logstash/actions/runs/25295755363/job/74154213862