### PR TITLE
Print warn log and deprecation when running with JDK < 21

### DIFF
--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -337,6 +337,9 @@ class LogStash::Runner < Clamp::StrictCommand
     elsif JavaVersion::CURRENT < JavaVersion::JAVA_17
       deprecation_logger.deprecated I18n.t("logstash.runner.java.version_17_minimum",
                                            :java_home => java.lang.System.getProperty("java.home"))
+    elsif JavaVersion::CURRENT < JavaVersion::JAVA_21
+      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_21_minimum",
+                                           :java_home => java.lang.System.getProperty("java.home"))
     end
 
     logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -452,6 +452,12 @@ en:
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
+        version_21_minimum: >-
+          Starting from Logstash 8.19.19, the minimum required version of Java will be Java 21;
+          your Java version from `%{java_home}` does not meet this requirement.
+          Running Logstash with the bundled JDK is recommended.
+          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
+          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
     agent:
       sighup: >-
         SIGHUP received.

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -453,7 +453,7 @@ en:
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
         version_21_minimum: >-
-          Starting from Logstash 8.19.19, the minimum required version of Java will be Java 21;
+          Java 17 is deprecated and in a future release the minimum required version of Java will be Java 21;
           your Java version from `%{java_home}` does not meet this requirement.
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Deprecate JDK 17 starting from 8.19.19. In a subsequent version the support for it will be dropped.


## What does this PR do?

Updates the runner part of Logstash, to log a deprecation message about the supportability of JDK  21, as eager as possibile in the execution flow of Logstash.

## Why is it important/What is the impact to the user?

The user is notified of the imminent end of support for JDK 17 with a deprecation log message.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Download a JDK 17 and use that to run Logstash with this PR. Check that deprecation logs contains a line that warn from using JDK 17 on >= 8.19.19.

- install JDK 17

  ```sh
     sdk install java 17.0.19-tem
  ```

- run Logstash

  ```sh
    LS_JAVA_HOME="/Users/andreaselva/.sdkman/candidates/java/17.0.19-tem" bin/logstash -e "input{stdin{}} output{stdout{}}"
  ```

- Check file in `logs/logstash-deprecation.log` to contain:
   ```
     Starting from Logstash 8.19.19, the minimum required version of Java will be Java 21; your Java version from `/Users/andreaselva/.sdkman/candidates/java/17.0.19-tem` does not meet this requirement. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
   ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #19236
