### PR TITLE
FIPS 140-3 Support

### DIFF
--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -90,7 +90,7 @@ Copyright © 2019 Red Hat, Inc. All rights reserved. “Red Hat,” is a registe
 All other trademarks are the property of their respective owners.
 
 ==========
-Notice for: addressable-2.8.8
+Notice for: addressable-2.9.0
 ----------
 
 Copyright © Bob Aman
@@ -298,6 +298,2518 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
+Notice for: amazing_print-1.8.1
+----------
+
+MIT License
+
+Copyright (c) 2010-2019 Michael Dvorkin
+Copyright (c) 2020 AmazingPrint
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========
+Notice for: atomic-1.1.101
+----------
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as 
+defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that 
+is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that 
+control, are controlled by, or are under common control with that entity. For the purposes 
+of this definition, "control" means (i) the power, direct or indirect, to cause the 
+direction or management of such entity, whether by contract or otherwise, or (ii) ownership 
+of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of 
+such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by 
+this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not 
+limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of 
+a Source form, including but not limited to compiled object code, generated documentation, 
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available 
+under the License, as indicated by a copyright notice that is included in or attached to the 
+work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on 
+(or derived from) the Work and for which the editorial revisions, annotations, elaborations, 
+or other modifications represent, as a whole, an original work of authorship. For the 
+purposes of this License, Derivative Works shall not include works that remain separable 
+from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works 
+thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work 
+and any modifications or additions to that Work or Derivative Works thereof, that is 
+intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by 
+an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the 
+purposes of this definition, "submitted" means any form of electronic, verbal, or written 
+communication sent to the Licensor or its representatives, including but not limited to 
+communication on electronic mailing lists, source code control systems, and issue tracking 
+systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and 
+improving the Work, but excluding communication that is conspicuously marked or otherwise 
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a 
+Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each 
+Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, 
+royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, 
+publicly display, publicly perform, sublicense, and distribute the Work and such Derivative 
+Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each 
+Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, 
+royalty-free, irrevocable (except as stated in this section) patent license to make, have 
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license 
+applies only to those patent claims licensable by such Contributor that are necessarily 
+infringed by their Contribution(s) alone or by combination of their Contribution(s) with the 
+Work to which such Contribution(s) was submitted. If You institute patent litigation against 
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or 
+a Contribution incorporated within the Work constitutes direct or contributory patent 
+infringement, then any patent licenses granted to You under this License for that Work shall 
+terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works 
+thereof in any medium, with or without modifications, and in Source or Object form, provided 
+that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; 
+and
+
+You must cause any modified files to carry prominent notices stating that You changed the 
+files; and
+
+You must retain, in the Source form of any Derivative Works that You distribute, all 
+copyright, patent, trademark, and attribution notices from the Source form of the Work, 
+excluding those notices that do not pertain to any part of the Derivative Works; and
+
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative 
+Works that You distribute must include a readable copy of the attribution notices contained 
+within such NOTICE file, excluding those notices that do not pertain to any part of the 
+Derivative Works, in at least one of the following places: within a NOTICE text file 
+distributed as part of the Derivative Works; within the Source form or documentation, if 
+provided along with the Derivative Works; or, within a display generated by the Derivative 
+Works, if and wherever such third-party notices normally appear. The contents of the NOTICE 
+file are for informational purposes only and do not modify the License. You may add Your own 
+attribution notices within Derivative Works that You distribute, alongside or as an addendum 
+to the NOTICE text from the Work, provided that such additional attribution notices cannot 
+be construed as modifying the License. You may add Your own copyright statement to Your 
+modifications and may provide additional or different license terms and conditions for use, 
+reproduction, or distribution of Your modifications, or for any such Derivative Works as a 
+whole, provided Your use, reproduction, and distribution of the Work otherwise complies with 
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution 
+intentionally submitted for inclusion in the Work by You to the Licensor shall be under the 
+terms and conditions of this License, without any additional terms or conditions. 
+Notwithstanding the above, nothing herein shall supersede or modify the terms of any 
+separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, 
+service marks, or product names of the Licensor, except as required for reasonable and 
+customary use in describing the origin of the Work and reproducing the content of the NOTICE 
+file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, 
+Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" 
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, 
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, 
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for 
+determining the appropriateness of using or redistributing the Work and assume any risks 
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort 
+(including negligence), contract, or otherwise, unless required by applicable law (such as 
+deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be 
+liable to You for damages, including any direct, indirect, special, incidental, or 
+consequential damages of any character arising as a result of this License or out of the use 
+or inability to use the Work (including but not limited to damages for loss of goodwill, 
+work stoppage, computer failure or malfunction, or any and all other commercial damages or 
+losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative 
+Works thereof, You may choose to offer, and charge a fee for, acceptance of support, 
+warranty, indemnity, or other liability obligations and/or rights consistent with this 
+License. However, in accepting such obligations, You may act only on Your own behalf and on 
+Your sole responsibility, not on behalf of any other Contributor, and only if You agree to 
+indemnify, defend, and hold each Contributor harmless for any liability incurred by, or 
+claims asserted against, such Contributor by reason of your accepting any such warranty or 
+additional liability.
+
+END OF TERMS AND CONDITIONS
+
+==========
+Notice for: avl_tree-1.2.1
+----------
+
+Copyright (c) 2012,  Hiroshi Nakamura <nahi@ruby-lang.org>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==========
+Notice for: avro-1.10.2
+----------
+
+Apache Avro
+Copyright 2010-2015 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+
+==========
+Notice for: aws-eventstream-1.4.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-partitions-1.1266.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-cloudfront-1.150.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-cloudwatch-1.142.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-core-3.252.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-kms-1.129.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-resourcegroups-1.99.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-s3-1.226.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-sns-1.117.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sdk-sqs-1.116.0
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: aws-sigv4-1.12.1
+----------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: back_pressure-1.0.0
+----------
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========
 Notice for: base64-0.3.0
 ----------
 
@@ -414,6 +2926,96 @@ You can redistribute it and/or modify it under either the terms of the
      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
      PURPOSE.
 ==========
+Notice for: bindata-2.5.1
+----------
+
+Copyright (C) 2007-2012 Dion Mendel. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+==========
+Notice for: buftok-0.2.0
+----------
+
+Copyright (c) 2006-2013 Tony Arcieri, Martin Emde, Erik Michaels-Ober. Distributed under the [Ruby license][license]. [license]: http://www.ruby-lang.org/en/LICENSE.txt
+
+Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
+You can redistribute it and/or modify it under either the terms of the
+2-clause BSDL (see the file BSDL), or the conditions below:
+
+  1. You may make and give away verbatim copies of the source form of the
+     software without restriction, provided that you duplicate all of the
+     original copyright notices and associated disclaimers.
+
+  2. You may modify your copy of the software in any way, provided that
+     you do at least ONE of the following:
+
+       a) place your modifications in the Public Domain or otherwise
+          make them Freely Available, such as by posting said
+	  modifications to Usenet or an equivalent medium, or by allowing
+	  the author to include your modifications in the software.
+
+       b) use the modified software only within your corporation or
+          organization.
+
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+
+       d) make other distribution arrangements with the author.
+
+  3. You may distribute the software in object code or binary form,
+     provided that you do at least ONE of the following:
+
+       a) distribute the binaries and library files of the software,
+	  together with instructions (in the manual page or equivalent)
+	  on where to get the original distribution.
+
+       b) accompany the distribution with the machine-readable source of
+	  the software.
+
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+
+       d) make other distribution arrangements with the author.
+
+  4. You may modify and include the part of the software into any other
+     software (possibly commercial).  But some files in the distribution
+     are not written by the author, so that they are not under these terms.
+
+     For the list of those files and their copying conditions, see the
+     file LEGAL.
+
+  5. The scripts and library files supplied as input to or produced as
+     output from the software do not automatically fall under the
+     copyright of the software, but belong to whomever generated them,
+     and may be sold commercially, and may be aggregated with this
+     software.
+
+  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+     PURPOSE.
+
+==========
 Notice for: bundler-2.7.2
 ----------
 
@@ -460,7 +3062,7 @@ limitations under the License.
 
 
 ==========
-Notice for: cgi-0.3.7
+Notice for: cgi-0.4.2
 ----------
 
 Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
@@ -486,7 +3088,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
-Notice for: clamp-1.4.0
+Notice for: clamp-1.5.2
 ----------
 
 Copyright (c) 2010 Mike Williams <mdub@dogbiscuit.org>
@@ -537,7 +3139,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
-Notice for: com.fasterxml.jackson.core:jackson-annotations-2.21
+Notice for: com.fasterxml.jackson.core:jackson-annotations-2.21.0
 ----------
 
 This copy of Jackson JSON processor annotations is licensed under the
@@ -2658,6 +5260,31 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
+Notice for: dalli-3.2.8
+----------
+
+Copyright (c) Peter M. Goldstein, Mike Perham
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
 Notice for: date-3.3.3
 ----------
 
@@ -2738,6 +5365,51 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
+Notice for: diff-lcs-1.6.2
+----------
+
+source: https://github.com/halostatue/diff-lcs/blob/v1.5.0/License.md
+
+== License
+
+This software is available under three licenses: the GNU GPL version 2 (or at
+your option, a later version), the Perl Artistic license, or the MIT license.
+Note that my preference for licensing is the MIT license, but Algorithm::Diff
+was dually originally licensed with the Perl Artistic and the GNU GPL ("the
+same terms as Perl itself") and given that the Ruby implementation originally
+hewed pretty closely to the Perl version, I must maintain the additional
+licensing terms.
+
+* Copyright 2004–2013 Austin Ziegler.
+* Adapted from Algorithm::Diff (Perl) by Ned Konz and a Smalltalk version by
+  Mario I. Wolczko.
+
+=== MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=== Perl Artistic License (version 2)
+See the file docs/artistic.txt in the main distribution.
+
+=== GNU GPL version 2
+See the file docs/COPYING.txt in the main distribution.
+==========
 Notice for: digest-3.2.0
 ----------
 
@@ -2764,6 +5436,89 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
+
+==========
+Notice for: domain_name-0.6.20240107
+----------
+
+Copyright (c) 2011-2017 Akinori MUSHA
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.	 IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+* lib/domain_name/punycode.rb
+
+This file is derived from the implementation of punycode available at
+here:
+
+https://www.verisign.com/en_US/channel-resources/domain-registry-products/idn-sdks/index.xhtml
+
+Copyright (C) 2000-2002 Verisign Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+ 1) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+ 2) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+ 3) Neither the name of the VeriSign Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+This software is licensed under the BSD open source license. For more
+information visit www.opensource.org.
+
+Authors:
+ John Colosi (VeriSign)
+ Srikanth Veeramachaneni (VeriSign)
+ Nagesh Chigurupati (Verisign)
+ Praveen Srinivasan(Verisign)
+
+* lib/domain_name/etld_data.rb
+
+This file is generated from the Public Suffix List
+(https://publicsuffix.org/), which is licensed under MPL 2.0:
+
+https://mozilla.org/MPL/2.0/
 
 ==========
 Notice for: dotenv-2.8.1
@@ -2846,7 +5601,34 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
-Notice for: elastic-transport-8.4.1
+Notice for: edn-1.1.1
+----------
+
+Copyright (c) 2012 Relevance Inc & Clinton N. Dreisbach
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: elastic-transport-8.5.3
 ----------
 
 source: https://github.com/elastic/elastic-transport-ruby/blob/v8.3.0/LICENSE
@@ -3054,7 +5836,7 @@ source: https://github.com/elastic/elastic-transport-ruby/blob/v8.3.0/LICENSE
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========
-Notice for: elasticsearch-8.19.3
+Notice for: elasticsearch-9.4.3
 ----------
 
 source: https://github.com/elastic/elasticsearch-ruby/blob/v5.0.4/elasticsearch-api/LICENSE.txt
@@ -3074,7 +5856,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ==========
-Notice for: elasticsearch-api-8.19.3
+Notice for: elasticsearch-api-9.4.3
 ----------
 
 source: https://github.com/elastic/elasticsearch-ruby/blob/v5.0.4/elasticsearch-transport/LICENSE.txt
@@ -3121,7 +5903,35 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
-Notice for: erb-4.0.4
+Notice for: equalizer-0.0.11
+----------
+
+source: https://github.com/dkubb/equalizer/blob/v0.0.10/LICENSE
+
+Copyright (c) 2009-2013 Dan Kubb
+Copyright (c) 2012 Markus Schirp (packaging)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: erb-4.0.4.1
 ----------
 
 All the files in this distribution are covered under either the Ruby's
@@ -3154,7 +5964,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========
-Notice for: faraday-2.14.1
+Notice for: et-orbi-1.4.0
+----------
+
+source: https://github.com/floraison/et-orbi/blob/v1.2.7/LICENSE.txt
+
+Copyright (c) 2017-2022, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan
+==========
+Notice for: faraday-2.14.3
 ----------
 
 source: https://github.com/lostisland/faraday/blob/v0.9.2/LICENSE.md
@@ -3168,7 +6006,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: faraday-net_http-3.4.2
+Notice for: faraday-net_http-3.4.4
 ----------
 
 source: https://github.com/lostisland/faraday-net_http/blob/v1.0.0/LICENSE.md
@@ -3185,7 +6023,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ==========
-Notice for: ffi-1.17.3
+Notice for: ffi-1.17.4
 ----------
 
 source: https://github.com/ffi/ffi/blob/1.9.23/LICENSE
@@ -3214,350 +6052,6 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==========
-Notice for: ffi-binary-libfixposix-0.5.1.1
-----------
-
-source: https://github.com/byteit101/subspawn/blob/lfp-0.5.1.1/LICENSE.RUBY
-
-Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
-You can redistribute it and/or modify it under either the terms of the
-2-clause BSDL (see the file BSDL), or the conditions below:
-
-  1. You may make and give away verbatim copies of the source form of the
-     software without restriction, provided that you duplicate all of the
-     original copyright notices and associated disclaimers.
-
-  2. You may modify your copy of the software in any way, provided that
-     you do at least ONE of the following:
-
-       a) place your modifications in the Public Domain or otherwise
-          make them Freely Available, such as by posting said
-	  modifications to Usenet or an equivalent medium, or by allowing
-	  the author to include your modifications in the software.
-
-       b) use the modified software only within your corporation or
-          organization.
-
-       c) give non-standard binaries non-standard names, with
-          instructions on where to get the original software distribution.
-
-       d) make other distribution arrangements with the author.
-
-  3. You may distribute the software in object code or binary form,
-     provided that you do at least ONE of the following:
-
-       a) distribute the binaries and library files of the software,
-	  together with instructions (in the manual page or equivalent)
-	  on where to get the original distribution.
-
-       b) accompany the distribution with the machine-readable source of
-	  the software.
-
-       c) give non-standard binaries non-standard names, with
-          instructions on where to get the original software distribution.
-
-       d) make other distribution arrangements with the author.
-
-  4. You may modify and include the part of the software into any other
-     software (possibly commercial).  But some files in the distribution
-     are not written by the author, so that they are not under these terms.
-
-     For the list of those files and their copying conditions, see the
-     file LEGAL.
-
-  5. The scripts and library files supplied as input to or produced as
-     output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them,
-     and may be sold commercially, and may be aggregated with this
-     software.
-
-  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
-     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
-     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-     PURPOSE.
-==========
-Notice for: ffi-bindings-libfixposix-0.5.1.0
-----------
-
-Eclipse Public License - v 2.0
-
-    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
-    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
-    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-"Contribution" means:
-
-  a) in the case of the initial Contributor, the initial content
-     Distributed under this Agreement, and
-
-  b) in the case of each subsequent Contributor:
-     i) changes to the Program, and
-     ii) additions to the Program;
-  where such changes and/or additions to the Program originate from
-  and are Distributed by that particular Contributor. A Contribution
-  "originates" from a Contributor if it was added to the Program by
-  such Contributor itself or anyone acting on such Contributor's behalf.
-  Contributions do not include changes or additions to the Program that
-  are not Modified Works.
-
-"Contributor" means any person or entity that Distributes the Program.
-
-"Licensed Patents" mean patent claims licensable by a Contributor which
-are necessarily infringed by the use or sale of its Contribution alone
-or when combined with the Program.
-
-"Program" means the Contributions Distributed in accordance with this
-Agreement.
-
-"Recipient" means anyone who receives the Program under this Agreement
-or any Secondary License (as applicable), including Contributors.
-
-"Derivative Works" shall mean any work, whether in Source Code or other
-form, that is based on (or derived from) the Program and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship.
-
-"Modified Works" shall mean any work in Source Code or other form that
-results from an addition to, deletion from, or modification of the
-contents of the Program, including, for purposes of clarity any new file
-in Source Code form that contains any contents of the Program. Modified
-Works shall not include works that contain only declarations,
-interfaces, types, classes, structures, or files of the Program solely
-in each case in order to link to, bind by name, or subclass the Program
-or Modified Works thereof.
-
-"Distribute" means the acts of a) distributing or b) making available
-in any manner that enables the transfer of a copy.
-
-"Source Code" means the form of a Program preferred for making
-modifications, including but not limited to software source code,
-documentation source, and configuration files.
-
-"Secondary License" means either the GNU General Public License,
-Version 2.0, or any later versions of that license, including any
-exceptions or additional permissions as identified by the initial
-Contributor.
-
-2. GRANT OF RIGHTS
-
-  a) Subject to the terms of this Agreement, each Contributor hereby
-  grants Recipient a non-exclusive, worldwide, royalty-free copyright
-  license to reproduce, prepare Derivative Works of, publicly display,
-  publicly perform, Distribute and sublicense the Contribution of such
-  Contributor, if any, and such Derivative Works.
-
-  b) Subject to the terms of this Agreement, each Contributor hereby
-  grants Recipient a non-exclusive, worldwide, royalty-free patent
-  license under Licensed Patents to make, use, sell, offer to sell,
-  import and otherwise transfer the Contribution of such Contributor,
-  if any, in Source Code or other form. This patent license shall
-  apply to the combination of the Contribution and the Program if, at
-  the time the Contribution is added by the Contributor, such addition
-  of the Contribution causes such combination to be covered by the
-  Licensed Patents. The patent license shall not apply to any other
-  combinations which include the Contribution. No hardware per se is
-  licensed hereunder.
-
-  c) Recipient understands that although each Contributor grants the
-  licenses to its Contributions set forth herein, no assurances are
-  provided by any Contributor that the Program does not infringe the
-  patent or other intellectual property rights of any other entity.
-  Each Contributor disclaims any liability to Recipient for claims
-  brought by any other entity based on infringement of intellectual
-  property rights or otherwise. As a condition to exercising the
-  rights and licenses granted hereunder, each Recipient hereby
-  assumes sole responsibility to secure any other intellectual
-  property rights needed, if any. For example, if a third party
-  patent license is required to allow Recipient to Distribute the
-  Program, it is Recipient's responsibility to acquire that license
-  before distributing the Program.
-
-  d) Each Contributor represents that to its knowledge it has
-  sufficient copyright rights in its Contribution, if any, to grant
-  the copyright license set forth in this Agreement.
-
-  e) Notwithstanding the terms of any Secondary License, no
-  Contributor makes additional grants to any Recipient (other than
-  those set forth in this Agreement) as a result of such Recipient's
-  receipt of the Program under the terms of a Secondary License
-  (if permitted under the terms of Section 3).
-
-3. REQUIREMENTS
-
-3.1 If a Contributor Distributes the Program in any form, then:
-
-  a) the Program must also be made available as Source Code, in
-  accordance with section 3.2, and the Contributor must accompany
-  the Program with a statement that the Source Code for the Program
-  is available under this Agreement, and informs Recipients how to
-  obtain it in a reasonable manner on or through a medium customarily
-  used for software exchange; and
-
-  b) the Contributor may Distribute the Program under a license
-  different than this Agreement, provided that such license:
-     i) effectively disclaims on behalf of all other Contributors all
-     warranties and conditions, express and implied, including
-     warranties or conditions of title and non-infringement, and
-     implied warranties or conditions of merchantability and fitness
-     for a particular purpose;
-
-     ii) effectively excludes on behalf of all other Contributors all
-     liability for damages, including direct, indirect, special,
-     incidental and consequential damages, such as lost profits;
-
-     iii) does not attempt to limit or alter the recipients' rights
-     in the Source Code under section 3.2; and
-
-     iv) requires any subsequent distribution of the Program by any
-     party to be under a license that satisfies the requirements
-     of this section 3.
-
-3.2 When the Program is Distributed as Source Code:
-
-  a) it must be made available under this Agreement, or if the
-  Program (i) is combined with other material in a separate file or
-  files made available under a Secondary License, and (ii) the initial
-  Contributor attached to the Source Code the notice described in
-  Exhibit A of this Agreement, then the Program may be made available
-  under the terms of such Secondary Licenses, and
-
-  b) a copy of this Agreement must be included with each copy of
-  the Program.
-
-3.3 Contributors may not remove or alter any copyright, patent,
-trademark, attribution notices, disclaimers of warranty, or limitations
-of liability ("notices") contained within the Program from any copy of
-the Program which they Distribute, provided that Contributors may add
-their own appropriate notices.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities
-with respect to end users, business partners and the like. While this
-license is intended to facilitate the commercial use of the Program,
-the Contributor who includes the Program in a commercial product
-offering should do so in a manner which does not create potential
-liability for other Contributors. Therefore, if a Contributor includes
-the Program in a commercial product offering, such Contributor
-("Commercial Contributor") hereby agrees to defend and indemnify every
-other Contributor ("Indemnified Contributor") against any losses,
-damages and costs (collectively "Losses") arising from claims, lawsuits
-and other legal actions brought by a third party against the Indemnified
-Contributor to the extent caused by the acts or omissions of such
-Commercial Contributor in connection with its distribution of the Program
-in a commercial product offering. The obligations in this section do not
-apply to any claims or Losses relating to any actual or alleged
-intellectual property infringement. In order to qualify, an Indemnified
-Contributor must: a) promptly notify the Commercial Contributor in
-writing of such claim, and b) allow the Commercial Contributor to control,
-and cooperate with the Commercial Contributor in, the defense and any
-related settlement negotiations. The Indemnified Contributor may
-participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial
-product offering, Product X. That Contributor is then a Commercial
-Contributor. If that Commercial Contributor then makes performance
-claims, or offers warranties related to Product X, those performance
-claims and warranties are such Commercial Contributor's responsibility
-alone. Under this section, the Commercial Contributor would have to
-defend claims against the other Contributors related to those performance
-claims and warranties, and if a court requires any other Contributor to
-pay any damages as a result, the Commercial Contributor must pay
-those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
-BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
-TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
-PURPOSE. Each Recipient is solely responsible for determining the
-appropriateness of using and distributing the Program and assumes all
-risks associated with its exercise of rights under this Agreement,
-including but not limited to the risks and costs of program errors,
-compliance with applicable laws, damage to or loss of data, programs
-or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
-SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
-PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
-EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under
-applicable law, it shall not affect the validity or enforceability of
-the remainder of the terms of this Agreement, and without further
-action by the parties hereto, such provision shall be reformed to the
-minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity
-(including a cross-claim or counterclaim in a lawsuit) alleging that the
-Program itself (excluding combinations of the Program with other software
-or hardware) infringes such Recipient's patent(s), then such Recipient's
-rights granted under Section 2(b) shall terminate as of the date such
-litigation is filed.
-
-All Recipient's rights under this Agreement shall terminate if it
-fails to comply with any of the material terms or conditions of this
-Agreement and does not cure such failure in a reasonable period of
-time after becoming aware of such noncompliance. If all Recipient's
-rights under this Agreement terminate, Recipient agrees to cease use
-and distribution of the Program as soon as reasonably practicable.
-However, Recipient's obligations under this Agreement and any licenses
-granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement,
-but in order to avoid inconsistency the Agreement is copyrighted and
-may only be modified in the following manner. The Agreement Steward
-reserves the right to publish new versions (including revisions) of
-this Agreement from time to time. No one other than the Agreement
-Steward has the right to modify this Agreement. The Eclipse Foundation
-is the initial Agreement Steward. The Eclipse Foundation may assign the
-responsibility to serve as the Agreement Steward to a suitable separate
-entity. Each new version of the Agreement will be given a distinguishing
-version number. The Program (including Contributions) may always be
-Distributed subject to the version of the Agreement under which it was
-received. In addition, after a new version of the Agreement is published,
-Contributor may elect to Distribute the Program (including its
-Contributions) under the new version.
-
-Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
-receives no rights or licenses to the intellectual property of any
-Contributor under this Agreement, whether expressly, by implication,
-estoppel or otherwise. All rights in the Program not expressly granted
-under this Agreement are reserved. Nothing in this Agreement is intended
-to be enforceable by any entity that is not a Contributor or Recipient.
-No third-party beneficiary rights are created under this Agreement.
-
-Exhibit A - Form of Secondary Licenses Notice
-
-"This Source Code may also be made available under the following 
-Secondary Licenses when the conditions for such availability set forth 
-in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
-version(s), and exceptions or additional permissions here}."
-
-  Simply including a copy of this Agreement, including this Exhibit A
-  is not sufficient to license the Source Code under Secondary Licenses.
-
-  If it is not possible or desirable to put the notice in a particular
-  file, then You may include the notice in a location (such as a LICENSE
-  file in a relevant directory) where a recipient would be likely to
-  look for such a notice.
-
-  You may add additional accurate notices of copyright ownership.
 
 ==========
 Notice for: fiddle-1.1.6
