### PR TITLE
Clear pipeline metrics when a pipeline fails to start

### DIFF
--- a/logstash-core/lib/logstash/pipeline_action/create.rb
+++ b/logstash-core/lib/logstash/pipeline_action/create.rb
@@ -53,7 +53,10 @@ module LogStash module PipelineAction
         new_pipeline.start # block until the pipeline is correctly started or crashed
       end
 
-      agent.untrack_ssl_resources(pipeline_id) unless success
+      unless success
+        agent.untrack_ssl_resources(pipeline_id)
+        new_pipeline.shutdown
+      end
       LogStash::ConvergeResult::ActionResult.create(self, success)
     end
 

--- a/logstash-core/spec/logstash/pipeline_action/create_spec.rb
+++ b/logstash-core/spec/logstash/pipeline_action/create_spec.rb
@@ -87,9 +87,39 @@ describe LogStash::PipelineAction::Create do
 
     context "with an error raised during `#register`" do
       let(:pipeline_config) { mock_pipeline_config(:main, "input { dummyblockinginput { id => '123' } } filter { ruby { init => '1/0' code => '1+2' } } output { null {} }") }
+      let(:metric) { LogStash::Instrument::Metric.new(LogStash::Instrument::Collector.new) }
 
       it "returns false" do
         expect(subject.execute(agent, pipelines)).not_to be_a_successful_action
+      end
+
+      it "clears the pipeline plugin metrics on a failed start" do
+        subject.execute(agent, pipelines)
+
+        snapshot = metric.collector.snapshot_metric.metric_store.get_with_path("stats/pipelines/main")
+        pipeline_metric = snapshot.dig(:stats, :pipelines, :main)
+
+        expect(pipeline_metric).not_to include(:plugins)
+        expect(pipeline_metric).not_to include(:events)
+        expect(pipeline_metric).not_to include(:flow)
+        expect(pipeline_metric).not_to include(:batch)
+      end
+
+      it "does not bloat plugin metrics across repeated failed start attempts" do
+        3.times do
+          described_class.new(pipeline_config, metric).execute(agent, pipelines)
+        end
+
+        snapshot = metric.collector.snapshot_metric.metric_store.get_with_path("stats/pipelines/main")
+        plugins_metric = snapshot.dig(:stats, :pipelines, :main, :plugins)
+
+        codecs = plugins_metric&.dig(:codecs)
+        outputs = plugins_metric&.dig(:outputs)
+        filters = plugins_metric&.dig(:filters)
+
+        expect(codecs.to_h).to be_empty
+        expect(outputs.to_h).to be_empty
+        expect(filters.to_h).to be_empty
       end
     end
   end


### PR DESCRIPTION

## Release notes

Fixes a metric leak in `_node/stats` when a pipeline repeatedly fails to start with `config.reload.automatic: true`. Previously, each retry left a fresh set of plugin metric entries in the collector, causing the stats payload to grow indefinitely.

## What does this PR do?

When `Create.execute` fails, it now calls `new_pipeline.shutdown` to clean up pipeline metrics.

`Reload` and `Recover` are unchanged. Both already invoke `old_pipeline.shutdown` before retrying, so they inherit the cleanup.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Verified the fix end-to-end via a Docker repro on the patched image

## How to test this PR locally
1. Run beats-input with invalid SSL certificate
2. Observe codec count over time `curl -s http://localhost:9600/_node/stats/pipelines/main`

Expected: `codecs` stays at 0–2 regardless of how high `failures` climbs. Total `_node/stats` payload size stays roughly constant (a few KB) instead of growing linearly with retries.

## Related issues

- Closes #19009
- Relates #16264