### PR TITLE
Bump jackson and jrjackson dependencies

### DIFF
--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -754,7 +754,7 @@ http://www.apache.org/licenses/LICENSE-2.0
    limitations under the License.
 
 ==========
-Notice for: com.fasterxml.jackson.core:jackson-core-2.21.2
+Notice for: com.fasterxml.jackson.core:jackson-core-2.21.4
 ----------
 
 # Jackson JSON processor
@@ -981,7 +981,7 @@ from the source code management (SCM) system project uses.
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========
-Notice for: com.fasterxml.jackson.core:jackson-databind-2.21.2
+Notice for: com.fasterxml.jackson.core:jackson-databind-2.21.4
 ----------
 
 # Jackson JSON processor
@@ -1217,7 +1217,7 @@ http://www.apache.org/licenses/LICENSE-2.0
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========
-Notice for: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor-2.21.2
+Notice for: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor-2.21.4
 ----------
 
 This copy of Jackson JSON processor databind module is licensed under the
@@ -1432,7 +1432,7 @@ http://www.apache.org/licenses/LICENSE-2.0
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========
-Notice for: com.fasterxml.jackson.module:jackson-module-afterburner-2.21.2
+Notice for: com.fasterxml.jackson.module:jackson-module-afterburner-2.21.4
 ----------
 
 This copy of Jackson JSON processor databind module is licensed under the
@@ -3924,10 +3924,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========
-Notice for: jrjackson-0.5.0
+Notice for: jrjackson-0.5.0.1
 ----------
 
-https://github.com/guyboertje/jrjackson/blob/v0.5.0/README.md
+https://github.com/guyboertje/jrjackson/blob/v0.5.0.1/README.md
 
 LICENSE applicable to this library:
 

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -3924,10 +3924,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========
-Notice for: jrjackson-0.5.1
+Notice for: jrjackson-0.5.2
 ----------
 
-https://github.com/guyboertje/jrjackson/blob/v0.5.1/README.md
+https://github.com/guyboertje/jrjackson/blob/v0.5.2/README.md
 
 LICENSE applicable to this library:
 

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -3924,10 +3924,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========
-Notice for: jrjackson-0.5.0.1
+Notice for: jrjackson-0.5.1
 ----------
 
-https://github.com/guyboertje/jrjackson/blob/v0.5.0.1/README.md
+https://github.com/guyboertje/jrjackson/blob/v0.5.1/README.md
 
 LICENSE applicable to this library:
 

--- a/versions.yml
+++ b/versions.yml
@@ -27,7 +27,7 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.5.0
-jackson: 2.21.2
-jackson-databind: 2.21.2
+jrjackson: 0.5.0.1
+jackson: 2.21.4
+jackson-databind: 2.21.4
 jackson-annotations: 2.21 # standalone release without a patch version

--- a/versions.yml
+++ b/versions.yml
@@ -27,7 +27,7 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.5.0.1
+jrjackson: 0.5.1
 jackson: 2.21.4
 jackson-databind: 2.21.4
 jackson-annotations: 2.21 # standalone release without a patch version

--- a/versions.yml
+++ b/versions.yml
@@ -27,7 +27,7 @@ jruby:
 # Note: this file is copied to the root of logstash-core because its gemspec needs it when
 #       bundler evaluates the gemspec via bin/logstash
 # Ensure Jackson version here is kept in sync with version used by jrjackson gem
-jrjackson: 0.5.1
+jrjackson: 0.5.2
 jackson: 2.21.4
 jackson-databind: 2.21.4
 jackson-annotations: 2.21 # standalone release without a patch version


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Update jackson-databind to 2.21.4

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

Updates jackson dep stack to latest patched version. 


NOTE: 

Depends on https://github.com/guyboertje/jrjackson/pull/101 and a release there. 