### PR TITLE
Revert "Pin i18n gem < 1.15.0 for JRuby 9.4.x compatibility"

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "treetop", "~> 1" #(MIT license)
 
-  gem.add_runtime_dependency "i18n", "~> 1", "< 1.15.0" #(MIT license) pinned until JRuby 10+; i18n 1.15+ requires Ruby 3.2+
+  gem.add_runtime_dependency "i18n", "~> 1" #(MIT license)
 
   gem.add_runtime_dependency "thwait"
 


### PR DESCRIPTION
Reverts elastic/logstash#19215

A release has been updated that restores 3.1 compatability https://github.com/ruby-i18n/i18n/commit/e4c806e513bf51f19c956fefbee38b5a105bebf8