### PR TITLE
Fix flaky `FileWatchServiceTest`

### DIFF
--- a/logstash-core/src/test/java/org/logstash/common/FileWatchServiceTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/FileWatchServiceTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
@@ -66,16 +65,16 @@ public class FileWatchServiceTest {
     @Test
     public void firesAllCallbacksForSameFile() throws Exception {
         File cert = tempDir.newFile("cert.pem");
-        AtomicInteger count = new AtomicInteger(0);
-        CountDownLatch latch = new CountDownLatch(2);
+        CountDownLatch first = new CountDownLatch(1);
+        CountDownLatch second = new CountDownLatch(1);
 
-        svc.register(cert.toPath(), event -> { count.incrementAndGet(); latch.countDown(); });
-        svc.register(cert.toPath(), event -> { count.incrementAndGet(); latch.countDown(); });
+        svc.register(cert.toPath(), event -> first.countDown());
+        svc.register(cert.toPath(), event -> second.countDown());
 
         Files.write(cert.toPath(), "updated".getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
 
-        assertTrue("not all callbacks fired within 3s", latch.await(3, TimeUnit.SECONDS));
-        assertEquals(2, count.get());
+        assertTrue("first callback not fired within 3s", first.await(3, TimeUnit.SECONDS));
+        assertTrue("second callback not fired within 3s", second.await(3, TimeUnit.SECONDS));
     }
 
     @Test
@@ -130,16 +129,14 @@ public class FileWatchServiceTest {
     @Test
     public void throwingCallbackDoesNotPreventSubsequentCallbacks() throws Exception {
         File cert = tempDir.newFile("cert.pem");
-        AtomicInteger count = new AtomicInteger(0);
         CountDownLatch latch = new CountDownLatch(1);
 
         svc.register(cert.toPath(), event -> { throw new RuntimeException("intentional test error"); });
-        svc.register(cert.toPath(), event -> { count.incrementAndGet(); latch.countDown(); });
+        svc.register(cert.toPath(), event -> latch.countDown());
 
         Files.write(cert.toPath(), "updated".getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
 
         assertTrue("second callback not fired within 3s", latch.await(3, TimeUnit.SECONDS));
-        assertEquals(1, count.get());
     }
 
     @Test


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

`FileWatchServiceTest` was added in #18978 alongside the `FileWatchService` itself. `firesAllCallbacksForSameFile` and `throwingCallbackDoesNotPreventSubsequentCallbacks` asserted exact callback counts after a single `Files.write`. `TRUNCATE_EXISTING` is truncate+write and inotify may surface those as two events, in which case each listener fires twice and the count check fails (4 vs 2).

Background services on the aarch64 CI AMI used to add enough I/O latency to coalesce the events. This was recently addressed in https://github.com/elastic/ci-agent-images/pull/2637 which removed that latency.

Replace the shared counter with a per-callback `CountDownLatch` so the tests assert that for the `FileWatchService` every registered callback is notified without depending on OS-level event coalescing.