### PR TITLE
Log JVM UseCompressedOops status at startup

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -307,6 +307,15 @@ class LogStash::Runner < Clamp::StrictCommand
     jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     logger.info "JVM bootstrap flags: #{jvmArgs}"
 
+    begin
+      hotspot_diagnostic_bean = ManagementFactory.getPlatformMXBean(com.sun.management.HotSpotDiagnosticMXBean.java_class)
+      compressed_oops = hotspot_diagnostic_bean.getVMOption("UseCompressedOops").getValue()
+      max_heap_size = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()
+      logger.info("Compressed ordinary object pointers (oops)", "heap.max" => max_heap_size, "compressed_oops" => compressed_oops)
+    rescue => e
+      logger.debug("Could not determine JVM UseCompressedOops setting", "exception" => e.message)
+    end
+
 
     # Verify the Jackson defaults
     LogStash::Util::Jackson.verify_jackson_overrides

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -267,6 +267,7 @@ class LogStash::Runner < Clamp::StrictCommand
     LogStash::Util::SettingsHelper.post_process
 
     require "logstash/util"
+    require "logstash/util/byte_value"
     require "logstash/util/java_version"
     require "stud/task"
 
@@ -311,9 +312,9 @@ class LogStash::Runner < Clamp::StrictCommand
       hotspot_diagnostic_bean = ManagementFactory.getPlatformMXBean(com.sun.management.HotSpotDiagnosticMXBean.java_class)
       compressed_oops = hotspot_diagnostic_bean.getVMOption("UseCompressedOops").getValue()
       max_heap_size = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()
-      logger.info("Compressed ordinary object pointers (oops)", "heap.max" => max_heap_size, "compressed_oops" => compressed_oops)
+      logger.info("Compressed ordinary object pointers (oops)", "max_heap_size" => LogStash::Util::ByteValue.human_readable(max_heap_size), "compressed_oops" => compressed_oops)
     rescue => e
-      logger.debug("Could not determine JVM UseCompressedOops setting", "exception" => e.message)
+      logger.warn("Could not determine if JVM uses compressed object pointers representation. This is generally used to save memory, but doesn't impact Logstash functionalities.", "exception" => e.message)
     end
 
 

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -639,7 +639,7 @@ describe LogStash::Runner do
     let(:args) { ["-t", "-e", "input { } output { }"] }
 
     it "logs whether compressed ordinary object pointers are enabled" do
-      expect(logger).to receive(:info).with("Compressed ordinary object pointers (oops)", hash_including("compressed_oops" => a_string_matching(/\Atrue|false\z/)))
+      expect(logger).to receive(:info).with("Compressed ordinary object pointers (oops)", hash_including("compressed_oops" => a_string_matching(/\A(?:true|false)\z/)))
       expect(subject.run(args)).to eq(0)
     end
   end

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -633,4 +633,14 @@ describe LogStash::Runner do
       end
     end
   end
+
+  describe "logging the JVM UseCompressedOops setting" do
+    subject { LogStash::Runner.new("") }
+    let(:args) { ["-t", "-e", "input { } output { }"] }
+
+    it "logs whether compressed ordinary object pointers are enabled" do
+      expect(logger).to receive(:info).with("Compressed ordinary object pointers (oops)", hash_including("compressed_oops" => a_string_matching(/\Atrue|false\z/)))
+      expect(subject.run(args)).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Log JVM UseCompressedOops status at startup, standardizes with Elasticsearch's startup logging, which surfaces whether compressed ordinary object pointers are enabled or disabled based on the configured heap size.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

```bash
bin/logstash -e 'input { generator { count => 1 } } output { stdout {} }'
```

Check the startup logs.

To confirm the value flips to `false` above the ~32GB compressed-oops threshold (needs a machine with enough RAM):

```bash
LS_JAVA_OPTS="-Xms33g -Xmx33g" bin/logstash -e 'input { generator { count => 1 } } output { stdout {} }'
```

Unit test coverage:

```
bin/rspec logstash-core/spec/logstash/runner_spec.rb -e "logging the JVM UseCompressedOops setting"
```

## Related issues

- Fixes https://github.com/elastic/logstash/issues/19246.

## Logs

```
[2026-07-13T08:32:46,731][INFO ][logstash.runner          ] Compressed ordinary object pointers (oops) {"max_heap_size" => "1024mb", "compressed_oops" => "true"}

[2026-07-13T13:19:20,922][INFO ][logstash.runner          ] Compressed ordinary object pointers (oops) {"max_heap_size" => "33gb", "compressed_oops" => "false"}
```
