### PR TITLE
Implement Log4j filter to deduplicate log messages

### DIFF
--- a/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.log;
+
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Log4j2 filter that suppresses repeated log lines using a Guava {@link BloomFilter}.
+ * <p>
+ * Deduplication key is {@code level + formattedMessage}. The first occurrence of a key
+ * yields {@link Result#NEUTRAL}; subsequent occurrences yield {@link Result#DENY}.
+ * </p>
+ * <p>
+ * Example {@code log4j2.properties} wiring on an appender:
+ * </p>
+ * <pre>
+ * appender.rolling.filter.dedup.type = DeduplicationFilter
+ * appender.rolling.filter.dedup.falsePositiveProbability = 0.01
+ * </pre>
+ */
+@Plugin(name = "DeduplicationFilter", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
+public final class DeduplicationFilter extends AbstractFilter {
+
+    static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.01;
+    private static final int DEFAULT_EXPECTED_INSERTIONS = 1_000_000;
+
+    private final BloomFilter<CharSequence> seenKeys;
+
+    @PluginFactory
+    public static DeduplicationFilter createFilter(
+            @PluginAttribute(value = "falsePositiveProbability", defaultDouble = DEFAULT_FALSE_POSITIVE_PROBABILITY)
+            final double falsePositiveProbability) {
+        return new DeduplicationFilter(resolveFalsePositiveProbability(falsePositiveProbability));
+    }
+
+    private DeduplicationFilter(final double falsePositiveProbability) {
+        seenKeys = BloomFilter.create(
+                Funnels.stringFunnel(StandardCharsets.UTF_8),
+                DEFAULT_EXPECTED_INSERTIONS,
+                falsePositiveProbability
+        );
+    }
+
+    static double resolveFalsePositiveProbability(final double falsePositiveProbability) {
+        if (falsePositiveProbability > 0.0 && falsePositiveProbability < 1.0) {
+            return falsePositiveProbability;
+        }
+        return DEFAULT_FALSE_POSITIVE_PROBABILITY;
+    }
+
+    @Override
+    public Result filter(final LogEvent event) {
+        final CharSequence key = dedupKey(event);
+        synchronized (seenKeys) {
+            if (seenKeys.mightContain(key)) {
+                return Result.DENY;
+            }
+            seenKeys.put(key);
+            return Result.NEUTRAL;
+        }
+    }
+
+    private static CharSequence dedupKey(final LogEvent event) {
+        return event.getLevel().name() + '\0' + event.getMessage().getFormattedMessage();
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
@@ -38,11 +38,12 @@ import java.nio.charset.StandardCharsets;
  * yields {@link Result#NEUTRAL}; subsequent occurrences yield {@link Result#DENY}.
  * </p>
  * <p>
- * Example {@code log4j2.properties} wiring on an appender:
+ * Example {@code log4j2.properties} wiring on a logger:
  * </p>
  * <pre>
- * appender.rolling.filter.dedup.type = DeduplicationFilter
- * appender.rolling.filter.dedup.falsePositiveProbability = 0.01
+ * logger.periodic_flusher.name = org.logstash.execution.PeriodicFlush
+ * logger.periodic_flusher.level = DEBUG
+ * logger.periodic_flusher.filter.dedup.type = DeduplicationFilter
  * </pre>
  */
 @Plugin(name = "DeduplicationFilter", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
@@ -79,11 +80,16 @@ public final class DeduplicationFilter extends AbstractFilter {
     public Result filter(final LogEvent event) {
         final String key = dedupKey(event);
         synchronized (seenKeys) {
-            if (seenKeys.mightContain(key)) {
-                return Result.DENY;
+            if (!seenKeys.mightContain(key)) {
+                seenKeys.put(key);
+                return Result.NEUTRAL;
             }
-            seenKeys.put(key);
-            return Result.NEUTRAL;
+            return Result.DENY;
+//            if (seenKeys.mightContain(key)) {
+//                return Result.DENY;
+//            }
+//            seenKeys.put(key);
+//            return Result.NEUTRAL;
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
@@ -51,7 +51,7 @@ public final class DeduplicationFilter extends AbstractFilter {
     static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.01;
     private static final int DEFAULT_EXPECTED_INSERTIONS = 1_000_000;
 
-    private final BloomFilter<CharSequence> seenKeys;
+    private final BloomFilter<String> seenKeys;
 
     @PluginFactory
     public static DeduplicationFilter createFilter(
@@ -77,7 +77,7 @@ public final class DeduplicationFilter extends AbstractFilter {
 
     @Override
     public Result filter(final LogEvent event) {
-        final CharSequence key = dedupKey(event);
+        final String key = dedupKey(event);
         synchronized (seenKeys) {
             if (seenKeys.mightContain(key)) {
                 return Result.DENY;
@@ -87,7 +87,7 @@ public final class DeduplicationFilter extends AbstractFilter {
         }
     }
 
-    private static CharSequence dedupKey(final LogEvent event) {
+    private static String dedupKey(final LogEvent event) {
         return event.getLevel().name() + '\0' + event.getMessage().getFormattedMessage();
     }
 }

--- a/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
@@ -85,11 +85,6 @@ public final class DeduplicationFilter extends AbstractFilter {
                 return Result.NEUTRAL;
             }
             return Result.DENY;
-//            if (seenKeys.mightContain(key)) {
-//                return Result.DENY;
-//            }
-//            seenKeys.put(key);
-//            return Result.NEUTRAL;
         }
     }
 

--- a/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
+++ b/logstash-core/src/main/java/org/logstash/log/DeduplicationFilter.java
@@ -21,6 +21,7 @@ package org.logstash.log;
 
 import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnels;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.LogEvent;
@@ -28,6 +29,7 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.status.StatusLogger;
 
 import java.nio.charset.StandardCharsets;
 
@@ -51,6 +53,7 @@ public final class DeduplicationFilter extends AbstractFilter {
 
     static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.01;
     private static final int DEFAULT_EXPECTED_INSERTIONS = 1_000_000;
+    private static final Logger STATUS_LOGGER = StatusLogger.getLogger();
 
     private final BloomFilter<String> seenKeys;
 
@@ -70,9 +73,11 @@ public final class DeduplicationFilter extends AbstractFilter {
     }
 
     static double resolveFalsePositiveProbability(final double falsePositiveProbability) {
-        if (falsePositiveProbability > 0.0 && falsePositiveProbability < 1.0) {
+        if (falsePositiveProbability > 0.0 && falsePositiveProbability <= 0.5) {
             return falsePositiveProbability;
         }
+        STATUS_LOGGER.warn("falsePositiveProbability is expected to be in the range (0, 5%] but was {}, defaulting to {}", 
+                falsePositiveProbability, DEFAULT_FALSE_POSITIVE_PROBABILITY);
         return DEFAULT_FALSE_POSITIVE_PROBABILITY;
     }
 

--- a/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
@@ -24,8 +24,18 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusListener;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 public class DeduplicationFilterTest {
@@ -91,5 +101,44 @@ public class DeduplicationFilterTest {
                 .setLevel(level)
                 .setMessage(new SimpleMessage(message))
                 .build();
+    }
+    
+    private static class SpyListener implements StatusListener {
+        
+        private final List<StatusData> spiedMessages = new ArrayList<>();
+        
+        @Override
+        public void log(StatusData data) {
+            spiedMessages.add(data);
+        }
+
+        @Override
+        public Level getStatusLevel() {
+            return Level.WARN;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+    
+    @Test
+    public void givenFalsePositiveProbabilitySetToValueOutsideExpectedRangeThenOverrideToDefaultAndLog() throws IOException {
+        // setup
+        try (SpyListener loggerSpy = new SpyListener()) {
+            StatusLogger.getLogger().registerListener(loggerSpy);
+
+            // Exercise
+            DeduplicationFilter.resolveFalsePositiveProbability(1.0);
+
+            // Verify
+            final StatusData data = loggerSpy.spiedMessages.get(0);
+            assertEquals(Level.WARN, data.getLevel());
+            assertThat(data.getMessage().getFormattedMessage(), containsString("falsePositiveProbability is expected to be in the range (0, 5%] but was"));
+            
+            // teardown
+            StatusLogger.getLogger().removeListener(loggerSpy);
+        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
@@ -41,7 +41,7 @@ public class DeduplicationFilterTest {
     }
 
     @Test
-    public void givenAStringAtInfoLevelWhenAppearsMultipleTimesThenIsDenied() {
+    public void givenAStringAtWarnLevelWhenAppearsMultipleTimesThenIsDenied() {
         final DeduplicationFilter filter = DeduplicationFilter.createFilter(
                 DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY);
 

--- a/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/DeduplicationFilterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.log;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeduplicationFilterTest {
+
+    @Test
+    public void givenAStringAtInfoLevelWhenAppearsFirstTimeThenIsForwarded() {
+        final DeduplicationFilter filter = DeduplicationFilter.createFilter(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY);
+
+        final Filter.Result result = filter.filter(logEvent(Level.INFO, "duplicate me"));
+
+        assertEquals(Filter.Result.NEUTRAL, result);
+    }
+
+    @Test
+    public void givenAStringAtInfoLevelWhenAppearsMultipleTimesThenIsDenied() {
+        final DeduplicationFilter filter = DeduplicationFilter.createFilter(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY);
+
+        filter.filter(logEvent(Level.WARN, "same line"));
+        final Filter.Result result = filter.filter(logEvent(Level.WARN, "same line"));
+
+        assertEquals(Filter.Result.DENY, result);
+    }
+
+    @Test
+    public void givenAStringWhenAppearsAtDifferentLevelThenIsForwarded() {
+        final DeduplicationFilter filter = DeduplicationFilter.createFilter(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY);
+
+        filter.filter(logEvent(Level.INFO, "shared text"));
+        final Filter.Result result = filter.filter(logEvent(Level.ERROR, "shared text"));
+
+        assertEquals(Filter.Result.NEUTRAL, result);
+    }
+
+    @Test
+    public void invalidFalsePositiveProbabilityFallsBackToDefault() {
+        assertEquals(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                DeduplicationFilter.resolveFalsePositiveProbability(0.0),
+                0.0
+        );
+        assertEquals(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                DeduplicationFilter.resolveFalsePositiveProbability(1.0),
+                0.0
+        );
+        assertEquals(
+                DeduplicationFilter.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                DeduplicationFilter.resolveFalsePositiveProbability(-0.5),
+                0.0
+        );
+    }
+
+    @Test
+    public void validFalsePositiveProbabilityIsPreserved() {
+        assertEquals(0.001, DeduplicationFilter.resolveFalsePositiveProbability(0.001), 0.0);
+    }
+
+    private static LogEvent logEvent(final Level level, final String message) {
+        return Log4jLogEvent.newBuilder()
+                .setLevel(level)
+                .setMessage(new SimpleMessage(message))
+                .build();
+    }
+}


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Implemented a log4j filter that uses Guava's Bloom filter to check if a log message at certain level was already emitted, and then avoid to emit again. This filter can work both attaching to a logger or to an appender.

## Why is it important/What is the impact to the user?
Permit the user to configure the drop filter on lines that could be really noisy if repeated too much.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [ ]

## How to test this PR locally

1. configure a logger to use the filter:
    ```properties
    logger.periodic_flusher.name = org.logstash.execution.PeriodicFlush
    logger.periodic_flusher.level = DEBUG
    logger.periodic_flusher.filter.dedup.type = DeduplicationFilter
   ```
2. run Logstash with:
   ```shell
   bin/logstash -e 'input { generator { message => "test" } } output { sink{} }' --debug
   ```
3. verify that in logs the following line appear just once instead of every 5 seconds:
   ```
   [org.logstash.execution.PeriodicFlush][main] Pushing flush onto pipeline 
   ``` 

## Related issues

- Closes #19105 

