### PR TITLE
Pin i18n gem < 1.15.0 for JRuby 9.4.x compatibility

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 
-  gem.add_runtime_dependency "i18n", "~> 1" #(MIT license)
+  gem.add_runtime_dependency "i18n", "~> 1", "< 1.15.0" #(MIT license) pinned until JRuby 10+; i18n 1.15+ requires Ruby 3.2+
 
   gem.add_runtime_dependency "thwait"
 


### PR DESCRIPTION
Pin `i18n` gem to `< 1.15.0` to restore compatibility with JRuby 9.4.x (Ruby 3.1).

### Root cause

[i18n 1.15.0](https://rubygems.org/gems/i18n/versions/1.15.0) (released 2026-06-17) introduced [Fiber-backed config storage](https://github.com/ruby-i18n/i18n/commit/bfc992d8fe0a8fc74a7133c2948bd7cabf9af635) using `Fiber[]`, which requires Ruby 3.2+. However, i18n 1.15.0 incorrectly declares `required_ruby_version >= 3.1`, so Bundler resolves it for JRuby 9.4.x but it fails at runtime with:

```
NoMethodError: undefined method `[]' for Fiber:Class
```

i18n 1.15.1 corrected `required_ruby_version` to `>= 3.2`, but 1.15.0 is still installable on Ruby 3.1 and Bundler prefers it over 1.14.x since it satisfies `~> 1`.

This breaks all plugin CI jobs running against Logstash versions that ship JRuby 9.4.x (8.x, 9.3.x).