### PR TITLE
Update jruby-openssl to 0.16.0

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -17,7 +17,7 @@ PATH
       i18n (~> 1)
       jar-dependencies (= 0.4.1)
       jrjackson (= 0.4.20)
-      jruby-openssl (~> 0.15.4)
+      jruby-openssl (~> 0.16.0)
       manticore (~> 0.6)
       minitar (~> 1)
       pry (~> 0.12)
@@ -178,7 +178,7 @@ GEM
     jruby-jms (1.3.0-java)
       gene_pool
       semantic_logger
-    jruby-openssl (0.15.7-java)
+    jruby-openssl (0.16.0-java)
     jruby-stdin-channel (0.2.0-java)
     json (2.12.2-java)
     json-schema (2.8.1)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'puma', '~> 6.3', '>= 6.4.2'
   gem.add_runtime_dependency 'ruby-maven-libs', '~> 3', '>= 3.8.9'
   gem.add_runtime_dependency "jar-dependencies",'= 0.4.1' # Pin to `0.4.1` until https://github.com/jruby/jruby/issues/7262 is resolved
-  gem.add_runtime_dependency "jruby-openssl", "~> 0.15.4" # Pin until upgrade to jruby 9.4.12.0 https://github.com/elastic/logstash/issues/17007 
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.16.0"
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Update `jruby-openssl` to 0.16.0. 

## What does this PR do?

Take up the latest jruby-openssl in 8.19.
