### PR TITLE
Remove un-needed json pin from gemfile template

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,5 +43,4 @@ gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "cgi", "~> 0.3.7" # Pins until a new jruby version with updated cgi is released (https://github.com/jruby/jruby/issues/8919)
-gem "json", "~> 2.19.2" # Pin json to the maintained 2.19.x line
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
This was added https://github.com/elastic/logstash/pull/19198 when a simple update in the vendored lockfile would acheive the same result. This commit removes the pin to avoid maintenence overhead.
