### PR TITLE
Remove cgi pin from Gemfile

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -42,5 +42,4 @@ gem "murmurhash3", "= 0.1.6" # Pins until version 0.1.7-java is released
 gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
-gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default


### PR DESCRIPTION
- enhancement

## Release notes
Removed cgi pin from Gemfile


## What does this PR do?

Removed cgi pin from Gemfile as JRuby (https://github.com/jruby/jruby/releases/tag/10.0.5.0) used in Logstash has cgi 0.4.2 which fixes CVE-2025-27220 (https://github.com/advisories/GHSA-mhwm-jh88-3gjf) and CVE-2025-27220 (https://github.com/advisories/GHSA-gh9q-2xrm-x6qv)

## Why is it important/What is the impact to the user?

Pin in Gemfile is not needed anymore. Cgi from JRuby is not vulnerable.

## Checklist

- [x] My code follows the style guidelines of this project
-~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Related issues

JRuby https://github.com/jruby/jruby/pull/8954
