### PR TITLE
Add RHEL 10, Oracle Linux 10, Rocky Linux 10, and Alma Linux 10 to exhaustive tests

### DIFF
--- a/.buildkite/scripts/common/vm-images.json
+++ b/.buildkite/scripts/common/vm-images.json
@@ -3,10 +3,10 @@
     "linux": {
         "ubuntu": ["ubuntu-2404", "ubuntu-2204", "ubuntu-2004"],
         "debian": ["debian-13", "debian-12", "debian-11"],
-        "rhel": ["rhel-9", "rhel-8"],
-        "oraclelinux": ["oraclelinux-9", "oraclelinux-8", "oraclelinux-7"],
-        "rocky": ["rocky-linux-9", "rocky-linux-8"],
-        "almalinux": ["almalinux-9", "almalinux-8"],
+        "rhel": ["rhel-10", "rhel-9", "rhel-8"],
+        "oraclelinux": ["oraclelinux-10", "oraclelinux-9", "oraclelinux-8", "oraclelinux-7"],
+        "rocky": ["rocky-linux-10", "rocky-linux-9", "rocky-linux-8"],
+        "almalinux": ["almalinux-10", "almalinux-9", "almalinux-8"],
         "amazonlinux": ["amazonlinux-2023"],
         "opensuse": ["opensuse-leap-15"]
     },

--- a/.buildkite/scripts/exhaustive-tests/generate-steps.py
+++ b/.buildkite/scripts/exhaustive-tests/generate-steps.py
@@ -13,10 +13,10 @@ VM_IMAGE_PREFIX = "platform-ingest-logstash-multi-jdk-"
 ACCEPTANCE_LINUX_OSES = [
     "ubuntu-2404", "ubuntu-2204", "ubuntu-2004",
     "debian-11", "debian-12", "debian-13",
-    "rhel-8", "rhel-9",
-    "oraclelinux-7", "oraclelinux-8", "oraclelinux-9",
-    "rocky-linux-8", "rocky-linux-9",
-    "almalinux-8", "almalinux-9",
+    "rhel-8", "rhel-9", "rhel-10",
+    "oraclelinux-7", "oraclelinux-8", "oraclelinux-9", "oraclelinux-10",
+    "rocky-linux-8", "rocky-linux-9", "rocky-linux-10",
+    "almalinux-8", "almalinux-9", "almalinux-10",
     "opensuse-leap-15",
     "amazonlinux-2023",
 ]

--- a/qa/rspec/commands/system_helpers.rb
+++ b/qa/rspec/commands/system_helpers.rb
@@ -21,7 +21,7 @@ module ServiceTester
   module SystemD
     def running?(package, jdk_path = '/usr/share/logstash/jdk/bin/java')
       stdout = ""
-      cmd = sudo_exec!("service #{package} status")
+      cmd = sudo_exec!("systemctl status #{package} --no-pager")
       stdout = cmd.stdout
       stdout.force_encoding(Encoding::UTF_8)
       (
@@ -32,7 +32,7 @@ module ServiceTester
     end
 
     def service_manager(service, action)
-      sudo_exec!("service #{service} #{action}")
+      sudo_exec!("systemctl #{action} #{service}")
     end
   end
 


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Adds four new OS distributions to the Logstash exhaustive test matrix and randomized compat CI:

- RHEL 10
- Oracle Linux 10
- Rocky Linux 10
- Alma Linux 10

The corresponding VM images (`logstash-multi-jdk-rhel-10`, `logstash-multi-jdk-oraclelinux-10`, `logstash-multi-jdk-rocky-linux-10`, `logstash-multi-jdk-almalinux-10`) were added to ci-agent-images in https://github.com/elastic/ci-agent-images/pull/2561.

## Why is it important/What is the impact to the user?

Keeps Logstash CI coverage aligned with the rest of the Elastic stack as support for new OS versions is rolled out.

Relates: https://github.com/elastic/ingest-dev/issues/7584 (RHEL 10)
Relates: https://github.com/elastic/ingest-dev/issues/7581 (Oracle Linux 10)
Relates: https://github.com/elastic/ingest-dev/issues/7582 (Rocky Linux 10)
Relates: https://github.com/elastic/ingest-dev/issues/7583 (Alma Linux 10)

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] VM images confirmed available in ci-agent-images (https://github.com/elastic/ci-agent-images/pull/2561)

## How to test this PR locally

Comment `run exhaustive tests` on this PR to trigger the exhaustive test pipeline against all four new OS targets.

## Related issues