### PR TITLE
Improve version bump flexibility and automate AWS and sequel deps to minor automatically

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -16,6 +16,16 @@ on:
         - "patch"
         - "minor"
         - "major"
+      extra_gems_minor:
+        description: 'Additional gems to bump at minor level (space-separated). AWS gems are always included automatically. Only used during patch runs.'
+        required: false
+        default: ''
+        type: string
+      extra_gems_major:
+        description: 'Gems to also bump at major level (space-separated). Used during patch or minor runs.'
+        required: false
+        default: ''
+        type: string
     
 permissions:
   pull-requests: write
@@ -54,6 +64,24 @@ jobs:
       - run: git config --global user.name "logstashmachine"
       - run: ./gradlew clean installDefaultGems
       - run: ./vendor/jruby/bin/jruby -S bundle update --all --${{ env.INPUTS_BUMP }} --strict
+      - name: Bump selected deps at minor level
+        if: ${{ inputs.bump == 'patch' }}
+        run: |
+          AWS_GEMS=$(./vendor/jruby/bin/jruby -S bundle list --name-only | grep '^aws-')
+          EXTRA="${{ inputs.extra_gems_minor }}"
+          GEMS=$(echo "${AWS_GEMS} ${EXTRA}" | xargs)
+          if [ -n "$GEMS" ]; then
+            echo "Bumping at --minor: ${GEMS}"
+            ./vendor/jruby/bin/jruby -S bundle update $GEMS --minor --strict --conservative
+          fi
+      - name: Bump selected deps at major level
+        if: ${{ inputs.bump != 'major' && inputs.extra_gems_major != '' }}
+        run: |
+          GEMS=$(echo "${{ inputs.extra_gems_major }}" | xargs)
+          if [ -n "$GEMS" ]; then
+            echo "Bumping at --major: ${GEMS}"
+            ./vendor/jruby/bin/jruby -S bundle update $GEMS --major --strict --conservative
+          fi
       - run: mv Gemfile.lock Gemfile.jruby-*.lock.release
       - run: echo "T=$(date +%s)" >> $GITHUB_ENV
       - run: echo "BRANCH=update_lock_${{ env.INPUTS_BRANCH }}_${T}" >> $GITHUB_ENV

--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -5,7 +5,7 @@ on:
       branch:
         description: 'Release Branch'     
         required: true
-        default: '8.4'
+        default: '9.4'
         type: string
       bump:
         description: 'Bump type'     
@@ -38,6 +38,8 @@ jobs:
     env:
       INPUTS_BRANCH: "${{ inputs.branch }}"
       INPUTS_BUMP: "${{ inputs.bump }}"
+      INPUTS_EXTRA_GEMS_MINOR: "${{ inputs.extra_gems_minor }}"
+      INPUTS_EXTRA_GEMS_MAJOR: "${{ inputs.extra_gems_major }}"
       BACKPORT_LABEL: "backport-${{ inputs.branch }}"
     steps:
       - name: Set up JDK 21
@@ -68,8 +70,7 @@ jobs:
         if: ${{ inputs.bump == 'patch' }}
         run: |
           AWS_GEMS=$(./vendor/jruby/bin/jruby -S bundle list --name-only | grep '^aws-')
-          EXTRA="${{ inputs.extra_gems_minor }}"
-          GEMS=$(echo "${AWS_GEMS} ${EXTRA}" | xargs)
+          GEMS=$(echo "${AWS_GEMS} ${INPUTS_EXTRA_GEMS_MINOR}" | xargs)
           if [ -n "$GEMS" ]; then
             echo "Bumping at --minor: ${GEMS}"
             ./vendor/jruby/bin/jruby -S bundle update $GEMS --minor --strict --conservative
@@ -77,7 +78,7 @@ jobs:
       - name: Bump selected deps at major level
         if: ${{ inputs.bump != 'major' && inputs.extra_gems_major != '' }}
         run: |
-          GEMS=$(echo "${{ inputs.extra_gems_major }}" | xargs)
+          GEMS=$(echo "${INPUTS_EXTRA_GEMS_MAJOR}" | xargs)
           if [ -n "$GEMS" ]; then
             echo "Bumping at --major: ${GEMS}"
             ./vendor/jruby/bin/jruby -S bundle update $GEMS --major --strict --conservative


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- enhancement
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Automates AWS minor updates on lock file patch bumps and adds 2 config parameters, allowing selected gems to be updated to minor or major automatically,  improving workflow flexibility.

## Why is it important/What is the impact to the user?

It allows to select gems where a desired feature/fix has been shipped as minor/major release and also keeps up to date gemps that don't ship patch releases (AWS).
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates [#7160](https://github.com/elastic/ingest-dev/issues/7160)

# Tests

Example [job run](https://github.com/alexcams/logstash/actions/runs/26217464923/job/77143445939) and the [resulting PR](https://github.com/alexcams/logstash/pull/6/changes). Some gems were manually downgraded at target branch befor the workflow execution. `elasticsearch` and `rubocop` chose as selected minor gems input param, and redis as major. 