### PR TITLE
[DOCS] Add changelog config file

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -41,7 +41,7 @@ extract:
   issues: true
   # Remove square-bracket prefixes from PR titles (default: false)
   # When enabled (true or via --strip-title-prefix), titles like "[ES|QL] Fix bug" become "Fix bug".
-  strip_title_prefix: false
+  strip_title_prefix: true
 
 # Available lifecycle values (strongly typed: preview, beta, ga)
 lifecycles:
@@ -190,9 +190,32 @@ bundle:
     - elastic/elasticsearch
     - elastic/kibana
     - elastic/logstash
-    - elastic/logstash-docs
-    - logstash-plugins/logstash-output-elasticsearch
+    - elastic/logstash-filter-elastic_integration
     - elastic/roadmap
+    - logstash-plugins/logstash-codec-collectd
+    - logstash-plugins/logstash-codec-netflow
+    - logstash-plugins/logstash-input-azure_event_hubs
+    - logstash-plugins/logstash-input-beats
+    - logstash-plugins/logstash-input-dead_letter_queue
+    - logstash-plugins/logstash-input-file
+    - logstash-plugins/logstash-input-http
+    - logstash-plugins/logstash-filter-aggregate
+    - logstash-plugins/logstash-filter-dissect
+    - logstash-plugins/logstash-filter-de_dot
+    - logstash-plugins/logstash-filter-date
+    - logstash-plugins/logstash-filter-fingerprint
+    - logstash-plugins/logstash-filter-geoip
+    - logstash-plugins/logstash-filter-grok
+    - logstash-plugins/logstash-filter-mutate
+    - logstash-plugins/logstash-input-gelf
+    - logstash-plugins/logstash-input-tcp
+    - logstash-plugins/logstash-input-unix
+    - logstash-plugins/logstash-integration-aws
+    - logstash-plugins/logstash-integration-jdbc
+    - logstash-plugins/logstash-integration-kafka
+    - logstash-plugins/logstash-output-elasticsearch
+    - logstash-plugins/logstash-output-nagios
+    - logstash-plugins/logstash-output-webhdfs
   # Optional: default GitHub repo name applied to all profiles that do not specify their own.
   repo: logstash
   # Optional: default GitHub owner applied to all profiles that do not specify their own.

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,0 +1,229 @@
+# Changelog Configuration
+# This file configures the valid values for changelog fields using the pivot structure.
+# Place this file as `changelog.yml` in the `docs/` directory
+#
+# NOTE: All list-like fields accept BOTH forms:
+#   - Comma-separated string: "value1, value2, value3"
+#   - YAML list:
+#     - value1
+#     - value2
+#     - value3
+# Both forms produce the same result. Choose whichever is more readable for your use case.
+
+# Filename strategy for generated changelog files.
+# Controls how files created by 'changelog add' are named.
+#   pr        — use the PR number (e.g., 12345.yaml).
+#   issue     — use the issue number (e.g., 67890.yaml).
+#   timestamp — use a Unix timestamp with a title slug (e.g., 1735689600-fix-search.yaml). Default.
+# Can be overridden per invocation with --use-pr-number or --use-issue-number CLI flags.
+filename: pr
+
+# Products configuration (optional)
+# If not specified, all products from products.yml are allowed (including those
+# that have 'public-reference' disabled).
+products:
+  # List of available product IDs (empty = all from products.yml)
+  available:
+    - logstash
+  # Default products when --products not specified
+  default:
+    - product: logstash
+      # lifecycle: ga
+
+# Extraction configuration
+# Controls automatic extraction of information from PR descriptions
+extract:
+  # Auto-extract release notes from PR descriptions (default: true)
+  # Can be overridden by CLI --no-extract-release-notes
+  release_notes: true
+  # Auto-extract issues from PR body (default: true)
+  # Looks for patterns like "Fixes #123", "Closes #456", etc.
+  issues: true
+  # Remove square-bracket prefixes from PR titles (default: false)
+  # When enabled (true or via --strip-title-prefix), titles like "[ES|QL] Fix bug" become "Fix bug".
+  strip_title_prefix: false
+
+# Available lifecycle values (strongly typed: preview, beta, ga)
+lifecycles:
+  - preview
+  - beta
+  - ga
+
+# Pivot configuration for types, subtypes, and areas with label mappings.
+# By default we render entries grouped by type > subtype > area.
+# NOTE: subtype and area are optional and either may be omitted.
+# Labels are specified in a "label -> value" format
+pivot:
+  # Type definitions with optional labels
+  # At a minimum, feature, bug-fix, and breaking-change must be configured.
+  # Keys are type names, values can be:
+  #   - simple string: comma-separated label list (e.g., ">bug, >fix")
+  #   - empty/null: no labels for this type
+  #   - object: { labels: "...", subtypes: {...} } for breaking-change type only
+  types:
+    # Complex object form with subtypes (ONLY allowed for breaking-change)
+    # Subtypes help categorize breaking changes by their nature
+    breaking-change:
+      labels: "breaking change"
+      # subtypes:
+      #   api: ">api-breaking"
+      #   behavioral: ">behavioral-breaking"
+      #   configuration: ">config-breaking"
+      #   dependency: ">dependency-breaking"
+      #   subscription: ">subscription-breaking"
+      #   plugin: ">plugin-breaking"
+      #   security: ">security-breaking"
+      #   other:
+    # Simple string form: labels as comma-separated string
+    bug-fix: ">bug, bug"
+    deprecation: "deprecation"
+    feature:
+    enhancement: "enhancement"
+    docs: "docs"
+    known-issue:
+    other:
+    regression: "regression"
+    security:
+
+  # Area definitions with labels
+  # Keys are area display names, values are label strings
+  # Multiple labels can be comma-separated
+  areas:
+    # Example mappings - customize based on your label naming conventions
+    # Elasticsearch Output:
+    # Search: ":Search/Search"
+    # Security: ":Security/Security"
+    # Watcher: ":Data Management/Watcher"
+
+# Product definitions with labels (optional).
+  # Keys are product spec strings; values are label strings or lists that trigger that product.
+  # A product spec string is: "<product-id> [<target-version>] [<lifecycle>]"
+  #   - Product ID only:           "elasticsearch"
+  #   - Product + target:          "kibana 9.2.0"
+  #   - Full spec:                 "cloud-serverless 2025-06 ga"
+  # When a PR has labels matching any product entry, all matching products are added.
+  # Precedence: --products CLI option > pivot.products label mapping > products.default > repo inference.
+  #
+  # products:
+  #   'elasticsearch':
+  #     - ":stack/elasticsearch"
+  #   'kibana':
+  #     - ":stack/kibana"
+  #   'cloud-serverless':
+  #     - ":cloud/serverless"
+  #   # Specify a target version if known:
+  #   # 'elasticsearch 9.2.0':
+  #   #   - ":feature/new-in-9.2"
+
+# Rules configuration — controls which PRs create changelogs and which changelogs are published.
+# All list-like fields (exclude, include, exclude_types) accept BOTH forms:
+#   - Comma-separated string: "value1, value2, value3"
+#   - YAML list: [value1, value2, value3]
+#
+# For details and examples, refer to the [rules documentation](https://github.com/elastic/docs-builder/blob/main/docs/contribute/configure-changelogs-ref.md#rules).
+rules:
+  # match: any
+
+  # Create — controls which PRs generate changelogs.
+  # create:
+  #   exclude: ">non-issue, >test"
+  #   # Or equivalently:
+  #   # exclude:
+  #   #   - ">non-issue"
+  #   #   - ">test"
+  #   # match: any
+  #   products:
+  #     'elasticsearch, kibana':
+  #       exclude: ">test"
+  #     'cloud-serverless':
+  #       exclude: "ILM"
+
+  # Bundle — filtering applied during 'changelog bundle' and 'changelog gh-release'.
+  # See https://github.com/elastic/docs-builder/blob/main/docs/contribute/configure-changelogs-ref.md#rules-bundle for Mode 1 / 2 / 3 behavior.
+  #
+  # Mode 2 (global content): use global lists only — no `products` key, or `products: {}`.
+  # Example — include changelogs that list elasticsearch OR kibana (evaluated per changelog):
+  # bundle:
+  #   match_products: any
+  #   include_products:
+  #     - elasticsearch
+  #     - kibana
+  #   exclude_types: "deprecation, known-issue"
+  #
+  # Example — exclude only when the changelog lists BOTH products (conjunction); extras allowed:
+  # bundle:
+  #   match_products: conjunction
+  #   exclude_products:
+  #     - kibana
+  #     - observability
+  #
+  # Mode 3 (per-product context): non-empty `rules.bundle.products` — global include/exclude/type/area
+  # under `bundle:` are NOT applied for filtering; configure filters under each product key.
+  # Example:
+  # bundle:
+  #   exclude_types: [docs]   # ignored for filtering in Mode 3 — duplicate under each product if needed
+  #   products:
+  #     observability:
+  #       exclude_products: ["cloud-enterprise"]
+  #       exclude_types: ["docs"]
+  #       include_areas:
+  #         - "APM"
+  #         - "Infrastructure monitoring"
+  #     kibana:
+  #       match_products: all
+  #       include_products: ["kibana", "security"]
+  #       exclude_types: ["docs"]
+
+# Bundle configuration (profiles and defaults)
+bundle:
+  # Input directory containing changelog YAML files
+  directory: docs/changelog
+  # Output directory for bundled changelog files
+  output_directory: docs/releases
+  # Whether to resolve (copy contents) by default
+  resolve: true
+  # description: |
+  #   This release includes new features and bug fixes.
+  # To allow cross-repo links, add more owner/repo entries.
+  link_allow_repos:
+    - elastic/beats
+    - elastic/elasticsearch
+    - elastic/kibana
+    - elastic/logstash
+    - elastic/logstash-docs
+    - logstash-plugins/logstash-output-elasticsearch
+    - elastic/roadmap
+  # Optional: default GitHub repo name applied to all profiles that do not specify their own.
+  repo: logstash
+  # Optional: default GitHub owner applied to all profiles that do not specify their own.
+  owner: elastic
+  # Optional: control auto-population of release-date for all profiles by default.
+  # release_dates: true
+
+  # Named bundle profiles for different release scenarios.
+  # Profiles can be used with both 'changelog bundle' and 'changelog remove':
+  #   docs-builder changelog bundle elasticsearch-release 9.2.0
+  #   docs-builder changelog remove elasticsearch-release 9.2.0
+  # When used with 'changelog remove', only the 'products' field is applied.
+  # The 'output', 'output_products', 'repo', 'owner', and 'hide_features' fields are
+  # bundle-specific and are ignored for removal.
+  profiles:
+    logstash-release:
+    #   Output filename ({version} is substituted at runtime)
+      output: "logstash-{version}.yaml"
+    #   Override the products array written to the bundle output.
+      output_products: "logstash {version}"
+    #   # Optional: profile-specific description (overrides bundle.description)
+    #   # description: |
+    #   #   Elasticsearch {version} includes:
+    #   #   - Performance improvements
+    #   #   - Bug fixes and stability enhancements
+    #   #   
+    #   #   Download the release binaries: https://github.com/{owner}/{repo}/releases/tag/v{version}
+    #   # Optional: control auto-population of release-date for this profile.
+    #   # When true (default), auto-populate release dates. When false, equivalent to --no-release-date.
+    #   # release_dates: true
+    #   # Feature IDs to hide when bundling with this profile (accepts string or list)
+    #   hide_features:
+    #     - feature-flag-1
+    #     - feature-flag-2


### PR DESCRIPTION
## Release notes

[rn:skip] 

## What does this PR do?

This PR adds a configuration file for release note changelog tooling per https://elastic.github.io/docs-builder/contribute/configure-changelogs/

## Why is it important/What is the impact to the user?

This file defines when/if changelogs will be created and rules for how the changelogs will be bundled at release time.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
