### PR TITLE
Make asciidoc RN generator org aware

### DIFF
--- a/tools/release/generate_release_notes.rb
+++ b/tools/release/generate_release_notes.rb
@@ -93,15 +93,17 @@ report << "==== Plugins\n"
 plugin_changes.each do |plugin, versions|
   _, type, name = plugin.split("-")
   header = "*#{name.capitalize} #{type.capitalize} - #{versions.last}*"
+  # Determine the correct GitHub organization
+  org = plugin.include?('elastic_integration') ? 'elastic' : 'logstash-plugins'
   start_changelog_file = Tempfile.new(plugin + 'start')
   end_changelog_file = Tempfile.new(plugin + 'end')
-  changelog = `curl https://raw.githubusercontent.com/logstash-plugins/#{plugin}/v#{versions.last}/CHANGELOG.md`.split("\n")
+  changelog = `curl https://raw.githubusercontent.com/#{org}/#{plugin}/v#{versions.last}/CHANGELOG.md`.split("\n")
   report << "#{header}\n"
   changelog.each do |line|
     break if line.match(/^## #{versions.first}/)
     next if line.match(/^##/)
     line.gsub!(/^\+/, "")
-    line.gsub!(/ #(?<number>\d+)\s*$/, " https://github.com/logstash-plugins/#{plugin}/issues/\\k<number>[#\\k<number>]")
+    line.gsub!(/ #(?<number>\d+)\s*$/, " https://github.com/#{org}/#{plugin}/issues/\\k<number>[#\\k<number>]")
     line.gsub!(/\[#(?<number>\d+)\]\((?<url>[^)]*)\)/, "\\k<url>[#\\k<number>]")
     line.gsub!(/^\s+-/, "*")
     report << line


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

This fix applies the logic that landed in https://github.com/elastic/logstash/pull/18315 to the asciidoc RN still used in the 8.19 branch.