### PR TITLE
Manually resolve lockfile for puma major version bump

### DIFF
--- a/Gemfile.jruby-3.1.lock.release
+++ b/Gemfile.jruby-3.1.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.19.17)
+      logstash-core (= 8.19.18)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (8.19.17-java)
+    logstash-core (8.19.18-java)
       clamp (~> 1, >= 1.3.3)
       concurrent-ruby (~> 1, < 1.1.10)
       down (~> 5.2.0)
@@ -21,7 +21,7 @@ PATH
       manticore (~> 0.6)
       minitar (~> 1)
       pry (~> 0.12)
-      puma (~> 6.3, >= 6.4.2)
+      puma (~> 8.0)
       rack (~> 3)
       ruby-maven-libs (~> 3, >= 3.8.9)
       rubyzip (~> 1)
@@ -46,7 +46,7 @@ GEM
     avro (1.10.2)
       multi_json (~> 1)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1261.0)
+    aws-partitions (1.1262.0)
     aws-sdk-cloudfront (1.150.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
@@ -183,7 +183,7 @@ GEM
     jruby-jms (1.3.0-java)
       gene_pool
       semantic_logger
-    jruby-openssl (0.16.0-java)
+    jruby-openssl (0.16.1-java)
     jruby-stdin-channel (0.2.0-java)
     json (2.12.2-java)
     json-schema (2.8.1)
@@ -758,7 +758,7 @@ GEM
       date
       jar-dependencies (>= 0.1.7)
     public_suffix (5.1.1)
-    puma (6.6.1-java)
+    puma (8.0.2-java)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1-java)


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

When https://github.com/elastic/logstash/pull/19227 was merged, it missed updating the lockfile. This resulted in the puma 6 still ending up in artifacts despite the logstash-core gemspec. When the version bump workflow for bumping patch versions ran the older bundler version was unable to respect --patch level. See https://github.com/elastic/logstash/pull/19241. Newer bundler versions ARE able to respect --patch when a major version changes in the gemspec. This commit updates puma and other gems at patch level by first updating puma with the newer bundler, then doing the patch updates and AWS gems at minor level: The exact steps are: 

```
# Seed the local lockfile with the "broken" one checked in upstream (with old puma and the full set of gems to be considered)
git show upstream/8.19:Gemfile.jruby-3.1.lock.release > Gemfile.lock

# Cross the puma major boundary cleanly with bundler 2.6.3
./vendor/jruby/bin/jruby -S bundle _2.6.3_ lock --update=puma

# patch everything else with 2.6.3
./vendor/jruby/bin/jruby -S bundle _2.6.3_ lock --update --patch --strict

# aws-minor pass (mirrors the workflow step)
./vendor/jruby/bin/jruby -S bundle _2.6.3_ install
AWS_GEMS=$(./vendor/jruby/bin/jruby -S bundle _2.6.3_ list --name-only | grep '^aws-')
GEMS=$(echo "${AWS_GEMS}" | xargs)
./vendor/jruby/bin/jruby -S bundle _2.6.3_ update ${=GEMS} --minor --strict --conservative

# settle/re-stamp with 2.3.26 and strip env-specific platform line
./vendor/jruby/bin/jruby -S bundle _2.3.26_ lock
sed -i '' -E '/^  universal-java-21$/d' Gemfile.lock
sed -i '' -E 's/^   2\.6\.3$/   2.3.26/' Gemfile.lock

# 5. promote to the tracked release lock + verify
cp Gemfile.lock Gemfile.jruby-3.1.lock.release
```