### PR TITLE
Track 9.next in .ci/logstash-versions.yml

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -5,7 +5,7 @@ logstash-core: 9.5.0
 logstash-core-plugin-api: 2.1.16
 # Logstash release track corresponding to keys in https://github.com/logstash-plugins/.ci/blob/1.x/logstash-versions.yml
 # For example 9.current, 9.previous, etc
-logstash-release-track: main
+logstash-release-track: 9.next
 
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Point release track to 9.next as defined in https://github.com/logstash-plugins/.ci/pull/148