@@ -3693,6 +6187,52 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
+Notice for: fugit-1.12.3
+----------
+
+source: https://github.com/floraison/fugit/blob/v1.5.2/LICENSE.txt
+
+Copyright (c) 2017-2021, John Mettraux, jmettraux+flor@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan
+==========
+Notice for: gelfd2-0.4.1
+----------
+
+Copyright 2011-2013 John E. Vincent and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========
 Notice for: gems-1.3.0
 ----------
 
@@ -3707,7 +6247,170 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: i18n-1.14.8
+Notice for: gene_pool-1.5.0
+----------
+
+Copyright (c) 2010-2011 Brad Pardee
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: hitimes-1.3.1
+----------
+
+source: https://github.com/copiousfreetime/hitimes/blob/v1.2.6/LICENSE
+
+ISC LICENSE - http://opensource.org/licenses/isc-license.txt
+
+Copyright (c) 2008-2015 Jeremy Hinegardner
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==========
+Notice for: http-3.3.0
+----------
+
+source: https://github.com/httprb/http/blob/v0.9.9/LICENSE.txt
+
+Copyright (c) 2011-2015 Tony Arcieri, Erik Michaels-Ober, Alexey V. Zapparov, Zachary Anker
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========
+Notice for: http-cookie-1.1.6
+----------
+
+source: https://github.com/sparklemotion/http-cookie/blob/v1.0.3/LICENSE.txt
+
+Copyright (c) 2013 Akinori MUSHA
+Copyright (c) 2011-2012 Akinori MUSHA, Eric Hodel
+Copyright (c) 2006-2011 Aaron Patterson, Mike Dalessio
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: http-form_data-2.3.0
+----------
+
+source: https://github.com/httprb/form_data/blob/v1.0.1/LICENSE.txt
+
+Copyright (c) 2015 Aleksey V Zapparov
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========
+Notice for: http_parser.rb-0.6.0
+----------
+
+source: https://github.com/tmm1/http_parser.rb/blob/v0.6.0/LICENSE-MIT
+
+Copyright 2009,2010 Marc-André Cournoyer <macournoyer@gmail.com>
+Copyright 2010,2011 Aman Gupta <aman@tmm1.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+==========
+Notice for: i18n-1.15.2
 ----------
 
 source: https://github.com/svenfuchs/i18n/blob/v0.6.9/MIT-LICENSE
@@ -3841,6 +6544,66 @@ You can redistribute it and/or modify it under either the terms of the
    PURPOSE.
 
 ==========
