### PR TITLE
Update jruby to 10.0.6.0

### DIFF
--- a/logstash-core/src/test/java/org/logstash/log/RubyBasicObjectSerializerTest.java
+++ b/logstash-core/src/test/java/org/logstash/log/RubyBasicObjectSerializerTest.java
@@ -76,7 +76,7 @@ public class RubyBasicObjectSerializerTest {
     @Test
     public void testSerializationWithRubyArrayValue() throws JsonProcessingException {
         final ThreadContext context = RUBY.getCurrentContext();
-        final RubyArray<RubySymbol> rubyArray = new RubyArray<>(RUBY, 2);
+        final RubyArray<?> rubyArray = RubyArray.newArray(context, 2);
         rubyArray.push(context, RubySymbol.newSymbol(RUBY, "one"));
         rubyArray.push(context, RubySymbol.newSymbol(RUBY, "two"));
 

--- a/versions.yml
+++ b/versions.yml
@@ -16,8 +16,8 @@ bundled_jdk:
 # jruby must reference a *released* version of jruby which can be downloaded from the official download url
 # *and* for which jars artifacts are published for compile-time
 jruby:
-  version: 10.0.5.0
-  sha256: 6b3aa0340bd60a2b131e12490bb498c45359d9c91e477f5760c3aa18e37d1988
+  version: 10.0.6.0
+  sha256: 58c0d10b8a6b0b74a6119109f094ce073a6a6e813c7368c3876d71967e3a877f
 # jruby-runtime-override, if specified, will override the jruby version installed in vendor/jruby
 #jruby-runtime-override:
 #  url: https://oss.sonatype.org/content/repositories/snapshots/org/jruby/jruby-dist/9.3.0.0-SNAPSHOT/jruby-dist-9.3.0.0-20210723.214927-259-bin.tar.gz


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Update jruby to 10.0.6.0

## What does this PR do?
Take up the latest 10.0 jruby release. Reference: https://github.com/jruby/jruby/releases/tag/10.0.6.0

Closes https://github.com/elastic/ingest-dev/issues/8650