### PR TITLE
Fix unresolvable Gemfile lock on 8.19

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -125,9 +125,6 @@ GEM
       elasticsearch-api (= 8.19.3)
       ostruct
     elasticsearch-api (8.19.3)
-      elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.18.1)
-    elasticsearch-api (8.18.1)
       multi_json
     equalizer (0.0.11)
     erb (4.0.4.1-java)
@@ -191,7 +188,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    jwt (2.10.3)
+    jwt (3.2.0)
       base64
     kramdown (2.5.2)
       rexml (>= 3.4.4)


### PR DESCRIPTION
`Gemfile.jruby-3.1.lock.release` became an invalid [Bundler resolution](https://buildkite.com/elastic/logstash-linux-jdk-matrix-pipeline/builds/787) after the Elastic client alignment in #19190
