### PR TITLE
Improve version bump flexibility and automate AWS and sequel deps to minor updates

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -5,7 +5,7 @@ on:
       branch:
         description: 'Release Branch'     
         required: true
-        default: '8.4'
+        default: '8.19'
         type: string
       bump:
         description: 'Bump type'     

--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -16,6 +16,11 @@ on:
         - "patch"
         - "minor"
         - "major"
+      extra_gems_minor:
+        description: 'Additional gems to bump at minor level (space-separated).'
+        required: false
+        default: ''
+        type: string
     
 permissions:
   pull-requests: write
@@ -45,6 +50,16 @@ jobs:
       - run: git config --global user.name "logstashmachine"
       - run: ./gradlew clean installDefaultGems
       - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ github.event.inputs.bump }} --strict
+      - name: Bump selected deps at minor level
+        if: ${{ inputs.bump == 'patch' }}
+        run: |
+          AWS_GEMS=$(./vendor/jruby/bin/jruby -S bundle list --name-only | grep '^aws-')
+          EXTRA="${{ inputs.extra_gems_minor }}"
+          GEMS=$(echo "${AWS_GEMS} sequel ${EXTRA}" | xargs)
+          if [ -n "$GEMS" ]; then
+            echo "Bumping at --minor: ${GEMS}"
+            ./vendor/jruby/bin/jruby -S bundle update $GEMS --minor --strict --conservative
+          fi
       - run: mv Gemfile.lock Gemfile.jruby-*.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_lock_${{ env.INPUTS_BRANCH }}_${T}" >> $GITHUB_ENV

--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -17,7 +17,12 @@ on:
         - "minor"
         - "major"
       extra_gems_minor:
-        description: 'Additional gems to bump at minor level (space-separated).'
+        description: 'Additional gems to bump at minor level (space-separated)'
+        required: false
+        default: ''
+        type: string
+      extra_gems_major:
+        description: 'Additional gems to bump at major level (space-separated)'
         required: false
         default: ''
         type: string
@@ -59,6 +64,14 @@ jobs:
           if [ -n "$GEMS" ]; then
             echo "Bumping at --minor: ${GEMS}"
             ./vendor/jruby/bin/jruby -S bundle update $GEMS --minor --strict --conservative
+          fi
+      - name: Bump selected deps at major level
+        if: ${{ inputs.bump != 'major' && inputs.extra_gems_major != '' }}
+        run: |
+          GEMS=$(echo "${{ inputs.extra_gems_major }}" | xargs)
+          if [ -n "$GEMS" ]; then
+            echo "Bumping at --major: ${GEMS}"
+            ./vendor/jruby/bin/jruby -S bundle update $GEMS --major --strict --conservative
           fi
       - run: mv Gemfile.lock Gemfile.jruby-*.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- enhancement
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Automate AWS and sequel minor bump on lock file patch bumps and adds a config parameter to version bump workflow to improve its flexibility. 
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?
It allows to select gems where a desired feature/fix has been shipped as minor release and also keeps up to date gemps that don't ship patch releases.
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
## Related issues
- Relates [#7160](https://github.com/elastic/ingest-dev/issues/7160)

## Tests

Example [job run](https://github.com/alexcams/logstash/actions/runs/26028350317/job/76507511077) and [PR created](https://github.com/alexcams/logstash/pull/5/changes) with `multi_json` as minor selected gem and `public_suffix` as major. AWS and sequel also downgraded manually to see them automatically updated to last minor. 