### PR TITLE
Add .gitignore protection against locally-created credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,11 @@ logstash-core/src/test/resources/org/logstash/plugins/plugin_aliases.yml
 qa/integration/fixtures/logs_rollover/log4j2.properties
 ci/serverless/config/*.log
 jdk/*
+# Local secrets and credentials -- never commit these
+.env
+.env.*
+*.pem
+*.key
+*credentials*
+*secret*
+kubeconfig


### PR DESCRIPTION
## What
Adds a small block of `.gitignore` patterns excluding common local credential/secret file shapes (`.env`, `*.pem`, `*.key`, `*credentials*`, `*secret*`, `kubeconfig`) that weren't previously covered.

## Why
No secret is currently exposed in this repo — this is a preventive measure, not a response to an incident.

The specific motivation is AI coding agents. `.env`-style local config is one of the most common patterns in scaffolding and framework conventions, and it shows up constantly as the natural, well-trodden way an agent completes a task like "wire up this API" or "connect this database" — especially when a teammate hands the agent a literal working credential and asks it to set something up. Agents that verify their own work by actually running it are also likely to materialize real, working credentials into a local file mid-session so they can confirm the code functions, rather than just writing code and hoping.

Unlike a human, an agent doesn't reliably pause at "should this live somewhere other than the working directory" — it's optimizing for completing the task in front of it. A `.gitignore` entry that already excludes these file shapes *before* the agent (or a human) ever creates one is a safety net that doesn't depend on that judgment call being made correctly in the moment — it's just already there.

This is part of a broader effort to check baseline hygiene that matters specifically for AI-agent-assisted development across actively-developed Elastic repos.

## Testing
No functional change — `.gitignore` only affects untracked files going forward. Nothing currently tracked is touched.
