### PR TITLE
Upgrade concurrent-ruby dependency by removing TimerTask timeout_interval usage

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
@@ -24,7 +24,6 @@ module LogStash module Instrument module PeriodicPoller
 
     DEFAULT_OPTIONS = {
       :polling_interval => 5,
-      :polling_timeout => 120
     }
 
     attr_reader :metric
@@ -39,25 +38,12 @@ module LogStash module Instrument module PeriodicPoller
     def update(time, result, exception)
       return unless exception
 
-      if exception.is_a?(Concurrent::TimeoutError)
-        # On a busy system this can happen, we just log it as a debug
-        # event instead of an error, Some of the JVM calls can take a long time or block.
-        logger.debug("Timeout exception",
-                :poller => self,
-                :result => result,
-                :polling_timeout => @options[:polling_timeout],
-                :polling_interval => @options[:polling_interval],
-                :exception => exception.class,
-                :executed_at => time)
-      else
-        logger.error("Exception",
-                :poller => self,
-                :result => result,
-                :exception => exception.class,
-                :polling_timeout => @options[:polling_timeout],
-                :polling_interval => @options[:polling_interval],
-                :executed_at => time)
-      end
+      logger.error("Exception",
+              :poller => self,
+              :result => result,
+              :exception => exception.class,
+              :polling_interval => @options[:polling_interval],
+              :executed_at => time)
     end
 
     def collect
@@ -66,8 +52,7 @@ module LogStash module Instrument module PeriodicPoller
 
     def start
       logger.debug("Starting",
-                   :polling_interval => @options[:polling_interval],
-                   :polling_timeout => @options[:polling_timeout]) if logger.debug?
+                   :polling_interval => @options[:polling_interval]) if logger.debug?
 
       collect # Collect data right away if possible
       @task.execute
@@ -82,7 +67,6 @@ module LogStash module Instrument module PeriodicPoller
     def configure_task
       @task = Concurrent::TimerTask.new { collect }
       @task.execution_interval = @options[:polling_interval]
-      @task.timeout_interval = @options[:polling_timeout]
       @task.add_observer(self)
     end
   end

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "clamp", "~> 1", ">= 1.3.3" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "~> 0.2" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 1"  #(MIT license)
-  gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
+  gem.add_runtime_dependency "concurrent-ruby", "~> 1"
   gem.add_runtime_dependency "rack", '~> 3'
   gem.add_runtime_dependency "sinatra", '~> 4'
   gem.add_runtime_dependency 'puma', '~> 8.0'
@@ -78,7 +78,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "multi_json", "~> 1.19.1" # pinned until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2
+  gem.add_runtime_dependency "multi_json", "~> 1"
   gem.add_runtime_dependency "elasticsearch", '>= 8', '< 10'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 

--- a/logstash-core/spec/logstash/instrument/periodic_poller/base_spec.rb
+++ b/logstash-core/spec/logstash/instrument/periodic_poller/base_spec.rb
@@ -24,24 +24,31 @@ describe LogStash::Instrument::PeriodicPoller::Base do
 
   subject { described_class.new(metric, options) }
 
-  describe "#update" do
-    it "logs an timeout exception to debug level" do
-      exception = Concurrent::TimeoutError.new
-      expect(subject.logger).to receive(:debug).with(anything, hash_including(:exception => exception.class))
-      subject.update(Time.now, "hola", exception)
+  describe "#configure_task" do
+    it "creates a TimerTask without a timeout_interval" do
+      task = subject.instance_variable_get(:@task)
+      expect(task).to be_a(Concurrent::TimerTask)
+      expect(task.timeout_interval).to be_nil
     end
 
-    it "logs any other exception to error level" do
+    it "sets the execution_interval from options" do
+      custom = described_class.new(metric, :polling_interval => 42)
+      task = custom.instance_variable_get(:@task)
+      expect(task.execution_interval).to eq(42)
+    end
+  end
+
+  describe "#update" do
+    it "logs any exception to error level" do
       exception = Class.new
       expect(subject.logger).to receive(:error).with(anything, hash_including(:exception => exception.class))
       subject.update(Time.now, "hola", exception)
     end
 
     it "doesnt log anything when no exception is received" do
-      exception = Concurrent::TimeoutError.new
       expect(subject.logger).not_to receive(:debug).with(anything)
       expect(subject.logger).not_to receive(:error).with(anything)
-      subject.update(Time.now, "hola", exception)
+      subject.update(Time.now, "hola", nil)
     end
   end
 end

--- a/x-pack/lib/monitoring/inputs/metrics.rb
+++ b/x-pack/lib/monitoring/inputs/metrics.rb
@@ -30,9 +30,10 @@ module LogStash module Inputs
     # Polling frequency in seconds on the metric store
     config :collection_interval, :type => :integer, :default => 10
 
-    # Maximum time in seconds a polling iteration of the metric store can take before it dies
-    # When it dies, the snapshot will wait the `collection_interval` before doing another snapshot.
-    config :collection_timeout_interval, :type => :integer, :default => 10 * 60
+    # @deprecated This setting is no longer effective. TimerTask timeouts were removed in
+    #   concurrent-ruby 1.1.10 because they caused thread leaks via unsafe Thread#raise.
+    #   See: https://github.com/ruby-concurrency/concurrent-ruby/pull/926
+    config :collection_timeout_interval, :type => :integer, :default => 10 * 60, :deprecated => "This setting no longer has any effect and will be removed in a future release."
 
     # Collect per-plugin / queue / other component stats
     config :extended_performance_collection, :type => :boolean, :default => true