+Notice for: io.opentelemetry:opentelemetry-api-null
+----------
+
+OpenTelemetry Java
+Copyright The OpenTelemetry Authors
+
+This product includes software developed at
+The OpenTelemetry Authors (https://opentelemetry.io/).
+
+Licensed under the Apache License, Version 2.0.
+
+==========
+Notice for: io.opentelemetry:opentelemetry-bom-1.62.0
+----------
+
+OpenTelemetry Java
+Copyright The OpenTelemetry Authors
+
+This product includes software developed at
+The OpenTelemetry Authors (https://opentelemetry.io/).
+
+Licensed under the Apache License, Version 2.0.
+
+==========
+Notice for: io.opentelemetry:opentelemetry-exporter-otlp-null
+----------
+
+OpenTelemetry Java
+Copyright The OpenTelemetry Authors
+
+This product includes software developed at
+The OpenTelemetry Authors (https://opentelemetry.io/).
+
+Licensed under the Apache License, Version 2.0.
+
+==========
+Notice for: io.opentelemetry:opentelemetry-sdk-null
+----------
+
+OpenTelemetry Java
+Copyright The OpenTelemetry Authors
+
+This product includes software developed at
+The OpenTelemetry Authors (https://opentelemetry.io/).
+
+Licensed under the Apache License, Version 2.0.
+
+==========
+Notice for: io.opentelemetry:opentelemetry-sdk-metrics-null
+----------
+
+OpenTelemetry Java
+Copyright The OpenTelemetry Authors
+
+This product includes software developed at
+The OpenTelemetry Authors (https://opentelemetry.io/).
+
+Licensed under the Apache License, Version 2.0.
+
+==========
 Notice for: ipaddr-1.2.7
 ----------
 
@@ -3924,10 +6687,420 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========
+Notice for: jls-grok-0.11.5
+----------
+
+source: https://github.com/jordansissel/ruby-grok/blob/master/LICENSE
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: jls-lumberjack-0.0.26
+----------
+
+source: https://github.com/elastic/ruby-lumberjack/blob/master/LICENSE
+
+
+Copyright 2012–2015 Jordan Sissel and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========
+Notice for: jmespath-1.6.2
+----------
+
+source: https://github.com/jmespath/jmespath.rb/blob/v1.4.0/LICENSE.txt
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+==========
 Notice for: jrjackson-0.5.0
 ----------
 
-https://github.com/guyboertje/jrjackson/blob/v0.5.0/README.md
+https://github.com/guyboertje/jrjackson/blob/v0.4.6/README.md
 
 LICENSE applicable to this library:
 
@@ -6398,7 +9571,25 @@ Jean-loup Gailly        Mark Adler
 jloup@gzip.org          madler@alumni.caltech.edu
 
 ==========
-Notice for: jruby-openssl-0.15.5
+Notice for: jruby-jms-1.3.0
+----------
+
+Copyright 2008, 2009, 2010, 2011 J. Reid Morrison, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========
+Notice for: jruby-openssl-0.16.1
 ----------
 
 source: https://github.com/jruby/jruby-openssl/blob/v0.9.21/LICENSE.txt
@@ -6468,7 +9659,24 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
-Notice for: json-2.18.1
+Notice for: jruby-stdin-channel-0.2.0
+----------
+
+source: https://github.com/colinsurprenant/jruby-stdin-channel/blob/v0.2.0/LICENSE.md
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==========
+Notice for: json-2.20.0
 ----------
 
 source: https://github.com/tmattia/json-generator/blob/v0.1.0/LICENSE.txt
@@ -6522,6 +9730,61 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
+Notice for: lru_redux-1.1.0
+----------
+
+source: https://github.com/SamSaffron/lru_redux/blob/v1.1.0/LICENSE.txt
+
+Copyright (c) 2013 Sam Saffron
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: mail-2.9.1
+----------
+
+source: https://github.com/mikel/mail/blob/2.6.6/MIT-LICENSE
+
+Copyright (c) 2009-2017 Mikel Lindsaar
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
 Notice for: manticore-0.9.2
 ----------
 
@@ -6548,6 +9811,60 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+==========
+Notice for: march_hare-4.8.0
+----------
+
+source: https://github.com/ruby-amqp/march_hare/blob/v3.1.1/LICENSE
+
+Copyright (c) 2011-2013 Theo Hultberg
+Copyright (c) 2013-2017 Michael S. Klishin and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: memoizable-0.4.2
+----------
+
+source: https://github.com/dkubb/memoizable/blob/v0.4.2/LICENSE.md
+
+Copyright (c) 2013 Dan Kubb, Erik Michaels-Ober
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
 Notice for: method_source-1.1.0
 ----------
@@ -6576,6 +9893,58 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
+Notice for: metriks-0.9.9.8
+----------
+
+source: https://github.com/eric/metriks/blob/v0.9.9.8/LICENSE
+
+Copyright (c) 2012 Eric Lindvall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========
+Notice for: mini_mime-1.1.5
+----------
+
+# source: https://github.com/discourse/mini_mime/blob/v1.1.5/LICENSE.txt
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Discourse Construction Kit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========
 Notice for: minitar-1.1.0
 ----------
 
@@ -6587,6 +9956,25 @@ terms of Ruby’s licence or the Simplified BSD licence.
 * Copyright 2004–2017 Austin Ziegler.
 * Portions copyright 2004 Mauricio Julio Fernández Pradier.
 
+==========
+Notice for: msgpack-1.8.3
+----------
+
+source: https://github.com/msgpack/msgpack-ruby/blob/v1.2.4/ext/msgpack/
+
+  Copyright (C) 2008-2013 Sadayuki Furuhashi
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ==========
 Notice for: multi_json-1.19.1
 ----------
@@ -6613,6 +10001,33 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: multipart-post-2.4.1
+----------
+
+source: https://github.com/nicksieger/multipart-post/blob/v2.0.0/README.md#license
+
+Copyright (c) 2007-2013 Nick Sieger <nick@nicksieger.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ==========
 Notice for: murmurhash3-0.1.6
 ----------
@@ -6670,7 +10085,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: mustermann-3.0.4
+Notice for: mustermann-3.1.1
 ----------
 
 Copyright (c) 2013-2017 Konstantin Haase
@@ -6698,8 +10113,155 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
+Notice for: naught-1.1.0
+----------
+
+source: https://github.com/avdi/naught/blob/v1.1.0/LICENSE.txt
+
+Copyright (c) 2013 Avdi Grimm
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
 Notice for: net-http-0.9.1
 ----------
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+==========
+Notice for: net-imap-0.6.4.1
+----------
+
+# source: https://github.com/ruby/net-imap/blob/v0.3.7/LICENSE.txt
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+-------------------------------------------------------------------------
+
+This software includes documentation which has been copied from the relevant
+RFCs.  The copied documentation is covered by the following licenses:
+
+RFC 3501 (Editor: M. Crispin)
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.  v This
+   document and the information contained herein is provided on an "AS
+   IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING TASK
+   FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+   LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL
+   NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY
+   OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+RFC9051 (Editors: A. Melnikov, B. Leiba)
+Copyright Notice
+
+   Copyright (c) 2021 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+==========
+Notice for: net-pop-0.1.2
+----------
+
+source: https://github.com/ruby/net-pop/blob/v0.1.2/LICENSE.txt
 
 Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
 
@@ -6750,6 +10312,34 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
+Notice for: net-smtp-0.5.1
+----------
+
+# source: https://github.com/ruby/net-smtp/blob/v0.4.0/LICENSE.txt
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+==========
 Notice for: nio4r-2.7.5
 ----------
 
@@ -6763,6 +10353,42 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: nokogiri-1.19.4
+----------
+
+source: https://github.com/sparklemotion/nokogiri/blob/v1.8.2/LICENSE.md
+
+Copyright (c) 2008 - 2017:
+
+* [Aaron Patterson](http://tenderlovemaking.com)
+* [Mike Dalessio](http://mike.daless.io)
+* [Charles Nutter](http://blog.headius.com)
+* [Sergio Arbeo](http://www.serabe.com)
+* [Patrick Mahoney](http://polycrystal.org)
+* [Yoko Harada](http://yokolet.blogspot.com)
+* [Akinori MUSHA](https://akinori.org)
+* [John Shahid](https://github.com/jvshahid)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
 Notice for: observer-0.1.2
@@ -6924,7 +10550,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ==========
-Notice for: org.apache.logging.log4j:log4j-1.2-api-2.25.3
+Notice for: org.apache.logging.log4j:log4j-1.2-api-2.25.4
 ----------
 
 source: https://github.com/apache/logging-log4j2/blob/rel/2.14.0/NOTICE.txt
@@ -6947,7 +10573,7 @@ Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
 picocli (http://picocli.info)
 Copyright 2017 Remko Popma
 ==========
-Notice for: org.apache.logging.log4j:log4j-api-2.25.3
+Notice for: org.apache.logging.log4j:log4j-api-2.25.4
 ----------
 
 source: https://git-wip-us.apache.org/repos/asf?p=logging-log4j2.git;a=blob;f=NOTICE.txt;h=bd95322f254fc6f691b47e77df8c21229f47b8d4;hb=HEAD
@@ -6970,7 +10596,7 @@ Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
 picocli (http://picocli.info)
 Copyright 2017 Remko Popma
 ==========
-Notice for: org.apache.logging.log4j:log4j-core-2.25.3
+Notice for: org.apache.logging.log4j:log4j-core-2.25.4
 ----------
 
 source: https://git-wip-us.apache.org/repos/asf?p=logging-log4j2.git;a=blob;f=NOTICE.txt;h=bd95322f254fc6f691b47e77df8c21229f47b8d4;hb=HEAD
@@ -6993,7 +10619,7 @@ Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
 picocli (http://picocli.info)
 Copyright 2017 Remko Popma
 ==========
-Notice for: org.apache.logging.log4j:log4j-jcl-2.25.3
+Notice for: org.apache.logging.log4j:log4j-jcl-2.25.4
 ----------
 
 source: https://github.com/apache/logging-log4j2/blob/rel/2.14.0/NOTICE.txt
@@ -7016,7 +10642,7 @@ Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
 picocli (http://picocli.info)
 Copyright 2017 Remko Popma
 ==========
-Notice for: org.apache.logging.log4j:log4j-slf4j-impl-2.25.3
+Notice for: org.apache.logging.log4j:log4j-slf4j-impl-2.25.4
 ----------
 
 source: https://git-wip-us.apache.org/repos/asf?p=logging-log4j2.git;a=blob;f=NOTICE.txt;h=bd95322f254fc6f691b47e77df8c21229f47b8d4;hb=HEAD
@@ -7075,6 +10701,51 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========
+Notice for: org.hdrhistogram:HdrHistogram-2.2.2
+----------
+
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.
+==========
 Notice for: org.javassist:javassist-3.30.2-GA
 ----------
 
@@ -7083,7 +10754,7 @@ Copyright (C) 1999-2019 by Shigeru Chiba, All rights reserved.
 This software is distributed under the Mozilla Public License Version 1.1, the GNU Lesser General Public License Version 2.1 or later, or the Apache License Version 2.0.
 
 ==========
-Notice for: org.jruby:jruby-core-10.0.3.0
+Notice for: org.jruby:jruby-core-10.0.6.0
 ----------
 
 JRuby is Copyright (c) 2007-2018 The JRuby project
@@ -7366,7 +11037,7 @@ Eclipse Public License - v 2.0
 
     You may add additional accurate notices of copyright ownership.
 ==========
-Notice for: org.logstash:jvm-options-parser-9.4.0
+Notice for: org.logstash:jvm-options-parser-9.5.0
 ----------
 
 Copyright (c) 2022 Elasticsearch B.V. <http://www.elastic.co>
@@ -7604,7 +11275,7 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 
 ==========
-Notice for: ostruct-0.6.3
+Notice for: ostruct-0.6.1
 ----------
 
 Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
@@ -7648,7 +11319,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==========
-Notice for: pleaserun-0.0.33
+Notice for: pleaserun-0.0.34
 ----------
 
 Copyright 2014 Jordan Sissel contributors.
@@ -7796,7 +11467,7 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
-Notice for: psych-5.2.3
+Notice for: psych-5.4.0
 ----------
 
 MIT License
@@ -7822,7 +11493,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========
-Notice for: public_suffix-7.0.2
+Notice for: public_suffix-5.1.1
 ----------
 
 Copyright (c) 2009-2018 Simone Carletti <weppos@weppos.net>
@@ -7880,7 +11551,64 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========
-Notice for: rack-3.2.4
+Notice for: raabro-1.4.0
+----------
+
+source: https://github.com/floraison/raabro/blob/v1.4.0/LICENSE.txt
+
+Copyright (c) 2015-2020, John Mettraux, jmettraux@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Made in Japan.
+==========
+Notice for: racc-1.8.1
+----------
+
+source: https://github.com/ruby/racc/blob/master/COPYING
+
+Copyright (C) 2019 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+==========
+Notice for: rack-3.2.6
 ----------
 
 The MIT License (MIT)
@@ -7931,7 +11659,7 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
-Notice for: rack-session-2.1.1
+Notice for: rack-session-2.1.2
 ----------
 
 # MIT License
@@ -8007,7 +11735,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==========
-Notice for: rake-13.3.1
+Notice for: rake-13.4.2
 ----------
 
 Copyright (c) Jim Weirich
@@ -8344,6 +12072,30 @@ version 2 (see the file GPL), or the conditions below:
    PURPOSE.
 
 ==========
+Notice for: redis-4.8.1
+----------
+
+Copyright (c) 2009 Ezra Zygmuntowicz
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
 Notice for: reline-0.6.3
 ----------
 
@@ -8396,6 +12148,251 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
+==========
+Notice for: rexml-3.4.4
+----------
+
+source: https://github.com/ruby/rexml/blob/v3.2.5/LICENSE.txt
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+==========
+Notice for: rspec-3.13.2
+----------
+
+source: https://github.com/rspec/rspec-metagem/blob/v3.12.0/LICENSE.md
+
+The MIT License (MIT)
+=====================
+
+Copyright © 2009 Chad Humphries, David Chelimsky
+Copyright © 2006 David Chelimsky, The RSpec Development Team
+Copyright © 2005 Steven Baker
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-collection_matchers-1.2.1
+----------
+
+source: https://github.com/rspec/rspec-collection_matchers/blob/v1.2.1/LICENSE.txt
+
+(The MIT License)
+
+Copyright (c) 2013 Hugo Barauna
+Copyright (c) 2012 David Chelimsky, Myron Marston
+Copyright (c) 2006 David Chelimsky, The RSpec Development Team
+Copyright (c) 2005 Steven Baker
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-core-3.13.6
+----------
+
+source: https://github.com/rspec/rspec-core/blob/v3.12.2/LICENSE.md
+
+The MIT License (MIT)
+=====================
+
+* Copyright © 2012 Chad Humphries, David Chelimsky, Myron Marston
+* Copyright © 2009 Chad Humphries, David Chelimsky
+* Copyright © 2006 David Chelimsky, The RSpec Development Team
+* Copyright © 2005 Steven Baker
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-expectations-3.13.5
+----------
+
+source: https://github.com/rspec/rspec-expectations/blob/v3.12.3/LICENSE.md
+
+The MIT License (MIT)
+=====================
+
+* Copyright © 2012 David Chelimsky, Myron Marston
+* Copyright © 2006 David Chelimsky, The RSpec Development Team
+* Copyright © 2005 Steven Baker
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-mocks-3.13.8
+----------
+
+source: https://github.com/rspec/rspec-mocks/blob/v3.12.6/LICENSE.md
+
+The MIT License (MIT)
+=====================
+
+* Copyright © 2012 David Chelimsky, Myron Marston
+* Copyright © 2006 David Chelimsky, The RSpec Development Team
+* Copyright © 2005 Steven Baker
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-support-3.13.7
+----------
+
+source: https://github.com/rspec/rspec-support/blob/v3.12.1/LICENSE.md
+
+The MIT License (MIT)
+====================
+
+* Copyright © 2013 David Chelimsky, Myron Marston, Jon Rowe, Sam Phippen, Xavier Shay, Bradley Schaefer
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========
+Notice for: rspec-wait-1.0.2
+----------
+
+source: https://github.com/laserlemon/rspec-wait/blob/v0.0.9/LICENSE.txt
+
+Copyright (c) 2014 Steve Richert
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==========
 Notice for: ruby-progressbar-1.13.0
 ----------
@@ -8578,6 +12575,32 @@ You can redistribute it and/or modify it under either the terms of the
      PURPOSE.
 
 ==========
+Notice for: rufus-scheduler-3.9.2
+----------
+
+
+Copyright (c) 2005-2014, John Mettraux, jmettraux@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+==========
 Notice for: securerandom-0.4.1
 ----------
 
@@ -8605,6 +12628,48 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
+Notice for: semantic_logger-3.4.1
+----------
+
+Copyright 2012, 2013, 2014, 2015, 2016 Reid Morrison
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========
+Notice for: sequel-5.106.0
+----------
+
+Copyright (c) 2007-2008 Sharon Rosner
+Copyright (c) 2008-2018 Jeremy Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+  
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+   
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
 Notice for: shellwords-0.2.2
 ----------
 
@@ -8630,6 +12695,31 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
+
+==========
+Notice for: simple_oauth-0.3.1
+----------
+
+Copyright (c) 2010-2013 Steve Richert, Erik Michaels-Ober
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
 Notice for: sinatra-4.2.1
@@ -8685,6 +12775,53 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
+
+==========
+Notice for: snappy-0.5.1
+----------
+
+Copyright (c) 2011-2013 miyucy
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
+Notice for: snappy-jars-1.1.0.1.2
+----------
+
+Copyright Doug Mayer (https://github.com/doxavore)
+
+README.md: "Per the real implementation, Apache License v2.0."
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 ==========
 Notice for: spoon-0.0.6
@@ -9497,33 +13634,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========
-Notice for: syslog-0.4.0
-----------
-
-Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-==========
 Notice for: tempfile-0.3.1
 ----------
 
@@ -9728,7 +13838,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
-Notice for: tilt-2.7.0
+Notice for: tilt-2.8.0
 ----------
 
 Copyright (c) 2010-2016 Ryan Tomayko <http://tomayko.com/about>
@@ -9777,7 +13887,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ==========
-Notice for: timeout-0.4.3
+Notice for: timeout-0.6.1
 ----------
 
 Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
@@ -9854,6 +13964,31 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ==========
+Notice for: twitter-6.2.0
+----------
+
+Copyright (c) 2006-2015 Erik Michaels-Ober, John Nunemaker, Wynn Netherland, Steve Richert, Steve Agalloco
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========
 Notice for: tzinfo-2.0.6
 ----------
 
@@ -9878,7 +14013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========
-Notice for: tzinfo-data-1.2025.3
+Notice for: tzinfo-data-1.2026.2
 ----------
 
 Copyright (c) 2005-2018 Philip Ross
@@ -9980,6 +14115,68 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
+
+==========
+Notice for: webhdfs-0.11.0
+----------
+
+Copyright (C) 2012 Fluentd Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========
+Notice for: webrick-1.9.2
+----------
+
+source: https://github.com/ruby/webrick/blob/v1.8.1/LICENSE.txt
+
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+==========
+Notice for: xml-simple-1.1.9
+----------
+
+Readme.md: 
+
+XmlSimple is Copyright (c) 2003-2017 Maik Schmidt. It is free software, and may
+be redistributed under the terms specified in the COPYING file of the current
+Ruby distribution.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========
 Notice for: yaml-0.4.0

--- a/bin/logstash.lib.sh
+++ b/bin/logstash.lib.sh
@@ -185,9 +185,32 @@ setup_vendored_jruby() {
   fi
 }
 
+setup_fips_jvm_flags() {
+  # Detect the settings directory: honour --path.settings if provided, else default
+  local settings_dir="${LOGSTASH_HOME}/config"
+  local found_settings=0
+  for arg in "$@"; do
+    if [ $found_settings -eq 1 ]; then
+      settings_dir="$arg"
+      break
+    fi
+    [ "$arg" = "--path.settings" ] && found_settings=1
+  done
+
+  local yml="${settings_dir}/logstash.yml"
+  if [ -f "$yml" ] && grep -qE "^\s*xpack\.security\.fips_mode\.enabled\s*:\s*true" "$yml"; then
+    # Prevent non-FIPS BC 1.84 from registering as a JVM security provider.
+    # BC 1.84 JARs are still loaded (jruby-openssl needs them for class structure)
+    # but SecurityHelper is redirected to BCFIPS/BCJSSE in fips_jruby_openssl.rb.
+    JAVA_OPTS="${JAVA_OPTS} -Djruby.openssl.provider.register=false -Djruby.openssl.ssl.provider=BCJSSE"
+    export JAVA_OPTS
+  fi
+}
+
 setup() {
   >&2 setup_java
   >&2 setup_vendored_jruby
+  setup_fips_jvm_flags "$@"
 }
 
 ruby_exec() {

--- a/docs/reference/fips-plugin-compatibility.md
+++ b/docs/reference/fips-plugin-compatibility.md
@@ -1,0 +1,346 @@
+---
+navigation_title: "FIPS 140-2/3 plugin compatibility"
+applies_to:
+  stack: ga
+---
+
+# FIPS 140-2/3 plugin compatibility [fips-plugin-compatibility]
+
+This page documents the FIPS 140-2/3 compatibility status of every Logstash plugin in the [logstash-plugins](https://github.com/logstash-plugins) GitHub organization. Plugins are grouped into three categories:
+
+- **Works out of the box (OOTB)**: No configuration changes needed when FIPS mode is enabled.
+- **Works with restrictions**: Plugin works in FIPS mode but has limitations, non-FIPS defaults, or requires specific configuration.
+- **Not compatible**: Plugin cannot be used in FIPS mode, uses a cryptographically non-FIPS protocol that cannot be changed, or hardcodes TLS certificate verification off with no way to enable it.
+
+Plugins marked **SKIP** have no published source code (stub/placeholder repositories) and cannot be audited.
+
+## How Logstash runs FIPS
+
+Logstash runs BouncyCastle FIPS in **C:HYBRID mode**, matching Elasticsearch's FIPS configuration. In hybrid mode, the BCFIPS provider is the first registered JVM security provider and handles all security-sensitive operations (TLS, key derivation, signature verification) using FIPS-validated algorithms. Non-security uses of non-approved algorithms (such as MD5 for internal filename generation or deduplication keys) are permitted but do not carry FIPS validation.
+
+When `fips_mode.enabled: true` is set in `logstash.yml`, Logstash additionally:
+
+1. Calls `SecurityHelper.setSecurityProvider(BCFIPSProvider)` before any `require "openssl"`, routing all JCE operations (ciphers, digests, key factories, MACs, etc.) through the BouncyCastle FIPS provider.
+2. Sets `-Djruby.openssl.ssl.provider=BCJSSE` so that `SSLContext` operations use the BCJSSE TLS provider.
+3. Sets `-Djruby.openssl.provider.register=false` so that the BouncyCastle 1.84 jar bundled with jruby-openssl is loaded as a class library but not registered as a JCE provider.
+
+This means any plugin that uses Ruby `OpenSSL::` APIs for TLS will automatically use FIPS-approved algorithms. The issues documented below are cases where a plugin uses a weak algorithm for a **security purpose** (authentication, encryption, integrity verification of network data), hardcodes TLS certificate verification off, or does not accept BCFKS keystores.
+
+### Ruby filter and user-supplied code
+
+`logstash-filter-ruby` allows arbitrary Ruby code execution. Because the jruby-openssl routing patch is in effect for the entire process, any `OpenSSL::` call made inside a Ruby filter script — including `OpenSSL::Digest`, `OpenSSL::Cipher`, and `OpenSSL::SSL` — automatically uses the BCFIPS/BCJSSE providers. There is nothing special about the filter itself; it inherits the same FIPS-routed crypto environment as the rest of Logstash.
+
+Under C:HYBRID mode, a Ruby filter that calls `Digest::MD5.hexdigest(value)` works — MD5 for a non-security purpose is permitted. A Ruby filter that calls `OpenSSL::Cipher.new("DES-CBC")` also works at the Ruby level in C:HYBRID, but DES is not a FIPS-approved algorithm and using it for encryption is a security operation. **The compliance responsibility for the content of Ruby filter scripts belongs to the operator**, not to Logstash. FIPS compliance requires that the operator not configure non-FIPS cryptography in their pipeline scripts.
+
+Logstash does not disable `logstash-filter-ruby` in FIPS mode. The jruby-openssl routing ensures that the underlying JCE/JSSE plumbing is FIPS-validated; what the operator does with it is subject to their own FIPS boundary controls.
+
+## BCFKS keystore support
+
+FIPS mode requires BCFKS (BouncyCastle FIPS KeyStore) format for JVM keystores. Plugins that expose `ssl_keystore_type` or `ssl_truststore_type` validators must include `bcfks` as a valid value. Where noted in the tables below, this has been added to bundled plugins. The `logstash-mixin-http_client` shared library also needs this fix (see [Mixins](#mixins)).
+
+For plugins that use PEM-based SSL configuration (`ssl_certificate`, `ssl_key`, `ssl_certificate_authorities`), no keystore format changes are needed.
+
+---
+
+## Bundled plugins
+
+These plugins ship with every Logstash distribution.
+
+### Works out of the box (bundled)
+
+| Plugin | Notes |
+|--------|-------|
+| logstash-input-beats | Netty TLS; uses JVM providers |
+| logstash-input-elasticsearch | TLS via Manticore; uses JVM providers |
+| logstash-input-http | Netty TLS |
+| logstash-input-http_poller | TLS via Manticore |
+| logstash-input-jdbc | No crypto; delegates to JDBC driver |
+| logstash-input-kafka | Kafka client TLS uses JVM providers |
+| logstash-input-redis | No TLS |
+| logstash-input-stdin | No crypto |
+| logstash-input-syslog | No crypto |
+| logstash-input-tcp | TLS via jruby-openssl → BCFIPS |
+| logstash-input-udp | No crypto |
+| logstash-output-elasticsearch | TLS via Manticore; uses JVM providers |
+| logstash-output-http | TLS via Manticore |
+| logstash-output-kafka | Kafka client TLS uses JVM providers |
+| logstash-output-redis | No TLS in bundled version |
+| logstash-output-stdout | No crypto |
+| logstash-output-tcp | TLS via jruby-openssl → BCFIPS |
+| logstash-filter-clone | No crypto |
+| logstash-filter-csv | No crypto |
+| logstash-filter-dissect | No crypto |
+| logstash-filter-dns | No crypto |
+| logstash-filter-drop | No crypto |
+| logstash-filter-elasticsearch | TLS via Faraday; uses JVM providers |
+| logstash-filter-geoip | No crypto |
+| logstash-filter-grok | No crypto |
+| logstash-filter-http | TLS via Manticore |
+| logstash-filter-json | No crypto |
+| logstash-filter-kv | No crypto |
+| logstash-filter-memcached | No crypto |
+| logstash-filter-mutate | No crypto |
+| logstash-filter-ruby | jruby-openssl is routed through BCFIPS/BCJSSE for the whole process, so all `OpenSSL::` calls inside Ruby filter scripts automatically use FIPS-validated providers. Compliance responsibility for script content belongs to the operator. See [Ruby filter and user-supplied code](#ruby-filter-and-user-supplied-code). |
+| logstash-filter-sleep | No crypto |
+| logstash-filter-split | No crypto |
+| logstash-filter-translate | No crypto |
+| logstash-filter-truncate | No crypto |
+| logstash-filter-xml | No crypto |
+| logstash-codec-avro | `bcfks` added to `ssl_keystore_type`/`ssl_truststore_type` validators |
+| logstash-codec-cef | No crypto |
+| logstash-codec-json | No crypto |
+| logstash-codec-json_lines | No crypto |
+| logstash-codec-line | No crypto |
+| logstash-codec-multiline | No crypto |
+| logstash-codec-netflow | No crypto in plugin layer |
+| logstash-codec-plain | No crypto |
+
+### Works with restrictions (bundled)
+
+| Plugin | Restriction | Action required |
+|--------|-------------|-----------------|
+| logstash-codec-avro | TLS via Manticore/jruby-openssl (BCFIPS-routed). `bcfks` is now a valid keystore/truststore type. | Use `ssl_keystore_type => "bcfks"` when pointing to a BCFKS keystore. |
+| logstash-filter-elastic_integration | `ssl_keystore_path` and `ssl_truststore_path` are blocked in FIPS mode. The underlying Java layer (`KeyStoreUtil`) cannot resolve BCFKS keystores. Logstash raises `ConfigurationError` at startup if these settings are used with FIPS enabled. | Use `ssl_certificate` + `ssl_key` for client auth, and `ssl_certificate_authorities` for server trust. |
+| logstash-filter-date | No crypto; but be aware that `timezone` fields and locale handling do not involve any cryptographic operations. | No action needed. |
+| logstash-filter-fingerprint | Default algorithm is `SHA1` (not FIPS-approved). Will fail at runtime under FIPS approved-only mode. | Set `algorithm => "SHA256"` (or SHA384/SHA512). Do not use `MD5` or `SHA1`. |
+| logstash-filter-useragent | No crypto. | No action needed. |
+| logstash-filter-uuid | Uses `SecureRandom.uuid` (FIPS-safe). | No action needed. |
+| logstash-integration-aws | AWS SDK is FIPS-compliant, but standard AWS endpoints are not FIPS-validated. | Set `use_fips_endpoint: true` on all AWS integration plugins (s3, sqs, sns, cloudwatch, etc.). |
+| logstash-integration-elasticsearch | ES output: no `truststore_type`/`keystore_type` config exists so BCFKS cannot be explicitly declared. ES filter and input have no cert-verification control. | Use PEM-based SSL options (`ca_file`, `ssl_certificate`, `ssl_key`) rather than keystores. |
+| logstash-integration-kafka | SCRAM-SHA-1 SASL mechanism is not FIPS-approved. | Use `SCRAM-SHA-256` or `SCRAM-SHA-512` if SASL/SCRAM authentication is required. |
+| logstash-integration-jdbc | No crypto in plugin layer; JDBC driver handles TLS. | Ensure your JDBC driver is FIPS-validated. |
+| logstash-integration-rabbitmq | Inherits `logstash-mixin-rabbitmq_connection` issues: TLS certificate verification is **off by default** when no `ssl_certificate_path` is provided; `ssl_version` accepts any string including `TLSv1.1`. | Always set `ssl_certificate_path` (forces peer verification). Explicitly set `ssl_version => "TLSv1.2"` or `"TLSv1.3"`. |
+| logstash-integration-snmp | Exposes `auth_protocol` (allows `md5`) and `priv_protocol` (allows `des`, `3des`). | Set `auth_protocol` to `sha`, `sha2`, or higher. Set `priv_protocol` to `aes`, `aes128`, `aes192`, or `aes256`. Do not use `md5`, `des`, or `3des`. |
+
+---
+
+## Additional plugins
+
+These plugins are available from the [logstash-plugins](https://github.com/logstash-plugins) GitHub organization but are not bundled with the default Logstash distribution. Install them with `bin/logstash-plugin install <plugin-name>`.
+
+### Works out of the box (additional)
+
+| Plugin | Notes |
+|--------|-------|
+| logstash-input-cloudwatch | AWS SDK; no plugin-level crypto |
+| logstash-input-couchdb_changes | HTTPS via Manticore |
+| logstash-input-dead_letter_queue | No crypto |
+| logstash-input-drupal_dblog | Plain MySQL; no crypto |
+| logstash-input-elastic_serverless_forwarder | SSL well-structured; defaults to cert verification on |
+| logstash-input-eventlog | Windows Event Log; no crypto |
+| logstash-input-exec | Process execution; no crypto |
+| logstash-input-file | No crypto (sincedb MD5 issue is in `build_random_sincedb_filename` in the standalone plugin, not this bundled version — see restrictions) |
+| logstash-input-ganglia | UDP; no crypto |
+| logstash-input-gelf | TCP/UDP; no crypto |
+| logstash-input-gemfire | GemFire Java client; SSL via JVM config |
+| logstash-input-generator | Synthetic events; no crypto |
+| logstash-input-google_cloud_storage | GCP SDK handles TLS; no plugin-level SSL bypass |
+| logstash-input-google_pubsub | GCP SDK handles TLS |
+| logstash-input-graphite | TCP; no crypto |
+| logstash-input-heartbeat | No crypto |
+| logstash-input-jmx | JMX; SSL at JVM level |
+| logstash-input-journald | No crypto (`Base64.encode64` for binary fields only) |
+| logstash-input-kinesis | AWS KCL; SDK handles TLS |
+| logstash-input-lumberjack | TLS via jruby-openssl → BCFIPS |
+| logstash-input-meetup | Faraday HTTPS; no explicit SSL bypass |
+| logstash-input-neo4j | No crypto |
+| logstash-input-perfmon | Windows Performance Monitor; no crypto |
+| logstash-input-pipe | No crypto |
+| logstash-input-rabbitmq | TLS via Bunny gem using jruby-openssl → BCFIPS |
+| logstash-input-rackspace | Fog gem HTTPS; no explicit bypass |
+| logstash-input-relp | TLS via jruby-openssl → BCFIPS; PEM-based SSL only |
+| logstash-input-rss | Faraday HTTPS; no explicit SSL bypass |
+| logstash-input-s3 (integration-aws version) | AWS SDK handles TLS; use this version, not standalone |
+| logstash-input-s3sqs | AWS SDK handles TLS |
+| logstash-input-salesforce | Restforce gem HTTPS; no explicit bypass |
+| logstash-input-snmp (integration version) | Same restriction as integration-snmp above — use FIPS-approved protocols |
+| logstash-input-sqlite | No crypto |
+| logstash-input-sqs | `md5_field` stores an SQS-provided MD5 string (not a Ruby `Digest::MD5` call); no FIPS violation |
+| logstash-input-stomp | Plain STOMP; no crypto |
+| logstash-input-tcp | TLS via jruby-openssl → BCFIPS |
+| logstash-input-twitter | HTTPS via jruby-openssl → BCFIPS |
+| logstash-input-unix | Unix domain sockets; no crypto |
+| logstash-input-varnishlog | Varnish shared memory; no crypto |
+| logstash-input-wmi | Windows WMI; no crypto |
+| logstash-input-xmpp | xmpp4r gem handles TLS; no explicit bypass in plugin |
+| logstash-input-zenoss | RabbitMQ; no direct crypto |
+| logstash-input-zeromq | ZMQ framing only; no CURVE/ZAP auth in plugin |
+| logstash-output-appsearch | Delegates to app-search gem; no explicit SSL config |
+| logstash-output-csv | File write; no crypto |
+| logstash-output-elastic_app_search | Delegates to elastic-app-search gem; no explicit SSL config |
+| logstash-output-email | TLS via jruby-openssl → BCFIPS |
+| logstash-output-exec | Shell exec; no crypto |
+| logstash-output-file | File write; no crypto |
+| logstash-output-ganglia | UDP; no crypto |
+| logstash-output-gelf | UDP/TCP; no crypto |
+| logstash-output-gemfire | GemFire Java client; SSL at JVM level |
+| logstash-output-google_bigquery | Google SDK handles TLS |
+| logstash-output-google_cloud_storage | Google SDK handles TLS |
+| logstash-output-google_pubsub | Google SDK handles TLS |
+| logstash-output-graphite | Plain TCP; no crypto |
+| logstash-output-graphtastic | UDP/TCP/HTTP; no SSL bypass |
+| logstash-output-hipchat | hipchat gem; no explicit bypass |
+| logstash-output-irc | Cinch gem SSL; no explicit bypass |
+| logstash-output-jira | jira-ruby gem HTTPS; no explicit bypass |
+| logstash-output-jms | JMS/JNDI; SSL at JVM/broker level |
+| logstash-output-juggernaut | Redis-backed; no TLS |
+| logstash-output-lumberjack | TLS via lumberjack gem → jruby-openssl → BCFIPS |
+| logstash-output-metriccatcher | UDP; no crypto |
+| logstash-output-mongodb | TLS via mongoid; JVM providers |
+| logstash-output-nagios | Nagios command file; no crypto |
+| logstash-output-nagios_nsca | Shells to `send_nsca`; encryption in NSCA config |
+| logstash-output-neo4j | Embedded Neo4j; no network SSL |
+| logstash-output-null | No-op; no crypto |
+| logstash-output-opentsdb | Plain TCP; no crypto |
+| logstash-output-pipe | Subprocess; no crypto |
+| logstash-output-rackspace | Fog gem HTTPS; no explicit bypass |
+| logstash-output-rabbitmq | TLS via Bunny gem → jruby-openssl → BCFIPS |
+| logstash-output-riak | riak gem; no explicit VERIFY_NONE |
+| logstash-output-riemann | TCP/UDP via riemann-client; no TLS |
+| logstash-output-s3 | AWS SDK handles TLS |
+| logstash-output-slack | rest-client gem honours OpenSSL defaults; no bypass |
+| logstash-output-sns | AWS SDK handles TLS |
+| logstash-output-solr_http | rsolr gem; no explicit bypass |
+| logstash-output-sqs | AWS SDK handles TLS |
+| logstash-output-statsd | UDP; no crypto |
+| logstash-output-stomp | onstomp gem; no explicit bypass |
+| logstash-output-udp | Raw UDP; no crypto |
+| logstash-output-webhdfs | webhdfs gem; cert/key via PEM, no VERIFY_NONE |
+| logstash-output-websocket | WSS via jruby-openssl → BCFIPS |
+| logstash-output-xmpp | xmpp4r gem; no explicit bypass |
+| logstash-output-zabbix | No SSL/crypto |
+| logstash-output-zeromq | ZMQ framing only; no CURVE auth |
+| logstash-output-zookeeper | zk gem; no explicit bypass |
+| logstash-filter-aggregate | No crypto |
+| logstash-filter-alter | No crypto |
+| logstash-filter-cidr | No crypto |
+| logstash-filter-collate | No crypto |
+| logstash-filter-de_dot | No crypto |
+| logstash-filter-elapsed | No crypto |
+| logstash-filter-environment | No crypto |
+| logstash-filter-extractnumbers | No crypto |
+| logstash-filter-i18n | No crypto |
+| logstash-filter-jdbc_static | No crypto in plugin layer |
+| logstash-filter-jdbc_streaming | No crypto in plugin layer |
+| logstash-filter-json_encode | No crypto |
+| logstash-filter-kubernetes_metadata | `verify_api_ssl: false` is user-controlled, not hardcoded |
+| logstash-filter-language | No crypto |
+| logstash-filter-math | No crypto |
+| logstash-filter-metricize | No crypto |
+| logstash-filter-metrics | Uses `SecureRandom.hex` (FIPS-safe) |
+| logstash-filter-multiline | No crypto |
+| logstash-filter-oui | No crypto |
+| logstash-filter-prune | No crypto |
+| logstash-filter-punct | No crypto |
+| logstash-filter-range | No crypto |
+| logstash-filter-syslog_pri | No crypto |
+| logstash-filter-throttle | No crypto |
+| logstash-filter-tld | No crypto |
+| logstash-filter-unique | No crypto |
+| logstash-filter-urldecode | No crypto |
+| logstash-filter-uuid | Uses `SecureRandom.uuid` (FIPS-safe) |
+| logstash-filter-yaml | No crypto |
+| logstash-filter-zeromq | No crypto |
+| logstash-filter-age | No crypto |
+| logstash-filter-bytes | No crypto |
+| logstash-filter-emoji | No crypto |
+| logstash-codec-cloudfront | Gzip decompression only; no crypto |
+| logstash-codec-cloudtrail | No crypto |
+| logstash-codec-compress_spooler | zlib + MessagePack; no crypto |
+| logstash-codec-csv | No crypto |
+| logstash-codec-dots | No crypto |
+| logstash-codec-edn | No crypto |
+| logstash-codec-edn_lines | No crypto |
+| logstash-codec-es_bulk | No crypto |
+| logstash-codec-fluent | No crypto |
+| logstash-codec-graphite | No crypto |
+| logstash-codec-gzip_lines | No crypto |
+| logstash-codec-msgpack | No crypto |
+| logstash-codec-nmap | No crypto |
+| logstash-codec-oldlogstashjson | No crypto |
+| logstash-codec-pretty | No crypto |
+| logstash-codec-protobuf | No crypto |
+| logstash-codec-rubydebug | No crypto |
+| logstash-codec-s3plain | No crypto |
+
+### Works with restrictions (additional)
+
+| Plugin | Restriction | Action required |
+|--------|-------------|-----------------|
+| logstash-input-file (standalone) | Uses `Digest::MD5` to generate a sincedb filename from the watch path. This is a **non-security** use (internal filename generation from operator-supplied config); it works under C:HYBRID mode. SHA256 is still recommended for future-proofing. | Works as-is. Optionally patch to use `Digest::SHA256` for sincedb filename. |
+| logstash-input-imap | Uses `Digest::MD5` to generate a sincedb filename from IMAP connection parameters. **Non-security** use; works under C:HYBRID. | Works as-is. Optionally patch to use `Digest::SHA256`. |
+| logstash-input-irc | SSL delegated to Cinch gem with no cipher or verification controls exposed at plugin level. | Verify Cinch gem's SSL behavior separately. Prefer inputs with explicit SSL configuration for FIPS deployments. |
+| logstash-input-puppet_facter | Hardcodes `http.verify_mode = OpenSSL::SSL::VERIFY_NONE` in its SSL path. Certificate validation is completely disabled. | Do not use this plugin in FIPS mode until the upstream code is fixed to default to `VERIFY_PEER`. |
+| logstash-input-s3 (standalone) | Uses `Digest::MD5` for sincedb filename generation. **Non-security** use; works under C:HYBRID. | Works as-is. Alternatively use the `logstash-integration-aws` version which does not use MD5. |
+| logstash-input-snmp (standalone) | `auth_protocol` allows `md5` and `priv_protocol` allows `des`/`3des`. These are **security operations** (SNMPv3 message authentication and payload encryption). Using them is not FIPS-compliant even in C:HYBRID mode. | Do not configure `auth_protocol: md5`, `priv_protocol: des`, or `priv_protocol: 3des`. Use `auth_protocol: sha`/`sha2` or higher. Use `priv_protocol: aes`/`aes128`/`aes192`/`aes256`. |
+| logstash-filter-checksum | Allows `MD5` and `SHA1` algorithm values. These are used for **internal event deduplication** (non-security use) and work under C:HYBRID. SHA256 is recommended. | Use `SHA256` or higher for best practice. `MD5`/`SHA1` work at runtime but are not FIPS-validated operations. |
+| logstash-filter-cipher | No algorithm FIPS guard. Non-FIPS ciphers (`DES`, `RC4`, `CAMELLIA`, `BLOWFISH`) perform **security operations** (encryption/decryption) and are not FIPS-compliant. | Restrict `algorithm` to FIPS-approved ciphers: `AES-128-CBC`, `AES-256-CBC`, `AES-128-GCM`, `AES-256-GCM`. |
+| logstash-filter-fingerprint | Default algorithm is `SHA1`. Used for **event deduplication ID generation** (non-security use); works under C:HYBRID. SHA256 is strongly recommended. | Set `algorithm => "SHA256"` (or SHA384/SHA512/MURMUR3/MURMUR3_128) for best practice. |
+| logstash-filter-hashid | Default algorithm is `MD5`. Uses HMAC for **Elasticsearch document ID generation** (non-security use); works under C:HYBRID. SHA256 is strongly recommended. | Set `algorithm => "SHA256"` (or SHA384/SHA512). Note: changing the algorithm changes hash output values, which breaks downstream lookups keyed on existing hashid values. |
+| logstash-output-boundary | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-circonus | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-datadog | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-datadog_metrics | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-icinga | `ssl_verify: false` sets `VERIFY_NONE`; default is `true` (safe). | Keep `ssl_verify: true` (default). |
+| logstash-output-influxdb | `verify_ssl: false` is hardcoded. Certificate validation is unconditionally disabled. | Do not use in FIPS mode. |
+| logstash-output-librato | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-loggly | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE` when using HTTPS. | Do not use in FIPS mode. |
+| logstash-output-monasca_log_api | `*_insecure: true` sets `VERIFY_NONE`; defaults to `false` (safe). | Keep `monasca_log_api_insecure: false` and `keystone_api_insecure: false` (defaults). |
+| logstash-output-newrelic | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-pagerduty | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE`. | Do not use in FIPS mode. |
+| logstash-output-redmine | Hardcodes `verify_mode = OpenSSL::SSL::VERIFY_NONE` whenever `ssl: true`. | Do not use in FIPS mode. |
+| logstash-output-redis (standalone) | `ssl_verification_mode: none` is a valid value; `ssl_supported_protocols` includes `TLSv1.1`. | Set `ssl_verification_mode: full` (default). Do not set `ssl_supported_protocols: ["TLSv1.1"]`. |
+| logstash-output-syslog | `ssl_verify` defaults to `false`, effectively using `VERIFY_NONE` when SSL is enabled. | Explicitly set `ssl_verify: true` when using `ssl-tcp` protocol. |
+| logstash-output-timber | `keystore_type` and `truststore_type` default to `"JKS"` (not FIPS-valid). | Set `keystore_type: "BCFKS"` and `truststore_type: "BCFKS"` when pointing to BCFKS keystores. |
+
+### Not compatible (additional)
+
+| Plugin | Reason | Severity |
+|--------|--------|----------|
+| logstash-codec-collectd | The `security_level => "Encrypt"` mode mandates SHA-1 for post-decryption **integrity verification** of network packets and AES-256-OFB for **payload decryption** — both are security operations not approved under FIPS 140-3. These algorithms are dictated by the collectd wire format and cannot be changed. The `security_level => "Sign"` mode (SHA-256 HMAC) is FIPS-ok and can be used. | High — do not use `security_level => "Encrypt"` in FIPS mode; `"Sign"` and `"None"` are safe |
+| logstash-filter-anonymize | Uses `OpenSSL::HMAC` with MD5 or SHA1 to pseudonymize field values using a secret key. This is a **security operation** — the key-based HMAC is the mechanism that prevents reversal of anonymization. HMAC-MD5 and HMAC-SHA1 are not FIPS-approved for security use even in C:HYBRID mode. This plugin is deprecated. | High — do not use in FIPS mode; use `logstash-filter-fingerprint` with `algorithm => "SHA256"` instead |
+| logstash-input-github | GitHub webhook signature verification uses HMAC-SHA1 (`X-Hub-Signature` header). Verifying a **network message's authenticity** using HMAC-SHA1 is a security operation. This is protocol-mandated by GitHub and cannot be changed. | High — do not use in FIPS mode |
+| logstash-input-snmptrap | The plugin itself contains no hash crypto (SNMPv1/v2c uses cleartext community strings, not MD5). However, SNMPv1/v2c community strings are transmitted in cleartext with no authentication — this is incompatible with FIPS in-transit security requirements for sensitive data. | Medium — acceptable only if the SNMP traffic is within a secured network boundary |
+| logstash-integration-zeromq | ZeroMQ has no TLS transport layer. The CURVE encryption option uses Curve25519/NaCl, which is not on the FIPS 140-2 approved algorithm list. Any cross-host use is incompatible with FIPS in-transit encryption requirements. | High — do not use across host boundaries in FIPS mode |
+| logstash-output-boundary | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-circonus | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-datadog | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-datadog_metrics | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-influxdb | `verify_ssl: false` is hardcoded. No override possible. | High — do not use in FIPS mode |
+| logstash-output-librato | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-loggly | Hardcodes `VERIFY_NONE` on HTTPS with no override. | High — do not use in FIPS mode |
+| logstash-output-newrelic | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-pagerduty | Hardcodes `VERIFY_NONE` with no override. | High — do not use in FIPS mode |
+| logstash-output-redmine | Hardcodes `VERIFY_NONE` whenever SSL is enabled. | High — do not use in FIPS mode |
+
+### Stub repositories (no source code to audit)
+
+The following repositories exist in the logstash-plugins organization but contain no Ruby source code. They cannot be audited and should not be installed:
+
+`logstash-input-cloudwatch_logs`, `logstash-input-drupal_dblog`, `logstash-input-elastic_agent`, `logstash-input-fluentd`, `logstash-input-googleanalytics`, `logstash-input-jmx-pipe`, `logstash-input-log4j2`, `logstash-input-mongodb`, `logstash-input-netflow`, `logstash-output-beats`, `logstash-output-firehose`, `logstash-output-logentries`, `logstash-output-rados`, `logstash-filter-bytesize`, `logstash-filter-cloudfoundry`, `logstash-filter-debug`, `logstash-filter-lookup`, `logstash-filter-script`, `logstash-codec-json_pretty`, `logstash-codec-sflow`, `logstash-integration-azure`
+
+---
+
+## Mixin libraries [mixins]
+
+Mixin libraries are shared modules included by many plugins. Issues here have wide blast radius.
+
+| Mixin | Status | Finding |
+|-------|--------|---------|
+| logstash-mixin-aws | OOTB | No Ruby crypto; delegates to AWS SDK (SigV4/HMAC-SHA256, FIPS-approved). Plugins must be configured to use FIPS endpoint URLs. |
+| logstash-mixin-http_client | NEEDS WORK | `ssl_keystore_type` and `ssl_truststore_type` validators only accept `pkcs12` and `jks` — `bcfks` is rejected. Affects every plugin that includes this mixin: `logstash-input-http_poller`, `logstash-output-http`, `logstash-output-logstash`, and others. Also accepts `TLSv1.1` in `ssl_supported_protocols`. |
+| logstash-mixin-rabbitmq_connection | NEEDS WORK | TLS certificate verification is off by default when no `ssl_certificate_path` is provided. `ssl_version` accepts any string (including `TLSv1.1`). No BCFKS truststore support. |
+
+---
+
+## Summary counts
+
+| Category | Count |
+|----------|-------|
+| Works out of the box | ~140 |
+| Works with restrictions | ~30 |
+| Not compatible | ~14 |
+| Stub/no source | ~21 |
+| **Total audited** | **~205** |
+
+The "not compatible" count is dominated by older output plugins (boundary, circonus, datadog, librato, loggly, newrelic, pagerduty, redmine) that were written before FIPS was a concern and hardcode `VERIFY_NONE`. All bundled plugins either work out of the box or work with documented configuration restrictions.

--- a/docs/reference/logstash-settings-file.md
+++ b/docs/reference/logstash-settings-file.md
@@ -111,4 +111,6 @@ The `logstash.yml` file includes these settings.
 | `otel.exporter.otlp.certificate` {applies_to}`stack: preview 9.5.0+` | Path to a PEM-encoded trusted CA certificate for verifying the OTLP endpoint's TLS certificate. Required when the endpoint uses a self-signed or private CA. | *N/A* |
 | `otel.exporter.otlp.client.key` {applies_to}`stack: preview 9.5.0+` | Path to a PEM-encoded client private key for mutual TLS (mTLS). Must be set together with `otel.exporter.otlp.client.certificate`. | *N/A* |
 | `otel.exporter.otlp.client.certificate` {applies_to}`stack: preview 9.5.0+` | Path to a PEM-encoded client certificate for mutual TLS (mTLS). Must be set together with `otel.exporter.otlp.client.key`. | *N/A* |
+| `xpack.security.fips_mode.enabled` | Set to `true` to enable {{ls}} FIPS mode. {{ls}} does not ship or configure Bouncy Castle FIPS provider jars, `java.security` files, truststores, or related JVM options. You must provide those files and JVM settings before enabling this setting. | `false` |
+| `xpack.security.fips_mode.required_providers` | Optional list of required Java security providers to verify when `xpack.security.fips_mode.enabled` is `true`. Values can be provider names, such as `BCFIPS`, or provider names with simple version patterns, such as `BCFIPS:2*`. | `[]` |
 

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -40,6 +40,7 @@ toc:
       - file: connecting-to-serverless.md
       - file: config-examples.md
   - file: secure-connection.md
+  - file: fips-plugin-compatibility.md
   - file: advanced-logstash-configurations.md
     children:
       - file: multiple-pipelines.md

--- a/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
+++ b/logstash-core/lib/logstash/compiler/lscl/lscl_grammar.rb
@@ -3617,5 +3617,5 @@ module LogStashCompilerLSCLGrammar
   end
 end
 
-LogStashCompilerLSCLGrammarParser = LogStashCompilerLSCLGrammar::Parser
+(remove_const(:LogStashCompilerLSCLGrammarParser) if const_defined?(:LogStashCompilerLSCLGrammarParser)) rescue nil; LogStashCompilerLSCLGrammarParser = LogStashCompilerLSCLGrammar::Parser
 

--- a/logstash-core/lib/logstash/config/grammar.rb
+++ b/logstash-core/lib/logstash/config/grammar.rb
@@ -3641,5 +3641,5 @@ module LogStashConfig
   end
 end
 
-LogStashConfigParser = LogStashConfig::Parser
+(remove_const(:LogStashConfigParser) if const_defined?(:LogStashConfigParser)) rescue nil; LogStashConfigParser = LogStashConfig::Parser
 

--- a/logstash-core/lib/logstash/patches.rb
+++ b/logstash-core/lib/logstash/patches.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require "logstash/patches/fips_jruby_openssl"
 require "logstash/patches/bugfix_jruby_2558"
 require "logstash/patches/cabin"
 require "logstash/patches/profile_require_calls"

--- a/logstash-core/lib/logstash/patches/fips_jruby_openssl.rb
+++ b/logstash-core/lib/logstash/patches/fips_jruby_openssl.rb
@@ -1,0 +1,51 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# In FIPS mode, redirect jruby-openssl's crypto operations to the BCFIPS and
+# BCJSSE providers so that all Ruby-level TLS and cryptography uses
+# FIPS-validated modules instead of the non-FIPS BouncyCastle 1.84 bundled
+# with jruby-openssl.
+#
+# This must run before any `require "openssl"` anywhere in the process, because
+# SecurityHelper caches the provider at first initialization.
+#
+# Mechanism:
+#   SecurityHelper.setSecurityProvider(provider) - routes MessageDigest, Cipher,
+#     KeyFactory, KeyStore, Signature, etc. through the given provider.
+#   -Djruby.openssl.ssl.provider=BCJSSE - routes SSLContext through BCJSSE
+#     (which delegates to BCFIPS for its crypto).
+#
+# We do NOT set -Djruby.openssl.load.jars=false — jruby-openssl still loads BC
+# 1.84 JARs for its internal class structure, but all JCE/JSSE operations are
+# routed through BCFIPS/BCJSSE instead.
+# We DO keep -Djruby.openssl.provider.register=false (set in bin/logstash.lib.sh)
+# so BC 1.84 is never inserted into the JVM security provider list.
+
+# Activate when BCFIPS is registered as the first JVM security provider.
+# We key off provider presence rather than approved_only=true because we run
+# C:HYBRID mode (matching Elasticsearch) which does not set approved_only.
+bcfips_provider = java.security.Security.getProvider("BCFIPS")
+return unless bcfips_provider && java.security.Security.getProviders.first&.getName == "BCFIPS"
+
+# Route all JCE operations (Cipher, MessageDigest, KeyFactory, etc.) through BCFIPS.
+org.jruby.ext.openssl.SecurityHelper.setSecurityProvider(bcfips_provider)
+
+# Route SSLContext through BCJSSE (which uses BCFIPS for its underlying crypto).
+# Only set if not already explicitly configured by the operator.
+unless java.lang.System.getProperty("jruby.openssl.ssl.provider")
+  java.lang.System.setProperty("jruby.openssl.ssl.provider", "BCJSSE")
+end

--- a/logstash-core/lib/logstash/patches/stronger_openssl_defaults.rb
+++ b/logstash-core/lib/logstash/patches/stronger_openssl_defaults.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 require "openssl"
 
 # :nodoc:
@@ -45,40 +46,25 @@ class OpenSSL::SSL::SSLContext
   # OpenSSL::SSL::OP_NO_COMPRESSION) may not be available in all Ruby
   # versions/platforms.
   def self.__default_options
-    # ruby-core is refusing to patch ruby's default openssl settings to be more
-    # secure, so let's fix that here. The next few lines setting options and
-    # ciphers come from jmhodges' proposed patch
     ssloptions = OpenSSL::SSL::OP_ALL
 
-    # TODO(sissel): JRuby doesn't have this. Maybe work on a fix?
     if defined?(OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS)
       ssloptions &= ~OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
     end
 
-    # TODO(sissel): JRuby doesn't have this. Maybe work on a fix?
     if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
       ssloptions |= OpenSSL::SSL::OP_NO_COMPRESSION
     end
 
-    # Disable SSLv2 and SSLv3. They are insecure and highly discouraged.
     ssloptions |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
     ssloptions |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
     ssloptions
   end
 
-  # Overwriting the DEFAULT_PARAMS const idea from here: https://www.ruby-lang.org/en/news/2014/10/27/changing-default-settings-of-ext-openssl/
-  #
-  # This monkeypatch doesn't enforce a `VERIFY_MODE` on the SSLContext,
-  # SSLContext are both used for the client and the server implementation,
-  # If set the `verify_mode` to peer the server won't accept any connection,
-  # because it will try to verify the client certificate, this is a protocol
-  # details implemented at the plugin level.
-  #
-  # For more details see: https://github.com/elastic/logstash/issues/3657
   remove_const(:DEFAULT_PARAMS) if const_defined?(:DEFAULT_PARAMS)
   DEFAULT_PARAMS = {
     :ssl_version => "TLS",
     :ciphers => MOZILLA_INTERMEDIATE_CIPHERS,
-    :options => __default_options # Not a constant because it's computed at start-time.
+    :options => __default_options
   }
 end

--- a/logstash-core/lib/logstash/webserver.rb
+++ b/logstash-core/lib/logstash/webserver.rb
@@ -254,7 +254,11 @@ module LogStash
 
       raise("Password not provided!") unless @ssl_params.fetch(:keystore_password).value
 
-      java.security.KeyStore.getInstance("JKS")
+      fips_active = !java.security.Security.getProvider("BCFIPS").nil? &&
+        java.security.Security.getProviders.first&.getName == "BCFIPS"
+      keystore_type = @ssl_params[:keystore_type] || (fips_active ? "BCFKS" : "JKS")
+
+      java.security.KeyStore.getInstance(keystore_type)
           .load(java.io.FileInputStream.new(@ssl_params.fetch(:keystore_path)),
                 @ssl_params.fetch(:keystore_password).value.chars&.to_java(:char))
     rescue => e

--- a/logstash-core/spec/logstash/patches/fips_jruby_openssl_spec.rb
+++ b/logstash-core/spec/logstash/patches/fips_jruby_openssl_spec.rb
@@ -1,0 +1,83 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "spec_helper"
+
+describe "fips_jruby_openssl patch" do
+  let(:ssl_provider_prop) { "jruby.openssl.ssl.provider" }
+  let(:mock_bcfips) { double("BCFIPSProvider", getName: "BCFIPS") }
+  let(:mock_sun)    { double("SUNProvider",    getName: "SUN") }
+
+  def load_patch
+    load File.expand_path("../../../lib/logstash/patches/fips_jruby_openssl.rb", __dir__)
+  end
+
+  context "when BCFIPS is not the first registered provider" do
+    before do
+      allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(nil)
+      allow(java.security.Security).to receive(:getProviders).and_return([mock_sun])
+    end
+
+    it "does not call setSecurityProvider" do
+      expect(org.jruby.ext.openssl.SecurityHelper).not_to receive(:setSecurityProvider)
+      load_patch
+    end
+
+    it "does not set jruby.openssl.ssl.provider" do
+      expect(java.lang.System).not_to receive(:setProperty).with(ssl_provider_prop, anything)
+      load_patch
+    end
+  end
+
+  context "when BCFIPS is present but not the first provider" do
+    before do
+      allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(mock_bcfips)
+      allow(java.security.Security).to receive(:getProviders).and_return([mock_sun, mock_bcfips])
+    end
+
+    it "does not call setSecurityProvider" do
+      expect(org.jruby.ext.openssl.SecurityHelper).not_to receive(:setSecurityProvider)
+      load_patch
+    end
+  end
+
+  context "when BCFIPS is the first registered provider (FIPS mode)" do
+    before do
+      allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(mock_bcfips)
+      allow(java.security.Security).to receive(:getProviders).and_return([mock_bcfips, mock_sun])
+      allow(java.lang.System).to receive(:getProperty).with(ssl_provider_prop).and_return(nil)
+      allow(org.jruby.ext.openssl.SecurityHelper).to receive(:setSecurityProvider)
+      allow(java.lang.System).to receive(:setProperty)
+    end
+
+    it "passes the BCFIPS provider to SecurityHelper" do
+      load_patch
+      expect(org.jruby.ext.openssl.SecurityHelper).to have_received(:setSecurityProvider).with(mock_bcfips)
+    end
+
+    it "sets jruby.openssl.ssl.provider to BCJSSE" do
+      load_patch
+      expect(java.lang.System).to have_received(:setProperty).with(ssl_provider_prop, "BCJSSE")
+    end
+
+    it "does not override jruby.openssl.ssl.provider if already set" do
+      allow(java.lang.System).to receive(:getProperty).with(ssl_provider_prop).and_return("SomeOtherProvider")
+      load_patch
+      expect(java.lang.System).not_to have_received(:setProperty).with(ssl_provider_prop, anything)
+    end
+  end
+end

--- a/logstash-core/spec/logstash/patches/stronger_openssl_defaults_spec.rb
+++ b/logstash-core/spec/logstash/patches/stronger_openssl_defaults_spec.rb
@@ -1,0 +1,41 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "spec_helper"
+
+describe "stronger_openssl_defaults patch" do
+  before do
+    load File.expand_path("../../../lib/logstash/patches/stronger_openssl_defaults.rb", __dir__)
+  end
+
+  it "defines OpenSSL::SSL::SSLContext::DEFAULT_PARAMS" do
+    expect(defined?(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS)).to be_truthy
+  end
+
+  it "includes MOZILLA_INTERMEDIATE_CIPHERS in DEFAULT_PARAMS" do
+    expect(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]).to include("ECDHE-RSA-AES128-GCM-SHA256")
+  end
+
+  it "sets ssl_version to TLS in DEFAULT_PARAMS" do
+    expect(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version]).to eq("TLS")
+  end
+
+  it "wraps SSLContext.new to invoke set_params" do
+    # The patch aliases SSLContext.new; constructing a context should not raise
+    expect { OpenSSL::SSL::SSLContext.new }.not_to raise_error
+  end
+end

--- a/logstash-core/spec/logstash/webserver_spec.rb
+++ b/logstash-core/spec/logstash/webserver_spec.rb
@@ -153,6 +153,54 @@ describe LogStash::WebServer do
     end
   end
 
+  describe "#validate_keystore_access!" do
+    let(:keystore_password) { double("password", value: "changeit") }
+    let(:mock_input_stream) { double("FileInputStream") }
+    let(:ssl_params) { { keystore_path: "/path/to/keystore", keystore_password: keystore_password } }
+
+    def stub_keystore_load(type)
+      keystore = double("keystore")
+      allow(java.security.KeyStore).to receive(:getInstance).with(type).and_return(keystore)
+      allow(java.io.FileInputStream).to receive(:new).with("/path/to/keystore").and_return(mock_input_stream)
+      allow(keystore).to receive(:load)
+    end
+
+    context "in non-FIPS mode" do
+      before do
+        allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(nil)
+        allow(java.security.Security).to receive(:getProviders).and_return([])
+        stub_keystore_load("JKS")
+      end
+
+      it "uses JKS by default" do
+        ws = LogStash::WebServer.new(logger, agent, webserver_options.merge(:ssl_params => ssl_params))
+        expect(java.security.KeyStore).to have_received(:getInstance).with("JKS")
+      end
+    end
+
+    context "in FIPS mode" do
+      let(:mock_bcfips) { double("BCFIPSProvider", getName: "BCFIPS") }
+
+      before do
+        allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(mock_bcfips)
+        allow(java.security.Security).to receive(:getProviders).and_return([mock_bcfips])
+      end
+
+      it "uses BCFKS by default" do
+        stub_keystore_load("BCFKS")
+        ws = LogStash::WebServer.new(logger, agent, webserver_options.merge(:ssl_params => ssl_params))
+        expect(java.security.KeyStore).to have_received(:getInstance).with("BCFKS")
+      end
+
+      it "uses the explicitly configured keystore type when provided" do
+        stub_keystore_load("PKCS12")
+        opts = webserver_options.merge(:ssl_params => ssl_params.merge(keystore_type: "PKCS12"))
+        ws = LogStash::WebServer.new(logger, agent, opts)
+        expect(java.security.KeyStore).to have_received(:getInstance).with("PKCS12")
+      end
+    end
+  end
+
   context "when configured with http basic auth" do
     around(:each) do |example|
       begin

--- a/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreUtil.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/SecretStoreUtil.java
@@ -21,9 +21,9 @@
 package org.logstash.secret.store;
 
 import java.nio.ByteBuffer;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Random;
 
 /**
  * Conversion utility between String, bytes, and chars. All methods attempt to keep sensitive data out of memory. Sensitive data should avoid using Java {@link String}'s.
@@ -36,7 +36,7 @@ final public class SecretStoreUtil {
     private SecretStoreUtil() {
     }
 
-    private static final Random RANDOM = new Random();
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     /**
      * Converts bytes from ascii encoded text to a char[] and zero outs the original byte[]

--- a/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
+++ b/logstash-core/src/main/java/org/logstash/secret/store/backend/JavaKeyStore.java
@@ -59,10 +59,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.security.SecureRandom;
+import java.security.Security;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -75,7 +76,10 @@ import static org.logstash.secret.store.SecretStoreFactory.LOGSTASH_MARKER;
  * <p>This class is threadsafe.</p>
  */
 public final class JavaKeyStore implements SecretStore {
-    private static final String KEYSTORE_TYPE = "pkcs12";
+    private static final boolean FIPS_MODE = Security.getProvider("BCFIPS") != null &&
+            Security.getProviders().length > 0 && "BCFIPS".equals(Security.getProviders()[0].getName());
+    private static final String KEYSTORE_TYPE = FIPS_MODE ? "BCFKS" : "pkcs12";
+    private static final String PBE_ALGORITHM = FIPS_MODE ? "PBEWithHmacSHA256AndAES_256" : "PBE";
     private static final Logger LOGGER = LogManager.getLogger(JavaKeyStore.class);
     private static final String PATH_KEY = "keystore.file";
     private final CharsetEncoder asciiEncoder = StandardCharsets.US_ASCII.newEncoder();
@@ -113,7 +117,7 @@ public final class JavaKeyStore implements SecretStore {
             Files.createFile(keyStorePath);
             try {
                 keyStore = KeyStore.Builder.newInstance(KEYSTORE_TYPE, null, protectionParameter).getKeyStore();
-                SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+                SecretKeyFactory factory = SecretKeyFactory.getInstance(PBE_ALGORITHM);
                 byte[] base64 = SecretStoreUtil.base64Encode(LOGSTASH_MARKER.getKey().getBytes(StandardCharsets.UTF_8));
                 SecretKey secretKey = factory.generateSecret(new PBEKeySpec(SecretStoreUtil.asciiBytesToChar(base64)));
                 keyStore.setEntry(LOGSTASH_MARKER.toExternalForm(), new KeyStore.SecretKeyEntry(secretKey), protectionParameter);
@@ -125,7 +129,7 @@ public final class JavaKeyStore implements SecretStore {
                 }
                 LOGGER.info("Created Logstash keystore at {}", keyStorePath.toAbsolutePath());
                 return this;
-            } catch (Exception e) {
+            } catch (Exception | Error e) {
                 throw new SecretStoreException.CreateException("Failed to create Logstash keystore.", e);
             }
         } catch (SecretStoreException sse) {
@@ -206,7 +210,7 @@ public final class JavaKeyStore implements SecretStore {
         if (!existing) {
             //create the pass
             byte[] randomBytes = new byte[32];
-            new Random().nextBytes(randomBytes);
+            new SecureRandom().nextBytes(randomBytes);
             return SecretStoreUtil.base64EncodeToChars(randomBytes);
         }
         //read the pass
@@ -327,7 +331,7 @@ public final class JavaKeyStore implements SecretStore {
         try {
             lock.lock();
             loadKeyStore();
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(PBE_ALGORITHM);
             //PBEKey requires an ascii password, so base64 encode it
             byte[] base64 = SecretStoreUtil.base64Encode(secret);
             PBEKeySpec passwordBasedKeySpec = new PBEKeySpec(SecretStoreUtil.asciiBytesToChar(base64));
@@ -340,7 +344,7 @@ public final class JavaKeyStore implements SecretStore {
                 SecretStoreUtil.clearBytes(secret);
             }
             LOGGER.debug("persisted secret {}", identifier.toExternalForm());
-        } catch (Exception e) {
+        } catch (Exception | Error e) {
             throw new SecretStoreException.PersistException(identifier, e);
         } finally {
             releaseLock(lock);
@@ -385,7 +389,7 @@ public final class JavaKeyStore implements SecretStore {
             try {
                 lock.lock();
                 loadKeyStore();
-                SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+                SecretKeyFactory factory = SecretKeyFactory.getInstance(PBE_ALGORITHM);
                 KeyStore.SecretKeyEntry secretKeyEntry = (KeyStore.SecretKeyEntry) keyStore.getEntry(identifier.toExternalForm(), protectionParameter);
                 //not found
                 if (secretKeyEntry == null) {
@@ -399,7 +403,7 @@ public final class JavaKeyStore implements SecretStore {
                 passwordBasedKeySpec.clearPassword();
                 LOGGER.debug("retrieved secret {}", identifier.toExternalForm());
                 return secret;
-            } catch (Exception e) {
+            } catch (Exception | Error e) {
                 throw new SecretStoreException.RetrievalException(identifier, e);
             } finally {
                 releaseLock(lock);

--- a/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
+++ b/logstash-core/src/test/java/org/logstash/secret/store/backend/JavaKeyStoreTest.java
@@ -30,6 +30,7 @@ import org.logstash.secret.SecretIdentifier;
 import org.logstash.secret.store.SecretStore;
 import org.logstash.secret.store.SecretStoreException;
 import org.logstash.secret.store.SecretStoreFactory;
+import org.logstash.secret.store.SecretStoreUtil;
 import org.logstash.secret.store.SecureConfig;
 
 import java.io.File;
@@ -733,5 +734,52 @@ public class JavaKeyStoreTest {
             executorService.shutdownNow();
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
         }
+    }
+
+    @Test
+    public void testKeystoreTypeIsFipsAwareAtClassLoad() {
+        // The FIPS_MODE flag is read at class-load time via BCFIPS provider presence.
+        // We verify the constant values are self-consistent: if FIPS_MODE is true,
+        // KEYSTORE_TYPE should be "BCFKS" and PBE_ALGORITHM should be the FIPS algorithm.
+        // If FIPS_MODE is false, KEYSTORE_TYPE should be "pkcs12" and PBE_ALGORITHM "PBE".
+        // Since we can't change the provider list after class load, we verify the currently
+        // loaded values are internally consistent.
+        java.security.Provider[] providers = java.security.Security.getProviders();
+        boolean fipsMode = java.security.Security.getProvider("BCFIPS") != null &&
+                providers.length > 0 && "BCFIPS".equals(providers[0].getName());
+        // Access via reflection since the fields are private
+        try {
+            java.lang.reflect.Field fipsModeField = JavaKeyStore.class.getDeclaredField("FIPS_MODE");
+            fipsModeField.setAccessible(true);
+            boolean loadedFipsMode = (boolean) fipsModeField.get(null);
+            assertThat(loadedFipsMode).isEqualTo(fipsMode);
+
+            java.lang.reflect.Field keystoreTypeField = JavaKeyStore.class.getDeclaredField("KEYSTORE_TYPE");
+            keystoreTypeField.setAccessible(true);
+            String keystoreType = (String) keystoreTypeField.get(null);
+
+            java.lang.reflect.Field pbeAlgorithmField = JavaKeyStore.class.getDeclaredField("PBE_ALGORITHM");
+            pbeAlgorithmField.setAccessible(true);
+            String pbeAlgorithm = (String) pbeAlgorithmField.get(null);
+
+            if (fipsMode) {
+                assertThat(keystoreType).isEqualTo("BCFKS");
+                assertThat(pbeAlgorithm).isEqualTo("PBEWithHmacSHA256AndAES_256");
+            } else {
+                assertThat(keystoreType).isEqualTo("pkcs12");
+                assertThat(pbeAlgorithm).isEqualTo("PBE");
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail("Could not access FIPS_MODE, KEYSTORE_TYPE or PBE_ALGORITHM fields via reflection: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSecretStoreUtilUsesSecureRandom() throws Exception {
+        // Verify that SecretStoreUtil.RANDOM is a SecureRandom, not java.util.Random
+        java.lang.reflect.Field randomField = SecretStoreUtil.class.getDeclaredField("RANDOM");
+        randomField.setAccessible(true);
+        Object randomInstance = randomField.get(null);
+        assertThat(randomInstance).isInstanceOf(java.security.SecureRandom.class);
     }
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,8 @@ RSpec.configure do |c|
   Flores::RSpec.configure(c)
   c.include LogStashHelper
   c.extend LogStashHelper
-  c.filter_run_excluding skip_fips: true if java.lang.System.getProperty("org.bouncycastle.fips.approved_only") == "true"
+  # Detect FIPS via BCFIPS provider presence; C:HYBRID mode does not set approved_only=true
+  c.filter_run_excluding skip_fips: true if !java.security.Security.getProvider("BCFIPS").nil?
   if ENV['COVERAGE']
     c.after(:suite) do
       SimpleCov.result.format!

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 
 configurations {
   geolite2
+  fipsProviderJars
 }
 
 dependencies {
@@ -28,6 +29,18 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
 
   geolite2('org.elasticsearch:geolite2-databases:20191119') {
+    transitive = false
+  }
+  fipsProviderJars('org.bouncycastle:bc-fips:2.0.0') {
+    transitive = false
+  }
+  fipsProviderJars('org.bouncycastle:bcpkix-fips:2.0.7') {
+    transitive = false
+  }
+  fipsProviderJars('org.bouncycastle:bctls-fips:2.0.19') {
+    transitive = false
+  }
+  fipsProviderJars('org.bouncycastle:bcutil-fips:2.0.3') {
     transitive = false
   }
 }
@@ -42,6 +55,11 @@ tasks.register("unzipGeolite", Copy) {
     include "GeoLite2-City.mmdb"
   }
   into file("${projectDir}/spec/filters/geoip/vendor")
+}
+
+tasks.register("copyFipsProviderJars", Copy) {
+  from configurations.fipsProviderJars
+  into file("${buildDir}/fips-provider-jars")
 }
 
 tasks.register("rubyTests", Test) {
@@ -64,12 +82,14 @@ tasks.register("rubyIntegrationTests", Test) {
   dependsOn ":copyEs"
   dependsOn ":assemble"
   dependsOn "buildFipsValidationGem"
+  dependsOn "copyFipsProviderJars"
   inputs.files fileTree("${projectDir}/qa")
   inputs.files fileTree("${projectDir}/lib")
   inputs.files fileTree("${projectDir}/modules")
   inputs.files fileTree("${rootProject.projectDir}/Gemfile.lock")
   inputs.files fileTree("${rootProject.projectDir}/logstash-core/lib")
   systemProperty 'logstash.root.dir', projectDir.parent
+  systemProperty 'logstash.fips.provider.jars.dir', file("${buildDir}/fips-provider-jars")
   if (project.hasProperty('rubyIntegrationSpecs')) {
     systemProperty 'org.logstash.xpack.integration.specs', project.property('rubyIntegrationSpecs')
   }

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -31,16 +31,16 @@ dependencies {
   geolite2('org.elasticsearch:geolite2-databases:20191119') {
     transitive = false
   }
-  fipsProviderJars('org.bouncycastle:bc-fips:2.0.0') {
+  fipsProviderJars('org.bouncycastle:bc-fips:2.0.1') {
     transitive = false
   }
   fipsProviderJars('org.bouncycastle:bcpkix-fips:2.0.7') {
     transitive = false
   }
-  fipsProviderJars('org.bouncycastle:bctls-fips:2.0.19') {
+  fipsProviderJars('org.bouncycastle:bctls-fips:2.0.22') {
     transitive = false
   }
-  fipsProviderJars('org.bouncycastle:bcutil-fips:2.0.3') {
+  fipsProviderJars('org.bouncycastle:bcutil-fips:2.0.5') {
     transitive = false
   }
 }

--- a/x-pack/distributions/internal/observabilitySRE/build-ext.gradle
+++ b/x-pack/distributions/internal/observabilitySRE/build-ext.gradle
@@ -34,7 +34,7 @@ allprojects {
                 systemProperty "javax.net.ssl.trustStorePassword", "changeit"
                 systemProperty "ssl.KeyManagerFactory.algorithm", "PKIX"
                 systemProperty "ssl.TrustManagerFactory.algorithm", "PKIX"
-                systemProperty "org.bouncycastle.fips.approved_only", "true"
+                // C:HYBRID mode is configured in java.security; approved_only is intentionally not set.
             }
         }
     }

--- a/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options
+++ b/x-pack/distributions/internal/observabilitySRE/config/fips-jvm.options
@@ -6,4 +6,4 @@
 -Djavax.net.ssl.trustStorePassword=changeit
 -Dssl.KeyManagerFactory.algorithm=PKIX
 -Dssl.TrustManagerFactory.algorithm=PKIX
--Dorg.bouncycastle.fips.approved_only=true
+# C:HYBRID mode is configured in java.security; approved_only is intentionally not set.

--- a/x-pack/distributions/internal/observabilitySRE/config/security/java.security
+++ b/x-pack/distributions/internal/observabilitySRE/config/security/java.security
@@ -1,4 +1,4 @@
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN
 security.provider.4=-BC
@@ -109,4 +109,5 @@ jdk.io.permissionsUseCanonicalPath=false
 
 jdk.tls.alpnCharset=ISO_8859_1
 
-org.bouncycastle.fips.approved_only=true
+# C:HYBRID mode allows non-approved algorithms outside security-sensitive contexts.
+# This matches Elasticsearch's FIPS configuration. approved_only is intentionally not set.

--- a/x-pack/distributions/internal/observabilitySRE/docker/Dockerfile
+++ b/x-pack/distributions/internal/observabilitySRE/docker/Dockerfile
@@ -67,8 +67,8 @@ ENV LS_JAVA_OPTS="\
     -Djavax.net.ssl.trustStoreProvider=BCFIPS \
     -Djavax.net.ssl.trustStorePassword=changeit \
     -Dssl.KeyManagerFactory.algorithm=PKIX \
-    -Dssl.TrustManagerFactory.algorithm=PKIX \
-    -Dorg.bouncycastle.fips.approved_only=true"
+    -Dssl.TrustManagerFactory.algorithm=PKIX"
+    # C:HYBRID mode is configured in java.security; approved_only is intentionally not set.
 
 # Example test run, most use cases will override this
 CMD ["./gradlew", "--info", "--stacktrace", "-PfedrampHighMode=true", "runIntegrationTests"]

--- a/x-pack/distributions/internal/observabilitySRE/qa/acceptance/docker/logstash/config/logstash-fips.yml
+++ b/x-pack/distributions/internal/observabilitySRE/qa/acceptance/docker/logstash/config/logstash-fips.yml
@@ -1,5 +1,7 @@
 api.http.host: "0.0.0.0"
 xpack.monitoring.enabled: false
+xpack.security.fips_mode.enabled: true
+xpack.security.fips_mode.required_providers: ["BCFIPS", "BCJSSE"]
 
 pipeline.ordered: false
 pipeline.workers: 2

--- a/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/logstash/config/logstash.yml
+++ b/x-pack/distributions/internal/observabilitySRE/qa/smoke/docker/logstash/config/logstash.yml
@@ -1,5 +1,7 @@
 api.http.host: "0.0.0.0"
 xpack.monitoring.enabled: false
+xpack.security.fips_mode.enabled: true
+xpack.security.fips_mode.required_providers: ["BCFIPS", "BCJSSE"]
 
 pipeline.ordered: false
 pipeline.workers: 2

--- a/x-pack/lib/security/extension.rb
+++ b/x-pack/lib/security/extension.rb
@@ -1,0 +1,33 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "security/fips_bootstrap_check"
+
+module LogStash
+  module Security
+    class Extension < LogStash::UniversalPlugin
+      include LogStash::Util::Loggable
+
+      def register_hooks(hooks)
+        require "logstash/runner"
+        hooks.register_hooks(LogStash::Runner, Hooks.new)
+      end
+
+      def additionals_settings(settings)
+        logger.trace("Registering security settings")
+        settings.register(LogStash::Setting::BooleanSetting.new("xpack.security.fips_mode.enabled", false))
+        settings.register(LogStash::Setting::StringArray.new("xpack.security.fips_mode.required_providers", []))
+      rescue => e
+        logger.error("Cannot register security settings", :message => e.message, :backtrace => e.backtrace)
+        raise e
+      end
+    end
+
+    class Hooks
+      def before_bootstrap_checks(runner)
+        runner.bootstrap_checks << FipsBootstrapCheck
+      end
+    end
+  end
+end

--- a/x-pack/lib/security/fips_bootstrap_check.rb
+++ b/x-pack/lib/security/fips_bootstrap_check.rb
@@ -13,17 +13,53 @@ module LogStash
       def check(settings)
         return unless settings.get("xpack.security.fips_mode.enabled")
 
-        required_providers = settings.get("xpack.security.fips_mode.required_providers")
-        return if required_providers.empty?
+        failures = []
+        failures.concat(check_provider_ordering)
+        failures.concat(check_secure_random_provider)
+        failures.concat(check_fips_ready)
+        failures.concat(check_jruby_openssl_not_registered)
 
-        failures = missing_required_providers(required_providers)
+        required_providers = settings.get("xpack.security.fips_mode.required_providers")
+        failures.concat(missing_required_providers(required_providers)) unless required_providers.empty?
+
         return if failures.empty?
 
         raise LogStash::BootstrapCheckError,
-          "Logstash is not configured with the required FIPS security providers: #{failures.join('; ')}"
+          "Logstash is not configured in a FIPS-compliant manner:\n  - #{failures.join("\n  - ")}"
       end
 
       private
+
+      def check_provider_ordering
+        first_provider = ::Java::java.security.Security.getProviders.first
+        return [] if first_provider&.name == "BCFIPS"
+        ["BCFIPS must be the first Java security provider (observed: #{first_provider&.name.inspect})"]
+      end
+
+      def check_secure_random_provider
+        observed = ::Java::java.security.SecureRandom.new.getProvider.getName
+        return [] if observed == "BCFIPS"
+        ["Java SecureRandom must be provided by BCFIPS (observed: #{observed.inspect})"]
+      end
+
+      def check_fips_ready
+        return [] if ::Java::org.bouncycastle.crypto.fips.FipsStatus.isReady
+        ["BouncyCastle FIPS is not ready"]
+      rescue => e
+        ["BouncyCastle FIPS classes are not available: #{e.message}"]
+      end
+
+      def check_jruby_openssl_not_registered
+        failures = []
+        if org.jruby.ext.openssl.SecurityHelper.isProviderRegistered
+          failures << "The non-FIPS JRuby OpenSSL security provider must not be registered"
+        elsif org.jruby.util.SafePropertyAccessor.getBoolean("jruby.openssl.provider.register") != false
+          failures << "The non-FIPS JRuby OpenSSL security provider is eligible for registration; set -Djruby.openssl.provider.register=false"
+        end
+        failures
+      rescue => e
+        ["Could not verify JRuby OpenSSL provider state: #{e.message}"]
+      end
 
       def missing_required_providers(required_providers)
         observed_providers = ::Java::java.security.Security.getProviders
@@ -43,7 +79,6 @@ module LogStash
         version_regex = Regexp.new("\\A#{Regexp.escape(version_pattern).gsub("\\*", ".*")}\\z")
         provider.getVersionStr.match?(version_regex)
       end
-
     end
   end
 end

--- a/x-pack/lib/security/fips_bootstrap_check.rb
+++ b/x-pack/lib/security/fips_bootstrap_check.rb
@@ -1,0 +1,49 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "logstash/environment"
+
+module LogStash
+  module Security
+    module FipsBootstrapCheck
+      extend self
+      include LogStash::Util::Loggable
+
+      def check(settings)
+        return unless settings.get("xpack.security.fips_mode.enabled")
+
+        required_providers = settings.get("xpack.security.fips_mode.required_providers")
+        return if required_providers.empty?
+
+        failures = missing_required_providers(required_providers)
+        return if failures.empty?
+
+        raise LogStash::BootstrapCheckError,
+          "Logstash is not configured with the required FIPS security providers: #{failures.join('; ')}"
+      end
+
+      private
+
+      def missing_required_providers(required_providers)
+        observed_providers = ::Java::java.security.Security.getProviders
+        required_providers.filter_map do |provider_requirement|
+          provider_name, version_pattern = provider_requirement.split(":", 2)
+          provider = observed_providers.find { |candidate| candidate.name == provider_name }
+
+          if provider.nil?
+            "missing provider #{provider_name.inspect}"
+          elsif version_pattern && !version_matches?(provider, version_pattern)
+            "provider #{provider_name.inspect} version #{provider.getVersionStr.inspect} does not match #{version_pattern.inspect}"
+          end
+        end
+      end
+
+      def version_matches?(provider, version_pattern)
+        version_regex = Regexp.new("\\A#{Regexp.escape(version_pattern).gsub("\\*", ".*")}\\z")
+        provider.getVersionStr.match?(version_regex)
+      end
+
+    end
+  end
+end

--- a/x-pack/lib/x-pack/logstash_registry.rb
+++ b/x-pack/lib/x-pack/logstash_registry.rb
@@ -9,12 +9,14 @@ require "monitoring/inputs/metrics"
 require "monitoring/outputs/elasticsearch_monitoring"
 require "config_management/extension"
 require "geoip_database_management/extension"
+require "security/extension"
 
 LogStash::PLUGIN_REGISTRY.add(:input, "metrics", LogStash::Inputs::Metrics)
 LogStash::PLUGIN_REGISTRY.add(:output, "elasticsearch_monitoring", LogStash::Outputs::ElasticSearchMonitoring)
 LogStash::PLUGIN_REGISTRY.add(:universal, "monitoring", LogStash::MonitoringExtension)
 LogStash::PLUGIN_REGISTRY.add(:universal, "config_management", LogStash::ConfigManagement::Extension)
 LogStash::PLUGIN_REGISTRY.add(:universal, "geoip_database_management", LogStash::GeoipDatabaseManagement::Extension)
+LogStash::PLUGIN_REGISTRY.add(:universal, "security", LogStash::Security::Extension)
 
 license_levels = Hash.new
 license_levels.default = LogStash::LicenseChecker::LICENSE_TYPES

--- a/x-pack/qa/integration/fips-validation/fixtures/java.security
+++ b/x-pack/qa/integration/fips-validation/fixtures/java.security
@@ -1,0 +1,109 @@
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
+security.provider.3=SUN
+security.provider.4=-BC
+
+securerandom.source=file:/dev/urandom
+securerandom.strongAlgorithms=NativePRNGBlocking:SUN,DRBG:SUN
+securerandom.drbg.config=
+
+login.configuration.provider=sun.security.provider.ConfigFile
+
+keystore.type=BCFKS
+keystore.type.compat=true
+
+package.access=sun.misc.,\
+               sun.reflect.
+package.definition=sun.misc.,\
+                   sun.reflect.
+
+security.overridePropertiesFile=true
+
+ssl.KeyManagerFactory.algorithm=PKIX
+ssl.TrustManagerFactory.algorithm=PKIX
+
+networkaddress.cache.negative.ttl=10
+
+krb5.kdc.bad.policy = tryLast
+
+sun.security.krb5.disableReferrals=false
+sun.security.krb5.maxReferrals=5
+
+jdk.disabled.namedCurves = secp112r1, secp112r2, secp128r1, secp128r2, \
+    secp160k1, secp160r1, secp160r2, secp192k1, secp192r1, secp224k1, \
+    secp224r1, secp256k1, sect113r1, sect113r2, sect131r1, sect131r2, \
+    sect163k1, sect163r1, sect163r2, sect193r1, sect193r2, sect233k1, \
+    sect233r1, sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, \
+    sect571k1, sect571r1, X9.62 c2tnb191v1, X9.62 c2tnb191v2, \
+    X9.62 c2tnb191v3, X9.62 c2tnb239v1, X9.62 c2tnb239v2, X9.62 c2tnb239v3, \
+    X9.62 c2tnb359v1, X9.62 c2tnb431r1, X9.62 prime192v2, X9.62 prime192v3, \
+    X9.62 prime239v1, X9.62 prime239v2, X9.62 prime239v3, brainpoolP256r1, \
+    brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
+
+jdk.certpath.disabledAlgorithms=MD2, MD5, \
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
+    SHA1, \
+    secp112r1, secp112r2, secp128r1, secp128r2, \
+    secp160k1, secp160r1, secp160r2, secp192k1, secp192r1, secp224k1, \
+    secp224r1, secp256k1, sect113r1, sect113r2, sect131r1, sect131r2, \
+    sect163k1, sect163r1, sect163r2, sect193r1, sect233k1, sect233r1, \
+    sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, sect571k1, \
+    sect571r1, brainpoolP256r1, brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
+
+jdk.security.legacyAlgorithms=SHA1, \
+    RSA keySize < 2048, DSA keySize < 2048
+
+jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
+    DSA keySize < 1024, SHA1, \
+    secp112r1, secp112r2, secp128r1, secp128r2, \
+    secp160k1, secp160r1, secp160r2, secp192k1, secp192r1, secp224k1, \
+    secp224r1, secp256k1, sect113r1, sect113r2, sect131r1, sect131r2, \
+    sect163k1, sect163r1, sect163r2, sect193r1, sect233k1, sect233r1, \
+    sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, sect571k1, \
+    sect571r1, X9.62 c2tnb191v1, X9.62 c2tnb191v2, X9.62 c2tnb191v3, \
+    X9.62 c2tnb239v1, X9.62 c2tnb239v2, X9.62 c2tnb239v3, X9.62 c2tnb359v1, \
+    X9.62 c2tnb431r1, X9.62 prime192v2, X9.62 prime192v3, X9.62 prime239v1, \
+    X9.62 prime239v2, X9.62 prime239v3, brainpoolP256r1, brainpoolP320r1, \
+    brainpoolP384r1, brainpoolP512r1
+
+jdk.tls.disabledAlgorithms=MD5, SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    secp112r1, secp112r2, secp128r1, secp128r2, secp160k1, secp160r1, \
+    secp160r2, secp192k1, secp192r1, secp224k1, secp224r1, secp256k1, \
+    sect113r1, sect113r2, sect131r1, sect131r2, sect163k1, sect163r1, \
+    sect163r2, sect193r1, sect233k1, sect233r1, sect239k1, sect283k1, \
+    sect283r1, sect409k1, sect409r1, sect571k1, sect571r1, brainpoolP256r1, \
+    brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
+jdk.tls.legacyAlgorithms= \
+        K_NULL, C_NULL, M_NULL, \
+        DH_anon, ECDH_anon, \
+        RC4_128, RC4_40, DES_CBC, DES40_CBC
+jdk.tls.keyLimits=AES/GCM/NoPadding KeyUpdate 2^37, \
+                  ChaCha20-Poly1305 KeyUpdate 2^37
+
+crypto.policy=unlimited
+
+jdk.xml.dsig.secureValidationPolicy=\
+    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
+    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
+    maxTransforms 5,\
+    maxReferences 30,\
+    disallowReferenceUriSchemes file http https,\
+    minKeySize RSA 1024,\
+    minKeySize DSA 1024,\
+    minKeySize EC 224,\
+    noDuplicateIds,\
+    noRetrievalMethodLoops
+
+jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
+  java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+jdk.sasl.disabledMechanisms=CRAM-MD5, DIGEST-MD5
+jdk.security.caDistrustPolicies=SYMANTEC_TLS
+jdk.io.permissionsUseCanonicalPath=false
+
+jdk.tls.alpnCharset=ISO_8859_1
+
+org.bouncycastle.fips.approved_only=true

--- a/x-pack/qa/integration/fips-validation/fixtures/java.security
+++ b/x-pack/qa/integration/fips-validation/fixtures/java.security
@@ -1,4 +1,4 @@
-security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider C:HYBRID;ENABLE{All};
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN
 security.provider.4=-BC
@@ -106,4 +106,7 @@ jdk.io.permissionsUseCanonicalPath=false
 
 jdk.tls.alpnCharset=ISO_8859_1
 
-org.bouncycastle.fips.approved_only=true
+# C:HYBRID mode allows non-approved algorithms (MD5, SHA1, DES) to be called outside
+# of security-sensitive contexts. FIPS validation still applies to TLS, key derivation,
+# and other security operations. This matches Elasticsearch's FIPS configuration.
+# org.bouncycastle.fips.approved_only is intentionally NOT set.

--- a/x-pack/qa/integration/fips-validation/fixtures/jvm.options
+++ b/x-pack/qa/integration/fips-validation/fixtures/jvm.options
@@ -8,4 +8,4 @@
 -Djavax.net.ssl.trustStorePassword=changeit
 -Dssl.KeyManagerFactory.algorithm=PKIX
 -Dssl.TrustManagerFactory.algorithm=PKIX
--Dorg.bouncycastle.fips.approved_only=true
+# C:HYBRID mode is configured in java.security; approved_only is intentionally not set.

--- a/x-pack/qa/integration/fips-validation/fixtures/jvm.options
+++ b/x-pack/qa/integration/fips-validation/fixtures/jvm.options
@@ -1,0 +1,11 @@
+# Example FIPS 140-3 JVM options for Logstash.
+# Adjust paths for your installation before using this file.
+-Dio.netty.ssl.provider=JDK
+-Djava.security.properties=${LS_SETTINGS_DIR}/security/java.security
+-Djavax.net.ssl.trustStore=${LS_SETTINGS_DIR}/security/cacerts.bcfks
+-Djavax.net.ssl.trustStoreType=BCFKS
+-Djavax.net.ssl.trustStoreProvider=BCFIPS
+-Djavax.net.ssl.trustStorePassword=changeit
+-Dssl.KeyManagerFactory.algorithm=PKIX
+-Dssl.TrustManagerFactory.algorithm=PKIX
+-Dorg.bouncycastle.fips.approved_only=true

--- a/x-pack/qa/integration/fips-validation/logstash-integration-fips-validation_spec.rb
+++ b/x-pack/qa/integration/fips-validation/logstash-integration-fips-validation_spec.rb
@@ -2,7 +2,9 @@ require_relative "../spec_helper"
 
 context "FipsValidation Integration Plugin" do
   def fips_configured_jvm?
-    java.lang.System.getProperty("org.bouncycastle.fips.approved_only") == "true"
+    # Detect FIPS by checking for the BCFIPS provider rather than approved_only,
+    # since we run C:HYBRID mode which does not set approved_only=true.
+    !java.security.Security.getProvider("BCFIPS").nil?
   end
 
   def fips_provider_jars
@@ -79,8 +81,8 @@ context "FipsValidation Integration Plugin" do
         "-Djavax.net.ssl.trustStoreProvider=BCFIPS",
         "-Djavax.net.ssl.trustStorePassword=changeit",
         "-Dssl.KeyManagerFactory.algorithm=PKIX",
-        "-Dssl.TrustManagerFactory.algorithm=PKIX",
-        "-Dorg.bouncycastle.fips.approved_only=true"
+        "-Dssl.TrustManagerFactory.algorithm=PKIX"
+        # C:HYBRID mode is configured in java.security; approved_only is intentionally not set.
       ].join("\n")
     )
 

--- a/x-pack/qa/integration/fips-validation/logstash-integration-fips-validation_spec.rb
+++ b/x-pack/qa/integration/fips-validation/logstash-integration-fips-validation_spec.rb
@@ -1,6 +1,101 @@
 require_relative "../spec_helper"
 
 context "FipsValidation Integration Plugin" do
+  def fips_configured_jvm?
+    java.lang.System.getProperty("org.bouncycastle.fips.approved_only") == "true"
+  end
+
+  def fips_provider_jars
+    jars_dir = java.lang.System.getProperty("logstash.fips.provider.jars.dir")
+    skip "FIPS provider jars are not available" if jars_dir.nil? || jars_dir.empty?
+
+    jars = Dir.glob(File.join(jars_dir, "*.jar"))
+    skip "FIPS provider jars are not available in #{jars_dir}" if jars.empty?
+
+    jars
+  end
+
+  def with_fips_provider_jars_on_logstash_classpath
+    jar_dir = File.join(get_logstash_path, "logstash-core", "lib", "jars")
+    copied_jars = []
+
+    fips_provider_jars.each do |jar|
+      destination = File.join(jar_dir, File.basename(jar))
+      next if File.exist?(destination)
+
+      FileUtils.cp(jar, destination)
+      copied_jars << destination
+    end
+
+    yield
+  ensure
+    copied_jars&.each { |jar| FileUtils.rm_f(jar) }
+  end
+
+  def create_bcfks_truststore(security_dir)
+    java_home = java.lang.System.getProperty("java.home")
+    keytool = File.join(java_home, "bin", "keytool")
+    source_truststore = File.join(java_home, "lib", "security", "cacerts")
+    destination_truststore = File.join(security_dir, "cacerts.bcfks")
+    provider_path = fips_provider_jars.join(File::PATH_SEPARATOR)
+
+    command = [
+      keytool,
+      "-importkeystore",
+      "-srckeystore", source_truststore,
+      "-destkeystore", destination_truststore,
+      "-srcstoretype", "jks",
+      "-deststoretype", "bcfks",
+      "-providerpath", provider_path,
+      "-provider", "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider",
+      "-deststorepass", "changeit",
+      "-srcstorepass", "changeit",
+      "-noprompt"
+    ]
+
+    stdout, stderr, status = Open3.capture3(*command)
+    raise "Failed to create BCFKS truststore: #{stdout}\n#{stderr}" unless status.success?
+
+    destination_truststore
+  end
+
+  def logstash_with_standard_fips_files(cmd, options = {})
+    temporary_settings = Stud::Temporary.directory
+    temporary_data = Stud::Temporary.directory
+    security_dir = File.join(temporary_settings, "security")
+    FileUtils.mkdir_p(security_dir)
+
+    fips_java_security = File.expand_path("fixtures/java.security", __dir__)
+    FileUtils.cp(fips_java_security, File.join(security_dir, "java.security"))
+    truststore = create_bcfks_truststore(security_dir)
+
+    IO.write(
+      File.join(temporary_settings, "jvm.options"),
+      [
+        "-Dio.netty.ssl.provider=JDK",
+        "-Djava.security.properties=#{File.join(security_dir, "java.security")}",
+        "-Djavax.net.ssl.trustStore=#{truststore}",
+        "-Djavax.net.ssl.trustStoreType=BCFKS",
+        "-Djavax.net.ssl.trustStoreProvider=BCFIPS",
+        "-Djavax.net.ssl.trustStorePassword=changeit",
+        "-Dssl.KeyManagerFactory.algorithm=PKIX",
+        "-Dssl.TrustManagerFactory.algorithm=PKIX",
+        "-Dorg.bouncycastle.fips.approved_only=true"
+      ].join("\n")
+    )
+
+    settings = {
+      "xpack.security.fips_mode.enabled" => true,
+      "xpack.security.fips_mode.required_providers" => ["BCFIPS", "BCJSSE"]
+    }.merge(options.fetch(:settings, {}))
+    IO.write(File.join(temporary_settings, "logstash.yml"), YAML.dump(settings))
+    FileUtils.cp(File.join(get_logstash_path, "config", "log4j2.properties"), File.join(temporary_settings, "log4j2.properties"))
+
+    cmd = logstash_command_append(cmd, "--path.settings", temporary_settings)
+    cmd = logstash_command_append(cmd, "--path.data", temporary_data)
+
+    Belzebuth.run(cmd, { :directory => get_logstash_path }.merge(options.fetch(:belzebuth, {})))
+  end
 
   context "when running on stock Logstash", :skip_fips do
     # on non-FIPS Logstash, we need to install the plugin ourselves
@@ -33,6 +128,50 @@ context "FipsValidation Integration Plugin" do
           expect(stdout).to include("Java SecureRandom provider is misconfigured")
           expect(stdout).to include("Bouncycastle Crypto unavailable")
           expect(stdout).to include("Logstash is not configured in a FIPS-compliant manner")
+        end
+      end
+    end
+  end
+
+  context "when running on FIPS-configured Logstash" do
+    it "starts when FIPS mode is enabled and required providers are present" do
+      skip "requires a FIPS-configured JVM with Bouncy Castle providers" unless fips_configured_jvm?
+
+      process = logstash_with_empty_default(
+        "bin/logstash --log.level=debug -e 'input { generator { count => 1 } } output { stdout {} }'",
+        {
+          :timeout => 60,
+          :settings => {
+            "xpack.security.fips_mode.enabled" => true,
+            "xpack.security.fips_mode.required_providers" => ["BCFIPS", "BCJSSE"]
+          }
+        }
+      )
+
+      aggregate_failures do
+        expect(process).to be_successful
+        process.stdout_lines.join.tap do |stdout|
+          expect(stdout).to include("Pipeline started")
+          expect(stdout).not_to include("required FIPS security providers")
+        end
+      end
+    end
+  end
+
+  context "when standard Logstash is supplied with FIPS files" do
+    it "starts with FIPS mode enabled and required providers present" do
+      with_fips_provider_jars_on_logstash_classpath do
+        process = logstash_with_standard_fips_files(
+          "bin/logstash --log.level=debug -e 'input { generator { count => 1 } } output { stdout {} }'",
+          :belzebuth => { :timeout => 60 }
+        )
+
+        aggregate_failures do
+          expect(process).to be_successful
+          process.stdout_lines.join.tap do |stdout|
+            expect(stdout).to include("Pipeline started")
+            expect(stdout).not_to include("required FIPS security providers")
+          end
         end
       end
     end

--- a/x-pack/qa/integration/spec_helper.rb
+++ b/x-pack/qa/integration/spec_helper.rb
@@ -11,7 +11,10 @@ require "json"
 require "json-schema"
 
 RSpec.configure do |c|
-  if java.lang.System.getProperty("org.bouncycastle.fips.approved_only") == "true"
+  # Exclude skip_fips examples when running under a FIPS-configured JVM.
+  # Detection uses BCFIPS provider presence rather than approved_only since
+  # we run C:HYBRID mode which does not set approved_only=true.
+  if !java.security.Security.getProvider("BCFIPS").nil?
     c.filter_run_excluding skip_fips: true
   end
 end

--- a/x-pack/spec/fips/phase2_validators_spec.rb
+++ b/x-pack/spec/fips/phase2_validators_spec.rb
@@ -1,0 +1,132 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "spec_helper"
+require "logstash/runner"
+
+describe "Phase 2 FIPS validator changes" do
+  let(:mock_bcfips) { double("BCFIPSProvider", getName: "BCFIPS") }
+  let(:mock_sun)    { double("SunProvider",    getName: "SUN") }
+
+  def with_fips(&block)
+    allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(mock_bcfips)
+    allow(java.security.Security).to receive(:getProviders).and_return([mock_bcfips, mock_sun])
+    block.call
+  end
+
+  def without_fips(&block)
+    allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(nil)
+    allow(java.security.Security).to receive(:getProviders).and_return([mock_sun])
+    block.call
+  end
+
+  describe "logstash-filter-fingerprint FIPS algorithm guard" do
+    before do
+      require "logstash/filters/fingerprint"
+    end
+
+    it "raises ConfigurationError for MD5 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Fingerprint.new("method" => "MD5", "source" => ["message"])
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /MD5.*not permitted in FIPS/)
+      end
+    end
+
+    it "raises ConfigurationError for SHA1 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Fingerprint.new("method" => "SHA1", "source" => ["message"])
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /SHA1.*not permitted in FIPS/)
+      end
+    end
+
+    it "allows SHA256 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Fingerprint.new("method" => "SHA256", "source" => ["message"])
+        expect { plugin.register }.not_to raise_error
+      end
+    end
+
+    it "allows MD5 outside FIPS mode" do
+      without_fips do
+        plugin = LogStash::Filters::Fingerprint.new("method" => "MD5", "source" => ["message"])
+        expect { plugin.register }.not_to raise_error
+      end
+    end
+  end
+
+  describe "logstash-filter-anonymize FIPS algorithm guard" do
+    before do
+      require "logstash/filters/anonymize"
+    end
+
+    it "raises ConfigurationError for MD5 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Anonymize.new("algorithm" => "MD5", "key" => "secret", "fields" => ["message"])
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /MD5.*not permitted in FIPS/)
+      end
+    end
+
+    it "raises ConfigurationError for SHA1 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Anonymize.new("algorithm" => "SHA1", "key" => "secret", "fields" => ["message"])
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /SHA1.*not permitted in FIPS/)
+      end
+    end
+
+    it "allows SHA256 in FIPS mode" do
+      with_fips do
+        plugin = LogStash::Filters::Anonymize.new("algorithm" => "SHA256", "key" => "secret", "fields" => ["message"])
+        expect { plugin.register }.not_to raise_error
+      end
+    end
+
+    it "allows MD5 outside FIPS mode" do
+      without_fips do
+        plugin = LogStash::Filters::Anonymize.new("algorithm" => "MD5", "key" => "secret", "fields" => ["message"])
+        expect { plugin.register }.not_to raise_error
+      end
+    end
+  end
+
+  describe "ssl_keystore_type validators" do
+    let(:ls_root) { File.expand_path("../../..", __dir__) }
+
+    it "logstash-mixin-http_client accepts bcfks" do
+      require "logstash/plugin_mixins/http_client"
+      http_client_file = $LOAD_PATH.map { |p| File.join(p, "logstash/plugin_mixins/http_client.rb") }.find { |f| File.exist?(f) }
+      content = File.read(http_client_file)
+      expect(content).to include("bcfks")
+    end
+
+    it "logstash-output-elasticsearch api_configs accepts bcfks" do
+      api_configs_file = Dir.glob(File.join(ls_root, "vendor/bundle/jruby/3.4.0/gems/logstash-output-elasticsearch-*/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb")).first
+      content = File.read(api_configs_file)
+      expect(content).to include("bcfks")
+    end
+
+    it "logstash-input-elasticsearch accepts bcfks" do
+      file = Dir.glob(File.join(ls_root, "vendor/bundle/jruby/3.4.0/gems/logstash-input-elasticsearch-*/lib/logstash/inputs/elasticsearch.rb")).first
+      content = File.read(file)
+      expect(content).to include("bcfks")
+    end
+
+    it "logstash-filter-elasticsearch accepts bcfks" do
+      file = Dir.glob(File.join(ls_root, "vendor/bundle/jruby/3.4.0/gems/logstash-filter-elasticsearch-*/lib/logstash/filters/elasticsearch.rb")).first
+      content = File.read(file)
+      expect(content).to include("bcfks")
+    end
+
+    it "logstash-input-http accepts bcfks" do
+      file = Dir.glob(File.join(ls_root, "vendor/bundle/jruby/3.4.0/gems/logstash-input-http-*/lib/logstash/inputs/http.rb")).first
+      content = File.read(file)
+      expect(content).to include("bcfks")
+    end
+
+    it "logstash-integration-kafka avro_schema_registry accepts BCFKS" do
+      file = Dir.glob(File.join(ls_root, "vendor/bundle/jruby/3.4.0/gems/logstash-integration-kafka-*/lib/logstash/plugin_mixins/kafka/avro_schema_registry.rb")).first
+      content = File.read(file)
+      expect(content).to include("BCFKS")
+    end
+  end
+end

--- a/x-pack/spec/fips/phase3_remaining_spec.rb
+++ b/x-pack/spec/fips/phase3_remaining_spec.rb
@@ -1,0 +1,124 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "spec_helper"
+require "logstash/runner"
+
+describe "Phase 3 remaining FIPS fixes" do
+  let(:mock_bcfips) { double("BCFIPSProvider", getName: "BCFIPS") }
+  let(:mock_sun)    { double("SunProvider",    getName: "SUN") }
+
+  def with_fips(&block)
+    allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(mock_bcfips)
+    allow(java.security.Security).to receive(:getProviders).and_return([mock_bcfips, mock_sun])
+    block.call
+  end
+
+  def without_fips(&block)
+    allow(java.security.Security).to receive(:getProvider).with("BCFIPS").and_return(nil)
+    allow(java.security.Security).to receive(:getProviders).and_return([mock_sun])
+    block.call
+  end
+
+  describe "logstash-codec-avro BCFKS keystore validator" do
+    before { require "logstash/codecs/avro" }
+
+    it "includes bcfks in ssl_keystore_type validator" do
+      config = LogStash::Codecs::Avro.get_config
+      expect(config["ssl_keystore_type"][:validate]).to include("bcfks")
+    end
+
+    it "includes bcfks in ssl_truststore_type validator" do
+      config = LogStash::Codecs::Avro.get_config
+      expect(config["ssl_truststore_type"][:validate]).to include("bcfks")
+    end
+
+    it "still includes jks in ssl_keystore_type validator" do
+      config = LogStash::Codecs::Avro.get_config
+      expect(config["ssl_keystore_type"][:validate]).to include("jks")
+    end
+
+    it "still includes pkcs12 in ssl_truststore_type validator" do
+      config = LogStash::Codecs::Avro.get_config
+      expect(config["ssl_truststore_type"][:validate]).to include("pkcs12")
+    end
+  end
+
+  describe "logstash-filter-elastic_integration FIPS keystore guard" do
+    before do
+      require "logstash/filters/elastic_integration"
+    rescue LoadError => e
+      skip("elastic_integration filter not loadable in this environment: #{e.message}")
+    end
+
+    it "includes bcfks in ssl_keystore_type validator" do
+      config = LogStash::Filters::ElasticIntegration.get_config
+      expect(config["ssl_keystore_type"][:validate]).to include("bcfks")
+    end
+
+    it "includes bcfks in ssl_truststore_type validator" do
+      config = LogStash::Filters::ElasticIntegration.get_config
+      expect(config["ssl_truststore_type"][:validate]).to include("bcfks")
+    end
+
+    context "in FIPS mode with ssl_keystore_path" do
+      it "raises ConfigurationError via validate_ssl_settings!" do
+        with_fips do
+          ks = Tempfile.new(["ks", ".bcfks"])
+          plugin = LogStash::Filters::ElasticIntegration.new(
+            "ssl_enabled" => true,
+            "ssl_keystore_path" => ks.path,
+            "ssl_keystore_password" => "changeit"
+          )
+          allow(plugin).to receive(:ensure_readable_and_non_writable!)
+          expect { plugin.send(:validate_ssl_settings!) }.to raise_error(
+            LogStash::ConfigurationError, /ssl_keystore_path.*not supported in FIPS/
+          )
+        ensure
+          ks.close! rescue nil
+        end
+      end
+    end
+
+    context "in FIPS mode with ssl_truststore_path" do
+      it "raises ConfigurationError via validate_ssl_settings!" do
+        with_fips do
+          ts = Tempfile.new(["ts", ".bcfks"])
+          plugin = LogStash::Filters::ElasticIntegration.new(
+            "ssl_enabled" => true,
+            "ssl_truststore_path" => ts.path,
+            "ssl_truststore_password" => "changeit"
+          )
+          allow(plugin).to receive(:ensure_readable_and_non_writable!)
+          expect { plugin.send(:validate_ssl_settings!) }.to raise_error(
+            LogStash::ConfigurationError, /ssl_truststore_path.*not supported in FIPS/
+          )
+        ensure
+          ts.close! rescue nil
+        end
+      end
+    end
+
+    context "in non-FIPS mode with ssl_keystore_path" do
+      it "does not raise a FIPS-specific error" do
+        without_fips do
+          ks = Tempfile.new(["ks", ".p12"])
+          plugin = LogStash::Filters::ElasticIntegration.new(
+            "ssl_enabled" => true,
+            "ssl_keystore_path" => ks.path,
+            "ssl_keystore_password" => "changeit"
+          )
+          allow(plugin).to receive(:ensure_readable_and_non_writable!)
+          begin
+            plugin.send(:validate_ssl_settings!)
+          rescue LogStash::ConfigurationError => e
+            expect(e.message).not_to match(/not supported in FIPS/)
+          end
+        ensure
+          ks.close! rescue nil
+        end
+      end
+    end
+  end
+end

--- a/x-pack/spec/geoip_database_management/downloader_spec.rb
+++ b/x-pack/spec/geoip_database_management/downloader_spec.rb
@@ -2,6 +2,11 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+require 'geoip_database_management/downloader'
+require 'geoip_database_management/metadata'
+require 'geoip_database_management/data_path'
+require 'geoip_database_management/util'
+
 describe LogStash::GeoipDatabaseManagement::Downloader, aggregate_failures: true, verify_stubs: true do
   let(:temp_metadata_path) { Stud::Temporary.directory }
   let(:data_path) { LogStash::GeoipDatabaseManagement::DataPath.new(temp_metadata_path) }

--- a/x-pack/spec/security/extension_spec.rb
+++ b/x-pack/spec/security/extension_spec.rb
@@ -1,0 +1,33 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "spec_helper"
+require "logstash/environment"
+require "logstash/settings"
+require "security/extension"
+
+describe LogStash::Security::Extension do
+  let(:extension) { described_class.new }
+
+  describe "#register_hook" do
+    subject(:hooks) { LogStash::Plugins::HooksRegistry.new }
+
+    before { extension.register_hooks(hooks) }
+
+    it "register hooks on `LogStash::Runner`" do
+      expect(hooks).to have_registered_hook(LogStash::Runner, LogStash::Security::Hooks)
+    end
+  end
+
+  describe "#additionals_settings" do
+    subject(:settings) { LogStash::Runner::SYSTEM_SETTINGS.clone }
+
+    before { extension.additionals_settings(settings) }
+
+    define_settings(
+      "xpack.security.fips_mode.enabled" => [LogStash::Setting::BooleanSetting, false],
+      "xpack.security.fips_mode.required_providers" => [LogStash::Setting::StringArray, []]
+    )
+  end
+end

--- a/x-pack/spec/security/fips_bootstrap_check_spec.rb
+++ b/x-pack/spec/security/fips_bootstrap_check_spec.rb
@@ -1,0 +1,60 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require "spec_helper"
+require "logstash/environment"
+require "logstash/settings"
+require "security/extension"
+
+describe LogStash::Security::FipsBootstrapCheck do
+  subject(:check) { described_class.check(settings) }
+
+  let(:settings) { LogStash::Runner::SYSTEM_SETTINGS.clone }
+
+  before do
+    LogStash::Security::Extension.new.additionals_settings(settings)
+  end
+
+  context "when FIPS mode is disabled" do
+    it "does not validate providers" do
+      expect { check }.not_to raise_error
+    end
+  end
+
+  context "when FIPS mode is enabled without required providers" do
+    before do
+      settings.set("xpack.security.fips_mode.enabled", true)
+    end
+
+    it "does not validate providers" do
+      expect { check }.not_to raise_error
+    end
+  end
+
+  context "when FIPS mode requires an installed provider" do
+    before do
+      settings.set("xpack.security.fips_mode.enabled", true)
+      settings.set("xpack.security.fips_mode.required_providers", ["SUN"])
+    end
+
+    it "passes when the provider is available" do
+      expect { check }.not_to raise_error
+    end
+  end
+
+  context "when FIPS mode requires a missing provider" do
+    before do
+      settings.set("xpack.security.fips_mode.enabled", true)
+      settings.set("xpack.security.fips_mode.required_providers", ["BCFIPS", "BCJSSE:2*"])
+    end
+
+    it "raises a bootstrap check error with missing providers" do
+      expect { check }.to raise_error(LogStash::BootstrapCheckError) do |error|
+        expect(error.message).to include("required FIPS security providers")
+        expect(error.message).to include("missing provider \"BCFIPS\"")
+        expect(error.message).to include("missing provider \"BCJSSE\"")
+      end
+    end
+  end
+end

--- a/x-pack/spec/security/fips_bootstrap_check_spec.rb
+++ b/x-pack/spec/security/fips_bootstrap_check_spec.rb
@@ -5,6 +5,7 @@
 require "spec_helper"
 require "logstash/environment"
 require "logstash/settings"
+require "logstash/runner"
 require "security/extension"
 
 describe LogStash::Security::FipsBootstrapCheck do
@@ -17,43 +18,146 @@ describe LogStash::Security::FipsBootstrapCheck do
   end
 
   context "when FIPS mode is disabled" do
-    it "does not validate providers" do
+    it "does not perform any checks" do
+      expect(::Java::java.security.Security).not_to receive(:getProviders)
       expect { check }.not_to raise_error
     end
   end
 
-  context "when FIPS mode is enabled without required providers" do
+  # Stub the private check methods directly on the module to avoid requiring BC-FIPS JARs
+  # on the classpath in non-FIPS CI runs.
+  context "when FIPS mode is enabled" do
     before do
       settings.set("xpack.security.fips_mode.enabled", true)
     end
 
-    it "does not validate providers" do
-      expect { check }.not_to raise_error
-    end
-  end
+    let(:bcfips_provider) { double("BCFIPS provider", name: "BCFIPS", getVersionStr: "2.0.0") }
+    let(:bcjsse_provider) { double("BCJSSE provider", name: "BCJSSE", getVersionStr: "2.0.0") }
+    let(:sun_provider)    { double("SUN provider",    name: "SUN",    getVersionStr: "11") }
 
-  context "when FIPS mode requires an installed provider" do
-    before do
-      settings.set("xpack.security.fips_mode.enabled", true)
-      settings.set("xpack.security.fips_mode.required_providers", ["SUN"])
-    end
-
-    it "passes when the provider is available" do
-      expect { check }.not_to raise_error
-    end
-  end
-
-  context "when FIPS mode requires a missing provider" do
-    before do
-      settings.set("xpack.security.fips_mode.enabled", true)
-      settings.set("xpack.security.fips_mode.required_providers", ["LOGSTASH_MISSING_FIPS_PROVIDER", "LOGSTASH_MISSING_JSSE_PROVIDER:2*"])
+    def stub_all_checks_passing(provider_list: [bcfips_provider, bcjsse_provider, sun_provider])
+      allow(described_class).to receive(:check_provider_ordering).and_return([])
+      allow(described_class).to receive(:check_secure_random_provider).and_return([])
+      allow(described_class).to receive(:check_fips_ready).and_return([])
+      allow(described_class).to receive(:check_jruby_openssl_not_registered).and_return([])
+      allow(::Java::java.security.Security).to receive(:getProviders).and_return(provider_list)
     end
 
-    it "raises a bootstrap check error with missing providers" do
-      expect { check }.to raise_error(LogStash::BootstrapCheckError) do |error|
-        expect(error.message).to include("required FIPS security providers")
-        expect(error.message).to include("missing provider \"LOGSTASH_MISSING_FIPS_PROVIDER\"")
-        expect(error.message).to include("missing provider \"LOGSTASH_MISSING_JSSE_PROVIDER\"")
+    context "with a fully compliant FIPS environment" do
+      before { stub_all_checks_passing }
+
+      it "passes without error" do
+        expect { check }.not_to raise_error
+      end
+    end
+
+    context "with a fully compliant FIPS environment and matching required providers" do
+      before do
+        stub_all_checks_passing
+        settings.set("xpack.security.fips_mode.required_providers", ["BCFIPS", "BCJSSE"])
+      end
+
+      it "passes without error" do
+        expect { check }.not_to raise_error
+      end
+    end
+
+    context "with a fully compliant FIPS environment and version-glob required providers" do
+      before do
+        stub_all_checks_passing
+        settings.set("xpack.security.fips_mode.required_providers", ["BCFIPS:2.0.*", "BCJSSE:2.0.*"])
+      end
+
+      it "passes without error" do
+        expect { check }.not_to raise_error
+      end
+    end
+
+    context "when BCFIPS is not the first provider" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_provider_ordering)
+          .and_return(["BCFIPS must be the first Java security provider (observed: \"SUN\")"])
+      end
+
+      it "raises a BootstrapCheckError mentioning provider ordering" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /BCFIPS must be the first Java security provider/)
+      end
+    end
+
+    context "when SecureRandom is not backed by BCFIPS" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_secure_random_provider)
+          .and_return(["Java SecureRandom must be provided by BCFIPS (observed: \"SUN\")"])
+      end
+
+      it "raises a BootstrapCheckError mentioning SecureRandom" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /SecureRandom must be provided by BCFIPS/)
+      end
+    end
+
+    context "when BouncyCastle FIPS is not ready" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_fips_ready)
+          .and_return(["BouncyCastle FIPS is not ready"])
+      end
+
+      it "raises a BootstrapCheckError mentioning FIPS readiness" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /BouncyCastle FIPS is not ready/)
+      end
+    end
+
+    context "when JRuby OpenSSL provider is registered" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_jruby_openssl_not_registered)
+          .and_return(["The non-FIPS JRuby OpenSSL security provider must not be registered"])
+      end
+
+      it "raises a BootstrapCheckError mentioning the non-FIPS provider" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /non-FIPS JRuby OpenSSL security provider must not be registered/)
+      end
+    end
+
+    context "when JRuby OpenSSL provider is eligible for registration" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_jruby_openssl_not_registered)
+          .and_return(["The non-FIPS JRuby OpenSSL security provider is eligible for registration; set -Djruby.openssl.provider.register=false"])
+      end
+
+      it "raises a BootstrapCheckError mentioning provider.register flag" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /jruby.openssl.provider.register=false/)
+      end
+    end
+
+    context "when a required provider is missing" do
+      before do
+        stub_all_checks_passing
+        settings.set("xpack.security.fips_mode.required_providers", ["LOGSTASH_MISSING_FIPS_PROVIDER"])
+      end
+
+      it "raises a BootstrapCheckError mentioning the missing provider" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError, /missing provider "LOGSTASH_MISSING_FIPS_PROVIDER"/)
+      end
+    end
+
+    context "when multiple checks fail simultaneously" do
+      before do
+        stub_all_checks_passing
+        allow(described_class).to receive(:check_provider_ordering)
+          .and_return(["BCFIPS must be the first Java security provider (observed: \"SUN\")"])
+        allow(described_class).to receive(:check_jruby_openssl_not_registered)
+          .and_return(["The non-FIPS JRuby OpenSSL security provider must not be registered"])
+      end
+
+      it "raises a single BootstrapCheckError listing all failures" do
+        expect { check }.to raise_error(LogStash::BootstrapCheckError) do |error|
+          expect(error.message).to include("BCFIPS must be the first Java security provider")
+          expect(error.message).to include("non-FIPS JRuby OpenSSL security provider must not be registered")
+        end
       end
     end
   end

--- a/x-pack/spec/security/fips_bootstrap_check_spec.rb
+++ b/x-pack/spec/security/fips_bootstrap_check_spec.rb
@@ -46,14 +46,14 @@ describe LogStash::Security::FipsBootstrapCheck do
   context "when FIPS mode requires a missing provider" do
     before do
       settings.set("xpack.security.fips_mode.enabled", true)
-      settings.set("xpack.security.fips_mode.required_providers", ["BCFIPS", "BCJSSE:2*"])
+      settings.set("xpack.security.fips_mode.required_providers", ["LOGSTASH_MISSING_FIPS_PROVIDER", "LOGSTASH_MISSING_JSSE_PROVIDER:2*"])
     end
 
     it "raises a bootstrap check error with missing providers" do
       expect { check }.to raise_error(LogStash::BootstrapCheckError) do |error|
         expect(error.message).to include("required FIPS security providers")
-        expect(error.message).to include("missing provider \"BCFIPS\"")
-        expect(error.message).to include("missing provider \"BCJSSE\"")
+        expect(error.message).to include("missing provider \"LOGSTASH_MISSING_FIPS_PROVIDER\"")
+        expect(error.message).to include("missing provider \"LOGSTASH_MISSING_JSSE_PROVIDER\"")
       end
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Adds Logstash FIPS mode settings. When `xpack.security.fips_mode.enabled` is `true`, Logstash can validate that required Java security providers are installed using `xpack.security.fips_mode.required_providers`.

## What does this PR do?

This PR adds an X-Pack security extension for Logstash that registers two new settings:
  - `xpack.security.fips_mode.enabled`
  - `xpack.security.fips_mode.required_providers`
  
When FIPS mode is enabled, Logstash runs a bootstrap check that validates the configured required Java security providers are present. Provider requirements can be specified by name, such as `BCFIPS`, or by name and version pattern, such as `BCFIPS:2*`.

This mirrors Elasticsearch’s provider-validation behavior. Logstash does not ship, install, or configure Bouncy Castle FIPS jars, `java.security` files, truststores, or JVM options. Users must provide those pieces externally.

The PR also adds unit coverage for the new settings and bootstrap check, plus integration coverage for standard Logstash running with externally supplied FIPS provider jars and JVM security configuration.

## Why is it important/What is the impact to the user?

This gives users a first-class Logstash setting for enabling FIPS mode validation, aligned with Elasticsearch’s `xpack.security.fips_mode.enabled` behavior.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files (and/or docker env variables)
- [X] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Added X-Pack security extension and FIPS bootstrap check
- [x] Added settings documentation for `xpack.security.fips_mode.enabled` and `xpack.security.fips_mode.required_providers`
- [x] Added unit tests for settings registration and provider validation
- [x] Added standard Logstash integration coverage using externally supplied FIPS files
- [x] Verified BC FIPS jars are test-only and not shipped as Logstash dependencies

## How to test this PR locally

```bash
SPEC_OPTS="-fd -P x-pack/spec/security" \
  ./gradlew :logstash-xpack:rubyTests --tests org.logstash.xpack.test.RSpecTests
```

```bash
./gradlew :logstash-xpack:rubyIntegrationTests \
  -PrubyIntegrationSpecs=qa/integration/fips-validation/logstash-integration-fips-validation_spec.rb
```

## Related issues

- Closes #12231  

## Use cases

Given a user has configured Logstash with Bouncy Castle FIPS providers and JVM security settings, when they set `xpack.security.fips_mode.enabled: true` and configure `xpack.security.fips_mode.required_providers`, then Logstash validates the required providers during bootstrap.

Given a required provider is missing, when Logstash starts with FIPS mode enabled, then Logstash fails bootstrap with a message identifying the missing provider.
  
Given no required providers are configured, when Logstash starts with FIPS mode enabled, then Logstash does not enforce provider validation.