### PR TITLE
Downgrade ES client

### DIFF
--- a/Gemfile.jruby-3.4.lock.release
+++ b/Gemfile.jruby-3.4.lock.release
@@ -117,11 +117,11 @@ GEM
     elastic-transport (8.5.3)
       faraday (< 3)
       multi_json
-    elasticsearch (9.4.3)
+    elasticsearch (8.19.3)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 9.4.3)
-    elasticsearch-api (9.4.3)
-      base64
+      elasticsearch-api (= 8.19.3)
+      ostruct
+    elasticsearch-api (8.19.3)
       multi_json
     equalizer (0.0.11)
     et-orbi (1.4.0)
@@ -721,6 +721,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     openssl_pkcs8_pure (0.0.0.2)
+    ostruct (0.6.3)
     paquet (0.2.1)
     parallel (1.28.0)
     parser (3.3.11.1)


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
The es client was accidentally upgraded with https://github.com/elastic/logstash/pull/19277 This was due to confustion with https://github.com/elastic/logstash/pull/19051 Which is clarified in https://github.com/elastic/logstash/issues/19205

This commit downgrades the client. This was achieved by modifying the gemspec to confine to 8.x and using bundler to resolve the lockfile. Once the resolution happened (bundler handles the downgrade) the relaxed gemspec was restored and the lockfile was generated again with bundler constrained to not allow major version bumps.