@@ -56,8 +57,7 @@ module LogStash module Inputs
 
     def configure_snapshot_poller
       @timer_task = Concurrent::TimerTask.new({
-        :execution_interval => @collection_interval,
-        :timeout_interval => @collection_timeout_interval
+        :execution_interval => @collection_interval
       }) do
         update(metric.collector.snapshot_metric) unless @agent.nil?
       end

--- a/x-pack/lib/monitoring/monitoring.rb
+++ b/x-pack/lib/monitoring/monitoring.rb
@@ -143,6 +143,14 @@ module LogStash
             "https://www.elastic.co/guide/en/logstash/current/monitoring-with-elastic-agent.html"
             )
 
+        if runner.settings.set?("xpack.monitoring.collection.timeout_interval") ||
+           runner.settings.set?("monitoring.collection.timeout_interval")
+          deprecation_logger.deprecated(
+            "The setting `monitoring.collection.timeout_interval` has no effect and will be removed in a future release. " \
+            "Timeout enforcement on monitoring collection was removed because it relied on an unsafe threading mechanism."
+          )
+        end
+
         logger.trace("registering the metrics pipeline")
         LogStash::SETTINGS.set("node.uuid", runner.agent.id)
         internal_pipeline_source = LogStash::Monitoring::InternalPipelineSource.new(setup_metrics_pipeline, runner.agent, LogStash::SETTINGS.clone, runner.ssl_file_tracker)

--- a/x-pack/lib/template.cfg.erb
+++ b/x-pack/lib/template.cfg.erb
@@ -5,7 +5,6 @@
 input {
   metrics {
     collection_interval => <%= collection_interval %>
-    collection_timeout_interval => <%= collection_timeout_interval %>
     extended_performance_collection => <%= extended_performance_collection? %>
     config_collection => <%= config_collection? %>
   }

--- a/x-pack/spec/monitoring/inputs/metrics_spec.rb
+++ b/x-pack/spec/monitoring/inputs/metrics_spec.rb
@@ -14,8 +14,7 @@ require 'monitoring/monitoring'
 
 describe LogStash::Inputs::Metrics do
   let(:xpack_monitoring_interval) { 1 }
-  let(:options) { { "collection_interval" => xpack_monitoring_interval,
-                      "collection_timeout_interval" => 600 } }
+  let(:options) { { "collection_interval" => xpack_monitoring_interval } }
   let(:elasticsearch_url) { nil }
   let(:elasticsearch_username) { nil }
   let(:elasticsearch_password) { nil }

--- a/x-pack/spec/monitoring/internal_pipeline_source_spec.rb
+++ b/x-pack/spec/monitoring/internal_pipeline_source_spec.rb
@@ -18,8 +18,7 @@ require 'monitoring/monitoring'
 describe LogStash::Monitoring::InternalPipelineSource do
   context 'license testing' do
     let(:xpack_monitoring_interval) { 1 }
-    let(:options) { { "collection_interval" => xpack_monitoring_interval,
-                        "collection_timeout_interval" => 600 } }
+    let(:options) { { "collection_interval" => xpack_monitoring_interval } }
 
     subject { described_class.new(pipeline_config, mock_agent, system_settings) }
     let(:mock_agent) { double("agent")}


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- enhancement
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Removes all usage of `Concurrent::TimerTask#timeout_interval` from Logstash and lifts the dependency pins on `concurrent-ruby` (from `"~> 1", "< 1.1.10"` to `"~> 1"`) and `multi_json` (from `"~> 1.19.1"` to `"~> 1"`).

Specifically:

- Removed `polling_timeout` and `Concurrent::TimeoutError` handling from `periodic_poller/base.rb`
- Removed `:timeout_interval` from the monitoring `TimerTask` in metrics.rb
- Removed collection_timeout_interval
- Added deprecation warnings for users who still have `monitoring.collection.timeout_interval` in their config
- Updated tests to reflect the removal
This upgrades concurrent-ruby 1.1.9 → 1.3.7 and multi_json 1.19.1 → 1.21.1.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

## Why is it important/What is the impact to the user?

`TimerTask#timeout_interval` was [removed in concurrent-ruby 1.1.10](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v1110-22-mar-2022) because it used `Thread#raise` to interrupt tasks, which is [fundamentally unsafe](https://github.com/ruby-concurrency/concurrent-ruby/pull/926), it can leak threads, corrupt data, and leave mutexes locked ([#639](https://github.com/ruby-concurrency/concurrent-ruby/issues/639)). Setting `timeout_interval` since 1.1.10 is a [no-op that prints a warning](https://github.com/ruby-concurrency/concurrent-ruby/commit/bc3813df7565e59eb352d0e408b48001c783aa15). Logstash was pinned below 1.1.10 to avoid that warning ([#13956](https://github.com/elastic/logstash/issues/13956)), this PR cleans up related unnecessary code.

**User impact**: No behavioral change, the timeout was already unsafe and ineffective. Users with `monitoring.collection.timeout_interval` in `logstash.yml` will see a deprecation warning; they can safely remove the setting. Lifting the pin unblocks dependency upgrades across the gem tree (`concurrent_ruby` and `multi_json`).

Resolves [#19247](https://github.com/elastic/logstash/issues/19247).
<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [X] I have added tests that prove my fix is effective or that my feature works


## Logs

```log
[WARN ][deprecation.logstash.monitoringextension.pipelineregisterhook] The setting `monitoring.collection.timeout_interval` has no effect and will be removed in a future release. Timeout enforcement on monitoring collection was removed because it relied on an unsafe threading mechanism.
```
<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
