### PR TITLE
Remove logstash-output-pipe from default bundle

### DIFF
--- a/rakelib/plugins-metadata.json
+++ b/rakelib/plugins-metadata.json
@@ -529,7 +529,7 @@
     "skip-list": false
   },
   "logstash-output-pipe": {
-    "default-plugins": true,
+    "default-plugins": false,
     "skip-list": false
   },
   "logstash-output-rabbitmq": {


### PR DESCRIPTION
## Release notes

Remove `logstash-output-pipe` from the set of plugins shipped by default.

## How to test this PR locally

```bash
./gradlew assembleTarDistribution
tar tzf build/logstash-*-SNAPSHOT.tar.gz | grep output-pipe
# Should return no results
```