### PR TITLE
[9.5 release] Copy gemfile.lock from 9.4

### DIFF
--- a/Gemfile.jruby-3.4.lock.release
+++ b/Gemfile.jruby-3.4.lock.release
@@ -2,12 +2,12 @@ PATH
   remote: logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 9.4.4)
+      logstash-core (= 9.5.0)
 
 PATH
   remote: logstash-core
   specs:
-    logstash-core (9.4.4-java)
+    logstash-core (9.5.0-java)
       clamp (~> 1, >= 1.3.3)
       concurrent-ruby (~> 1, < 1.1.10)
       csv (~> 3.0)
@@ -46,11 +46,11 @@ GEM
     avro (1.10.2)
       multi_json (~> 1)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1262.0)
+    aws-partitions (1.1266.0)
     aws-sdk-cloudfront (1.150.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-cloudwatch (1.141.0)
+    aws-sdk-cloudwatch (1.142.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-core (3.252.0)
@@ -84,7 +84,7 @@ GEM
     base64 (0.3.0)
     belzebuth (0.2.3)
       childprocess
-    benchmark-ips (2.14.0)
+    benchmark-ips (2.15.1)
     bigdecimal (3.3.1-java)
     bindata (2.5.1)
     buftok (0.2.0)
@@ -117,11 +117,11 @@ GEM
     elastic-transport (8.5.3)
       faraday (< 3)
       multi_json
-    elasticsearch (8.19.3)
+    elasticsearch (9.4.3)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.19.3)
-      ostruct
-    elasticsearch-api (8.19.3)
+      elasticsearch-api (= 9.4.3)
+    elasticsearch-api (9.4.3)
+      base64
       multi_json
     equalizer (0.0.11)
     et-orbi (1.4.0)
@@ -145,7 +145,7 @@ GEM
       pleaserun (~> 0.0.29)
       rexml
       stud
-    fugit (1.12.2)
+    fugit (1.12.3)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     gelfd2 (0.4.1)
@@ -164,7 +164,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_parser.rb (0.6.0-java)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     insist (1.0.0)
     io-console (0.8.2-java)
@@ -181,12 +181,12 @@ GEM
       semantic_logger
     jruby-openssl (0.16.1-java)
     jruby-stdin-channel (0.2.0-java)
-    json (2.19.9-java)
+    json (2.20.0-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
-    language_server-protocol (3.17.0.5)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     logstash-codec-avro (3.5.0-java)
@@ -309,8 +309,8 @@ GEM
     logstash-filter-elastic_integration (9.4.4-java)
       logstash-core (>= 8.7.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-filter-elasticsearch (4.3.1)
-      elasticsearch (>= 7.14.9, < 9)
+    logstash-filter-elasticsearch (4.4.1)
+      elasticsearch (>= 8, < 10)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
@@ -395,7 +395,7 @@ GEM
       logstash-codec-plain
       logstash-core-plugin-api (~> 2.0)
       stud (>= 0.0.22)
-    logstash-input-beats (7.0.11-java)
+    logstash-input-beats (7.0.12-java)
       concurrent-ruby (~> 1.0)
       logstash-codec-multiline (>= 2.0.5)
       logstash-codec-plain
@@ -420,8 +420,8 @@ GEM
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       logstash-mixin-normalize_config_support (~> 1.0)
       logstash-mixin-plugin_factory_support
-    logstash-input-elasticsearch (5.2.2)
-      elasticsearch (>= 7.17.9, < 9)
+    logstash-input-elasticsearch (5.3.2)
+      elasticsearch (>= 8, < 10)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
@@ -468,7 +468,7 @@ GEM
       logstash-mixin-ecs_compatibility_support (~> 1.2)
       logstash-mixin-event_support (~> 1.0)
       stud
-    logstash-input-http (4.1.10-java)
+    logstash-input-http (4.1.11-java)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.2)
@@ -567,7 +567,7 @@ GEM
       sequel (>= 5.74.0)
       tzinfo
       tzinfo-data
-    logstash-integration-kafka (11.8.10-java)
+    logstash-integration-kafka (12.1.5-java)
       logstash-codec-json
       logstash-codec-plain
       logstash-core (>= 8.3.0)
@@ -590,7 +590,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       march_hare (~> 4.0)
       stud (~> 0.0.22)
-    logstash-integration-snmp (4.2.2-java)
+    logstash-integration-snmp (4.3.1-java)
       logstash-codec-plain
       logstash-core (>= 6.5.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -623,7 +623,7 @@ GEM
     logstash-output-csv (3.0.11)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-output-file
-    logstash-output-elasticsearch (12.1.3-java)
+    logstash-output-elasticsearch (12.1.6-java)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
       logstash-mixin-deprecation_logger_support (~> 1.0)
@@ -654,9 +654,6 @@ GEM
     logstash-output-null (3.0.5)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
-    logstash-output-pipe (3.0.7)
-      logstash-codec-plain
-      logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-output-redis (5.2.0)
       logstash-core (>= 6.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -671,7 +668,7 @@ GEM
       logstash-core (>= 8.1.0)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       stud
-    logstash-output-udp (3.2.0)
+    logstash-output-udp (3.3.0)
       logstash-codec-json
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     logstash-output-webhdfs (3.1.1-java)
@@ -680,7 +677,7 @@ GEM
     logstash-patterns-core (4.3.4)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
     lru_redux (1.1.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -703,8 +700,7 @@ GEM
     multipart-post (2.4.1)
     murmurhash3 (0.1.6-java)
     mustache (0.99.8)
-    mustermann (3.0.4)
-      ruby2_keywords (~> 0.0.1)
+    mustermann (3.1.1)
     naught (1.1.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -725,7 +721,6 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     openssl_pkcs8_pure (0.0.0.2)
-    ostruct (0.6.3)
     paquet (0.2.1)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -744,7 +739,7 @@ GEM
       method_source (~> 1.0)
       reline (>= 0.6.0)
       spoon (~> 0.0)
-    psych (5.3.1-java)
+    psych (5.4.0-java)
       date
       jar-dependencies (>= 0.1.7)
     public_suffix (5.1.1)
@@ -763,7 +758,7 @@ GEM
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     redis (4.8.1)
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -798,7 +793,6 @@ GEM
     rubocop-ast (1.42.0)
       parser (>= 3.3.7.2)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
@@ -807,7 +801,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     semantic_logger (3.4.1)
       concurrent-ruby (~> 1.0)
-    sequel (5.103.0)
+    sequel (5.106.0)
       bigdecimal
     simple_oauth (0.3.1)
     simplecov (0.22.0)
@@ -972,7 +966,6 @@ DEPENDENCIES
   logstash-output-lumberjack
   logstash-output-nagios
   logstash-output-null
-  logstash-output-pipe
   logstash-output-redis
   logstash-output-stdout
   logstash-output-tcp

--- a/Gemfile.jruby-3.4.lock.release
+++ b/Gemfile.jruby-3.4.lock.release
@@ -1,0 +1,1002 @@
+PATH
+  remote: logstash-core-plugin-api
+  specs:
+    logstash-core-plugin-api (2.1.16-java)
+      logstash-core (= 9.4.4)
+
+PATH
+  remote: logstash-core
+  specs:
+    logstash-core (9.4.4-java)
+      clamp (~> 1, >= 1.3.3)
+      concurrent-ruby (~> 1, < 1.1.10)
+      csv (~> 3.0)
+      down (~> 5.2.0)
+      elasticsearch (>= 8, < 10)
+      filesize (~> 0.2)
+      gems (~> 1)
+      i18n (~> 1)
+      jrjackson (= 0.5.0)
+      manticore (~> 0.6)
+      minitar (~> 1)
+      multi_json (~> 1.19.1)
+      observer (~> 0.1)
+      pry (~> 0.12)
+      puma (~> 8.0)
+      rack (~> 3)
+      rubyzip (~> 1)
+      sinatra (~> 4)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.6)
+      thwait
+      treetop (~> 1)
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    amazing_print (1.8.1)
+    arr-pm (0.0.12)
+    ast (2.4.3)
+    atomic (1.1.101-java)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
+    avro (1.10.2)
+      multi_json (~> 1)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1262.0)
+    aws-sdk-cloudfront (1.150.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-cloudwatch (1.141.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-core (3.252.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.129.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-resourcegroups (1.99.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.226.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sns (1.117.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.116.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    back_pressure (1.0.0)
+    backports (3.25.3)
+    base64 (0.3.0)
+    belzebuth (0.2.3)
+      childprocess
+    benchmark-ips (2.14.0)
+    bigdecimal (3.3.1-java)
+    bindata (2.5.1)
+    buftok (0.2.0)
+    builder (3.3.0)
+    cabin (0.9.1)
+    childprocess (4.1.0)
+    ci_reporter (2.1.0)
+      builder (>= 2.1.2)
+      rexml
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    clamp (1.5.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    csv (3.3.5)
+    dalli (3.2.8)
+    date (3.3.3-java)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    domain_name (0.6.20240107)
+    dotenv (2.8.1)
+    down (5.2.4)
+      addressable (~> 2.8)
+    e2mmap (0.1.0)
+    edn (1.1.1)
+    elastic-transport (8.5.3)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.19.3)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.19.3)
+      ostruct
+    elasticsearch-api (8.19.3)
+      multi_json
+    equalizer (0.0.11)
+    et-orbi (1.4.0)
+      tzinfo
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    ffi (1.17.4-java)
+    filesize (0.2.0)
+    fileutils (1.8.0)
+    fivemat (1.3.7)
+    flores (0.0.8)
+    fpm (1.17.0)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.9.1)
+      clamp (>= 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
+    gelfd2 (0.4.1)
+    gem_publisher (1.5.0)
+    gems (1.3.0)
+    gene_pool (1.5.0)
+      concurrent-ruby (>= 1.0)
+    hashdiff (1.2.1)
+    hitimes (1.3.1-java)
+    http (3.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.1.6)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0-java)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    insist (1.0.0)
+    io-console (0.8.2-java)
+    jar-dependencies (0.5.4)
+    jls-grok (0.11.5)
+      cabin (>= 0.6.0)
+    jls-lumberjack (0.0.26)
+      concurrent-ruby
+    jmespath (1.6.2)
+    jrjackson (0.5.0-java)
+      bigdecimal
+    jruby-jms (1.3.0-java)
+      gene_pool
+      semantic_logger
+    jruby-openssl (0.16.1-java)
+    jruby-stdin-channel (0.2.0-java)
+    json (2.19.9-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    logstash-codec-avro (3.5.0-java)
+      avro (~> 1.10.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+    logstash-codec-cef (6.2.8-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-collectd (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-dots (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-codec-edn (3.1.0)
+      edn
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-edn_lines (3.1.0)
+      edn
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-es_bulk (3.1.0)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-fluent (3.4.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-graphite (3.0.6)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-json (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-json_lines (3.2.2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-codec-line (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-msgpack (3.1.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      msgpack (~> 1.1)
+    logstash-codec-multiline (3.1.2)
+      concurrent-ruby
+      jls-grok (~> 0.11.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-patterns-core
+    logstash-codec-netflow (4.3.4)
+      bindata (>= 1.5.0)
+      logstash-core-plugin-api (~> 2.0)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-plain (3.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+    logstash-codec-rubydebug (3.1.0)
+      amazing_print (~> 1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-devutils (2.6.3-java)
+      fivemat
+      gem_publisher
+      kramdown (~> 2)
+      logstash-codec-plain
+      logstash-core (>= 6.3)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    logstash-filter-aggregate (2.11.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-anonymize (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-cidr (3.2.0-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-clone (4.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.1)
+    logstash-filter-csv (3.1.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-date (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-de_dot (1.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-dissect (1.3.0)
+      logstash-core-plugin-api (>= 2.1.1, <= 2.99)
+    logstash-filter-dns (3.2.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      lru_redux (~> 1.1.0)
+    logstash-filter-drop (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elastic_integration (9.4.4-java)
+      logstash-core (>= 8.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-elasticsearch (4.3.1)
+      elasticsearch (>= 7.14.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+    logstash-filter-fingerprint (3.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      murmurhash3 (= 0.1.6)
+    logstash-filter-geoip (8.0.0-java)
+      logstash-core (>= 8.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-filter-grok (4.4.4)
+      jls-grok (~> 0.11.3)
+      logstash-core (>= 5.6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-patterns-core (>= 4.3.0, < 5)
+      stud (~> 0.0.22)
+    logstash-filter-http (2.0.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-json (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-kv (4.7.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-filter-memcached (1.2.0)
+      dalli (~> 3)
+      logstash-core-plugin-api (~> 2.0)
+    logstash-filter-metrics (4.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      metriks
+      thread_safe
+    logstash-filter-mutate (3.6.0)
+      bigdecimal
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-prune (3.0.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-ruby (3.1.8)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-sleep (3.0.7)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-split (3.1.10)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-syslog_pri (3.2.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-throttle (4.0.4)
+      atomic
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      thread_safe
+    logstash-filter-translate (3.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      psych (>= 5.1.0)
+    logstash-filter-truncate (1.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-urldecode (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-useragent (3.3.5-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-filter-uuid (3.0.5)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-filter-xml (4.3.2)
+      logstash-core (>= 8.15.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      nokogiri (>= 1.18.9)
+      xml-simple
+    logstash-input-azure_event_hubs (1.5.8)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (~> 2.0)
+      stud (>= 0.0.22)
+    logstash-input-beats (7.0.11-java)
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (>= 2.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      thread_safe (~> 0.3.5)
+    logstash-input-couchdb_changes (3.1.6)
+      json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22)
+    logstash-input-dead_letter_queue (2.0.2)
+      logstash-codec-plain
+      logstash-core (>= 8.4.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-input-elastic_serverless_forwarder (2.0.0-java)
+      logstash-codec-json_lines
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-http (>= 3.7.2)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-plugin_factory_support
+    logstash-input-elasticsearch (5.2.2)
+      elasticsearch (>= 7.17.9, < 9)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      manticore (>= 0.7.1)
+      tzinfo
+      tzinfo-data
+    logstash-input-exec (3.6.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-scheduler (~> 1.0)
+      stud (~> 0.0.22)
+    logstash-input-file (4.4.7)
+      addressable
+      concurrent-ruby (~> 1.0)
+      logstash-codec-multiline (~> 3.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-ganglia (3.1.4)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (~> 0.0.22)
+    logstash-input-gelf (3.4.0)
+      gelfd2 (= 0.4.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-generator (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-input-graphite (3.0.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-input-tcp
+    logstash-input-heartbeat (3.1.1)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-event_support (~> 1.0)
+      stud
+    logstash-input-http (4.1.10-java)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      logstash-mixin-normalize_config_support (~> 1.0)
+    logstash-input-http_poller (6.0.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0, >= 1.0.1)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-input-jms (3.3.1-java)
+      jruby-jms (>= 1.2.0)
+      logstash-codec-json (~> 3.0)
+      logstash-codec-plain (~> 3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      semantic_logger (< 4.0.0)
+    logstash-input-pipe (3.1.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      stud (~> 0.0.22)
+    logstash-input-redis (3.7.1)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (>= 4.0.1, < 5)
+    logstash-input-stdin (3.4.0)
+      jruby-stdin-channel
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-syslog (3.7.1)
+      concurrent-ruby
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-filter-date
+      logstash-filter-grok (>= 4.4.1)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-input-tcp (7.0.11-java)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-codec-multiline
+      logstash-codec-plain
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+    logstash-input-twitter (4.1.1)
+      http-form_data (~> 2)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      public_suffix (> 4, < 6)
+      stud (>= 0.0.22, < 0.1)
+      twitter (= 6.2.0)
+    logstash-input-udp (3.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.2)
+      stud (~> 0.0.22)
+    logstash-input-unix (3.1.3)
+      logstash-codec-line
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+    logstash-integration-aws (7.3.4-java)
+      aws-sdk-cloudfront
+      aws-sdk-cloudwatch
+      aws-sdk-core (~> 3)
+      aws-sdk-resourcegroups
+      aws-sdk-s3
+      aws-sdk-sns
+      aws-sdk-sqs
+      concurrent-ruby
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      rexml
+      rufus-scheduler (>= 3.0.9)
+      stud (~> 0.0.22)
+    logstash-integration-jdbc (5.6.3)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-scheduler (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+      lru_redux
+      sequel (>= 5.74.0)
+      tzinfo
+      tzinfo-data
+    logstash-integration-kafka (11.8.10-java)
+      logstash-codec-json
+      logstash-codec-plain
+      logstash-core (>= 8.3.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      manticore (>= 0.5.4, < 1.0.0)
+      stud (>= 0.0.22, < 0.1.0)
+    logstash-integration-logstash (1.0.4-java)
+      logstash-codec-json_lines (~> 3.1)
+      logstash-core-plugin-api (>= 2.1.12, <= 2.99)
+      logstash-input-http (>= 3.7.0)
+      logstash-mixin-http_client (~> 7.3)
+      logstash-mixin-plugin_factory_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.1)
+      stud
+    logstash-integration-rabbitmq (7.4.1-java)
+      back_pressure (~> 1.0)
+      logstash-codec-json
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      march_hare (~> 4.0)
+      stud (~> 0.0.22)
+    logstash-integration-snmp (4.2.2-java)
+      logstash-codec-plain
+      logstash-core (>= 6.5.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ecs_compatibility_support (~> 1.3)
+      logstash-mixin-event_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      logstash-mixin-validator_support (~> 1.0)
+    logstash-mixin-ca_trusted_fingerprint_support (1.0.1-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-deprecation_logger_support (1.0.0-java)
+      logstash-core (>= 5.0.0)
+    logstash-mixin-ecs_compatibility_support (1.3.0-java)
+      logstash-core (>= 6.0.0)
+    logstash-mixin-event_support (1.0.1-java)
+      logstash-core (>= 6.8)
+    logstash-mixin-http_client (7.5.0)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+    logstash-mixin-normalize_config_support (1.0.0-java)
+      logstash-core (>= 6.8.0)
+    logstash-mixin-plugin_factory_support (1.0.0-java)
+      logstash-core (>= 7.13.0)
+    logstash-mixin-scheduler (1.0.1-java)
+      logstash-core (>= 7.16)
+      rufus-scheduler (>= 3.0.9)
+    logstash-mixin-validator_support (1.1.1-java)
+      logstash-core (>= 6.8)
+    logstash-output-csv (3.0.11)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-output-file
+    logstash-output-elasticsearch (12.1.3-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-ca_trusted_fingerprint_support (~> 1.0)
+      logstash-mixin-deprecation_logger_support (~> 1.0)
+      logstash-mixin-ecs_compatibility_support (~> 1.0)
+      logstash-mixin-normalize_config_support (~> 1.0)
+      manticore (>= 0.8.0, < 1.0.0)
+      stud (~> 0.0, >= 0.0.17)
+    logstash-output-email (4.1.3)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      mail (~> 2.8)
+      mustache (>= 0.99.8)
+    logstash-output-file (4.3.0)
+      logstash-codec-json_lines
+      logstash-codec-line
+      logstash-core-plugin-api (>= 2.0.0, < 2.99)
+    logstash-output-graphite (3.1.6)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-http (6.0.1)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      logstash-mixin-http_client (>= 7.5.0, < 8.0.0)
+    logstash-output-lumberjack (3.1.9)
+      jls-lumberjack (>= 0.0.26)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-nagios (3.0.7)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-null (3.0.5)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-pipe (3.0.7)
+      logstash-codec-plain
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-redis (5.2.0)
+      logstash-core (>= 6.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      redis (~> 4)
+      stud
+    logstash-output-stdout (3.1.4)
+      logstash-codec-rubydebug
+      logstash-core-plugin-api (>= 1.60.1, < 2.99)
+    logstash-output-tcp (7.0.1)
+      jruby-openssl (>= 0.12.2)
+      logstash-codec-json
+      logstash-core (>= 8.1.0)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      stud
+    logstash-output-udp (3.2.0)
+      logstash-codec-json
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    logstash-output-webhdfs (3.1.1-java)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+      webhdfs
+    logstash-patterns-core (4.3.4)
+      logstash-core-plugin-api (>= 1.60, <= 2.99)
+    lru_redux (1.1.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    manticore (0.9.2-java)
+      openssl_pkcs8_pure
+    march_hare (4.8.0-java)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (1.1.0)
+    metriks (0.9.9.8)
+      atomic (~> 1.0)
+      avl_tree (~> 1.2.0)
+      hitimes (~> 1.1)
+    mini_mime (1.1.5)
+    minitar (1.1.0)
+    msgpack (1.8.3-java)
+    multi_json (1.19.1)
+    multipart-post (2.4.1)
+    murmurhash3 (0.1.6-java)
+    mustache (0.99.8)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
+    naught (1.1.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.4.1)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.5-java)
+    nokogiri (1.19.4-java)
+      racc (~> 1.4)
+    observer (0.1.2)
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    openssl_pkcs8_pure (0.0.0.2)
+    ostruct (0.6.3)
+    paquet (0.2.1)
+    parallel (1.28.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    pleaserun (0.0.34)
+      cabin (> 0)
+      clamp
+      dotenv (~> 2)
+      insist
+      mustache (= 0.99.8)
+      stud
+    polyglot (0.3.5)
+    pry (0.16.0-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+      spoon (~> 0.0)
+    psych (5.3.1-java)
+      date
+      jar-dependencies (>= 0.1.7)
+    public_suffix (5.1.1)
+    puma (8.0.2-java)
+      nio4r (~> 2.0)
+    raabro (1.4.0)
+    racc (1.8.1-java)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    redis (4.8.1)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rspec-wait (1.0.2)
+      rspec (>= 3.4)
+    rubocop (1.74.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.42.0)
+      parser (>= 3.3.7.2)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (1.3.0)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
+    sawyer (0.9.3)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    semantic_logger (3.4.1)
+      concurrent-ruby (~> 1.0)
+    sequel (5.103.0)
+      bigdecimal
+    simple_oauth (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-json (0.2.3)
+      json
+      simplecov
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.7.0)
+    timeout (0.6.1)
+    treetop (1.6.18)
+      polyglot (~> 0.3)
+    twitter (6.2.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 3.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.2)
+      tzinfo (>= 1.0.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webhdfs (0.11.0)
+      addressable
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    xml-simple (1.1.9)
+      rexml
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  belzebuth
+  benchmark-ips
+  bigdecimal (~> 3.1)
+  childprocess (~> 4)
+  ci_reporter_rspec (~> 1)
+  date (= 3.3.3)
+  fileutils (~> 1.7)
+  flores (~> 0.0.8)
+  fpm (~> 1, >= 1.14.1)
+  gems (~> 1)
+  jar-dependencies (= 0.5.4)
+  json-schema (~> 2)
+  logstash-codec-avro
+  logstash-codec-cef
+  logstash-codec-collectd
+  logstash-codec-dots
+  logstash-codec-edn
+  logstash-codec-edn_lines
+  logstash-codec-es_bulk
+  logstash-codec-fluent
+  logstash-codec-graphite
+  logstash-codec-json
+  logstash-codec-json_lines
+  logstash-codec-line
+  logstash-codec-msgpack
+  logstash-codec-multiline
+  logstash-codec-netflow
+  logstash-codec-plain
+  logstash-codec-rubydebug
+  logstash-core!
+  logstash-core-plugin-api!
+  logstash-devutils (~> 2.6.0)
+  logstash-filter-aggregate
+  logstash-filter-anonymize
+  logstash-filter-cidr
+  logstash-filter-clone
+  logstash-filter-csv
+  logstash-filter-date
+  logstash-filter-de_dot
+  logstash-filter-dissect
+  logstash-filter-dns
+  logstash-filter-drop
+  logstash-filter-elastic_integration
+  logstash-filter-elasticsearch
+  logstash-filter-fingerprint
+  logstash-filter-geoip
+  logstash-filter-grok
+  logstash-filter-http
+  logstash-filter-json
+  logstash-filter-kv
+  logstash-filter-memcached
+  logstash-filter-metrics
+  logstash-filter-mutate
+  logstash-filter-prune
+  logstash-filter-ruby
+  logstash-filter-sleep
+  logstash-filter-split
+  logstash-filter-syslog_pri
+  logstash-filter-throttle
+  logstash-filter-translate
+  logstash-filter-truncate
+  logstash-filter-urldecode
+  logstash-filter-useragent
+  logstash-filter-uuid
+  logstash-filter-xml
+  logstash-input-azure_event_hubs
+  logstash-input-beats
+  logstash-input-couchdb_changes
+  logstash-input-dead_letter_queue
+  logstash-input-elastic_serverless_forwarder
+  logstash-input-elasticsearch
+  logstash-input-exec
+  logstash-input-file
+  logstash-input-ganglia
+  logstash-input-gelf
+  logstash-input-generator
+  logstash-input-graphite
+  logstash-input-heartbeat
+  logstash-input-http
+  logstash-input-http_poller
+  logstash-input-jms
+  logstash-input-pipe
+  logstash-input-redis
+  logstash-input-stdin
+  logstash-input-syslog
+  logstash-input-tcp
+  logstash-input-twitter
+  logstash-input-udp
+  logstash-input-unix
+  logstash-integration-aws
+  logstash-integration-jdbc
+  logstash-integration-kafka
+  logstash-integration-logstash
+  logstash-integration-rabbitmq
+  logstash-integration-snmp
+  logstash-output-csv
+  logstash-output-elasticsearch (>= 11.14.0)
+  logstash-output-email
+  logstash-output-file
+  logstash-output-graphite
+  logstash-output-http
+  logstash-output-lumberjack
+  logstash-output-nagios
+  logstash-output-null
+  logstash-output-pipe
+  logstash-output-redis
+  logstash-output-stdout
+  logstash-output-tcp
+  logstash-output-udp
+  logstash-output-webhdfs
+  minitar (~> 1)
+  murmurhash3 (= 0.1.6)
+  octokit (~> 4.25)
+  paquet (~> 0.2)
+  pleaserun (~> 0.0.28)
+  polyglot
+  rack-test
+  rake (~> 13)
+  rspec (~> 3.5)
+  rubocop
+  rubocop-ast (= 1.42.0)
+  ruby-progressbar (~> 1)
+  rubyzip (~> 1)
+  simplecov (~> 0.22.0)
+  simplecov-json
+  stud (~> 0.0.22)
+  thwait
+  treetop
+  webmock (~> 3)
+
+BUNDLED WITH
+   2.7.2


### PR DESCRIPTION
Generate bundle lock file for new LS release.
