### PR TITLE
Pin bundled json gem to 2.19.2

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -177,7 +177,7 @@ GEM
       semantic_logger
     jruby-openssl (0.16.0-java)
     jruby-stdin-channel (0.2.0-java)
-    json (2.18.1-java)
+    json (2.19.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
     kramdown (2.5.2)
@@ -873,6 +873,7 @@ DEPENDENCIES
   fpm (~> 1, >= 1.14.1)
   gems (~> 1)
   jar-dependencies (= 0.5.4)
+  json (~> 2.19.2)
   json-schema (~> 2)
   logstash-codec-avro
   logstash-codec-cef

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,4 +43,5 @@ gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
+gem "json", "~> 2.19.2" # Pin json to the maintained 2.19.x line
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Pin the bundled `json` gem to `2.19.2` on the 9.3 branch
