### PR TITLE
WIP Remove openssl from apk setup

### DIFF
--- a/x-pack/distributions/internal/observabilitySRE/docker/Dockerfile
+++ b/x-pack/distributions/internal/observabilitySRE/docker/Dockerfile
@@ -15,8 +15,7 @@ RUN apk add --no-cache \
     make \
     gcc \
     java-cacerts \
-    glibc-dev \
-    openssl
+    glibc-dev
 
 # Create directories with correct ownership
 RUN mkdir -p /etc/java/security && \


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

It looks like that package should be available on base image and is now causing issues being downloaded with apk. Test its removal.