### PR TITLE
[Doc] Clarify API server TLS keystore auto-reload behavior

### DIFF
--- a/docs/reference/reloading-config.md
+++ b/docs/reference/reloading-config.md
@@ -75,7 +75,7 @@ For centralized pipeline management and legacy internal collection for monitorin
 This feature is not supported on Windows.
 :::
 
-Changes to the [Logstash API server](/reference/monitoring-logstash.md#monitoring-api-security) in the [`api.ssl.*`](/reference/logstash-settings-file.md) settings are not reloaded automatically. Restart Logstash to apply those changes.
+The Logstash API server automatically picks up changes to the keystore file referenced by `api.ssl.keystore.path`. Replacing the file on disk does not require restarting Logstash.
 
 
 ## Plugins that prevent automatic reloading [plugins-block-reload]

--- a/docs/reference/reloading-config.md
+++ b/docs/reference/reloading-config.md
@@ -75,7 +75,7 @@ For centralized pipeline management and legacy internal collection for monitorin
 This feature is not supported on Windows.
 :::
 
-The Logstash API server automatically picks up changes to the keystore file referenced by `api.ssl.keystore.path`. Replacing the file on disk does not require restarting Logstash.
+The [Logstash API server](/reference/monitoring-logstash.md#monitoring-api-security) supports the same behavior for its keystore file, regardless of `ssl.reload.automatic`. When the file referenced by `api.ssl.keystore.path` is replaced on disk, the API server uses the new certificate on subsequent client connections without requiring a Logstash restart.
 
 
 ## Plugins that prevent automatic reloading [plugins-block-reload]


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Corrects a note added in #19065 that claimed all `api.ssl.*` settings require a Logstash restart to take effect. In practice, the Logstash API server (JRuby Puma) re-reads the keystore file referenced by `api.ssl.keystore.path` on every new client connection, so replacing the file on disk does not require a restart.

The previous wording told users a restart was always needed to rotate the API server certificate. This PR replaces it with what actually happens.

## Author's Checklist

- [x] Docs-only change
- [x] Verified locally that replacing the PKCS12 file referenced by `api.ssl.keystore.path` is picked up by Puma on the next request, with no Logstash restart and no code change required on `main`.

<details>
<summary><b>How to test this puma cert rotation</b></summary>

**1. Generate two independently-rooted PKCS12 keystores under `/tmp/tls-test/`:**

```bash
mkdir -p /tmp/tls-test && cd /tmp/tls-test

for v in v1 v2; do
  # Self-signed CA
  openssl req -x509 -newkey rsa:2048 -days 3650 -nodes \
    -subj "/CN=Local Test CA $v" \
    -keyout ca-$v.key -out ca-$v.crt

  # Leaf key + CSR for localhost / 127.0.0.1
  openssl req -newkey rsa:2048 -nodes \
    -subj "/CN=localhost" \
    -keyout server-$v.key -out server-$v.csr

  # Sign the leaf with the CA
  openssl x509 -req -in server-$v.csr -CA ca-$v.crt -CAkey ca-$v.key \
    -CAcreateserial -days 3650 \
    -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1") \
    -out server-$v.crt

  # Bundle the leaf into a PKCS12 keystore
  openssl pkcs12 -export -in server-$v.crt -inkey server-$v.key \
    -out server-$v.p12 -name server-$v -password pass:changeit
done
```

This leaves `ca-v1.crt`, `ca-v2.crt`, `server-v1.p12`, and `server-v2.p12` under `/tmp/tls-test/`. Both keystores use the password `changeit`.

**2. Stage the v1 keystore and write Logstash settings:**

```bash
mkdir -p /tmp/tls-test/data
cp /tmp/tls-test/server-v1.p12 /tmp/tls-test/active.p12

cat > /tmp/tls-test/logstash.yml <<'EOF'
api.ssl.enabled: true
api.ssl.keystore.path: /tmp/tls-test/active.p12
api.ssl.keystore.password: changeit
EOF

cat > /tmp/tls-test/pipelines.yml <<'EOF'
- pipeline.id: main
  config.string: "input { generator { count => 0 } } output { stdout {} }"
EOF
```

**3. Start Logstash from the repo root and leave it running:**

```bash
bin/logstash --path.settings /tmp/tls-test --path.data /tmp/tls-test/data
```

**4. In a second terminal, confirm the v1 cert is in use:**

```bash
# Returns HTTP 200; server cert chains to ca-v1
curl -sS --cacert /tmp/tls-test/ca-v1.crt https://127.0.0.1:9600/

# Fails the SSL handshake; server cert does not chain to ca-v2
curl -sS --cacert /tmp/tls-test/ca-v2.crt https://127.0.0.1:9600/ ; echo "(expected handshake failure)"
```

**5. Atomic-replace the keystore on disk with the v2 version:**

```bash
cp /tmp/tls-test/server-v2.p12 /tmp/tls-test/active.p12.new
mv /tmp/tls-test/active.p12.new /tmp/tls-test/active.p12
```

**6. Re-run both probes immediately. With no Logstash restart in between, the chains should swap:**

```bash
# Now returns HTTP 200; server cert chains to ca-v2
curl -sS --cacert /tmp/tls-test/ca-v2.crt https://127.0.0.1:9600/

# Now fails the SSL handshake; server cert no longer chains to ca-v1
curl -sS --cacert /tmp/tls-test/ca-v1.crt https://127.0.0.1:9600/ ; echo "(expected handshake failure)"
```

</details>

## Related issues

- Relates #19057
- Follow-up to #19065
