### PR TITLE
Avoid to run on JDK < 21

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -68,16 +68,8 @@ steps:
             value: "adoptiumjdk_11"
           - label: "OpenJDK 21"
             value: "openjdk_21"
-          - label: "OpenJDK 17"
-            value: "openjdk_17"
-          - label: "OpenJDK 11"
-            value: "openjdk_11"
           - label: "Zulu 21"
             value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
-          - label: "Zulu 11"
-            value: "zulu_11"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -33,22 +33,10 @@ steps:
         options:
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
-          - label: "Adoptium JDK 17 (Eclipse Temurin)"
-            value: "adoptiumjdk_17"
-          - label: "Adoptium JDK 11 (Eclipse Temurin)"
-            value: "adoptiumjdk_11"
           - label: "OpenJDK 21"
             value: "openjdk_21"
-          - label: "OpenJDK 17"
-            value: "openjdk_17"
-          - label: "OpenJDK 11"
-            value: "openjdk_11"
           - label: "Zulu 21"
             value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
-          - label: "Zulu 11"
-            value: "zulu_11"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -88,3 +88,8 @@
 # Sets the maximum nesting depth. The depth is a count of objects and arrays that have not
 # been closed, `{` and `[` respectively.
 #-Dlogstash.jackson.stream-read-constraints.max-nesting-depth=1000
+
+# Bypass JDK version check
+#
+# Setting this to true permit to run Logstash with an unsupported JDK version.
+#-Dlogstash.jdk.force=true

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -331,6 +331,7 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated msg
     end
 
+    jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     if JavaVersion::CURRENT < JavaVersion::JAVA_11
       logger.warn I18n.t("logstash.runner.java.version",
                                              :java_home => java.lang.System.getProperty("java.home"))
@@ -338,8 +339,16 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated I18n.t("logstash.runner.java.version_17_minimum",
                                            :java_home => java.lang.System.getProperty("java.home"))
     elsif JavaVersion::CURRENT < JavaVersion::JAVA_21
-      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_21_minimum",
-                                           :java_home => java.lang.System.getProperty("java.home"))
+      if force_jdk_check(jvmArgs)
+        logger.warn I18n.t("logstash.runner.java.version_below_21_force",
+                           :java_home => java.lang.System.getProperty("java.home"),
+                           :java_version => JavaVersion::CURRENT)
+      else
+        logger.error I18n.t("logstash.runner.java.version_21_minimum",
+                            :java_home => java.lang.System.getProperty("java.home"), 
+                            :java_version => JavaVersion::CURRENT)
+        return 1
+      end
     end
 
     logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]
@@ -350,7 +359,7 @@ class LogStash::Runner < Clamp::StrictCommand
     end
 
     logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
-    jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
+    # jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     logger.info "JVM bootstrap flags: #{jvmArgs}"
 
     # Add local modules to the registry before everything else
@@ -650,4 +659,8 @@ class LogStash::Runner < Clamp::StrictCommand
     end
   end
 
+  def force_jdk_check(jvm_args_list)
+    jvm_args_list.include? "-Dlogstash.jdk.force=true"
+  end
+  private :force_jdk_check
 end

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -359,7 +359,6 @@ class LogStash::Runner < Clamp::StrictCommand
     end
 
     logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
-    # jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     logger.info "JVM bootstrap flags: #{jvmArgs}"
 
     # Add local modules to the registry before everything else

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -453,8 +453,15 @@ en:
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
         version_21_minimum: >-
-          Java 17 is deprecated and in a future release the minimum required version of Java will be Java 21;
-          your Java version from `%{java_home}` does not meet this requirement.
+          Starting from Logstash 8.19.19 the minimum required version of Java is 21;
+          your Java version from `%{java_home}` is `%{java_version}` and does not meet this requirement.
+          Running Logstash with the bundled JDK is recommended.
+          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
+          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
+        version_below_21_force: >-
+          Starting from Logstash 8.19.19 the minimum required version of Java is 21;
+          your Java version from `%{java_home}` is `%{java_version}` and does not meet this requirement.
+          You have selected to force the execution with unsupported Java version, and could generate unexpected malfunctions.
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -22,6 +22,7 @@ package org.logstash.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Helper class to compare current version of JVM with a target version.
@@ -83,5 +84,10 @@ public class JavaVersion implements Comparable<JavaVersion> {
     @Override
     public int compareTo(JavaVersion other) {
         return compare(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return version.stream().map(Object::toString).collect(Collectors.joining("."));
     }
 }


### PR DESCRIPTION
## Release notes
Checks that the minimum required JDK is verified. Avoid to run on JDK below 21.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Updates runner.rb to do a JDK version check. In case the recognised JDK version is below 21 logs an error message and exit.
At the same time permit to manually force the check , reading the  `logstash.jdk.force` from JVM options. Set `-Dlogstash.jdk.force=true` either in `config/jvm.options` or `LS_JAVA_OPTS` to run Logstash. If this condition is met a warn message is logged and execution proceed as usual.

## Why is it important/What is the impact to the user?

A user should always use verified and supported JDK version. Starting from `8.19.19` the JDK 17 is deprecated and the suggested (and bundled) one is JDK 21. If the user customized his Java, setting `LS_JAVA_HOME`,  to an unsupported version, Logstash stops. This can be manually forced setting `-Dlogstash.jdk.force=true` in either `LS_JAVA_OPTS` or in the `config/jvm.options`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Verify that with unsupported JDK version, Logstash logs an error and refuse to start.
```sh
LS_JAVA_HOME="/path/to/java/17.0.19-tem" bin/logstash -e "input{stdin{}} output{stdout{}}"
```

Verify that with unsupported JDK version AND manually forcing it, Logstash logs a warning and start.
```sh
LS_JAVA_HOME="/path/to/java/17.0.19-tem" LS_JAVA_OPTS="-Dlogstash.jdk.force=true"  bin/logstash -e "input{stdin{}} output{stdout{}}"
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #19237 


## Logs

Example execution avoidance:
```
Using LS_JAVA_HOME defined java: /Users/andreaselva/.sdkman/candidates/java/17.0.19-tem.
Sending Logstash logs to /Users/andreaselva/workspace/logstash_andsel/logs which is now configured via log4j2.properties
[2026-07-16T11:24:39,161][INFO ][logstash.runner          ] Log4j configuration path used is: /Users/andreaselva/workspace/logstash_andsel/config/log4j2.properties
[2026-07-16T11:24:39,164][ERROR][logstash.runner          ] Starting from Logstash 8.19.19 the minimum required version of Java is 21; your Java version from `/Users/andreaselva/.sdkman/candidates/java/17.0.19-tem` is `17` and does not meet this requirement. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
[2026-07-16T11:24:39,169][FATAL][org.logstash.Logstash    ] Logstash stopped processing because of an error: (SystemExit) exit
org.jruby.exceptions.SystemExit: (SystemExit) exit
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:928)
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:887)
	at Users.andreaselva.workspace.logstash_andsel.lib.bootstrap.environment.<main>(/Users/andreaselva/workspace/logstash_andsel/lib/bootstrap/environment.rb:90)
```

Example with manual force:

```
[2026-07-16T11:19:00,700][INFO ][logstash.runner          ] Log4j configuration path used is: /Users/andreaselva/workspace/logstash_andsel/config/log4j2.properties
[2026-07-16T11:19:00,703][WARN ][logstash.runner          ] Starting from Logstash 8.19.19 the minimum required version of Java is 21; your Java version from `/Users/andreaselva/.sdkman/candidates/java/17.0.19-tem` is `17` and does not meet this requirement. You have selected to force the execution with unsupported Java version, and could generate unexpected malfunctions. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
[2026-07-16T11:19:00,704][WARN ][logstash.runner          ] The use of JAVA_HOME has been deprecated. Logstash 8.0 and later ignores JAVA_HOME and uses the bundled JDK. Running Logstash with the bundled JDK is recommended. The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability. If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), you can configure LS_JAVA_HOME to use that version instead.
[2026-07-16T11:19:00,704][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.19.19", "jruby.version"=>"jruby 9.4.15.0 (3.1.7) 2026-06-08 6114208a31 OpenJDK 64-Bit Server VM 17.0.19+10 on 17.0.19+10 +indy +jit [arm64-darwin]"}
[2026-07-16T11:19:00,704][INFO ][logstash.runner          ] JVM bootstrap flags: [-Xms1g, -Xmx1g, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djruby.compile.invokedynamic=true, -XX:+HeapDumpOnOutOfMemoryError, -Djava.security.egd=file:/dev/urandom, -Dlog4j2.isThreadContextMapInheritable=true, -Dlogstash.jdk.force=true, -Djruby.regexp.interruptible=true, -Djdk.io.File.enableADS=true, --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED, --add-opens=java.base/java.security=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.nio.channels=ALL-UNNAMED, --add-opens=java.base/sun.nio.ch=ALL-UNNAMED, --add-opens=java.management/sun.management=ALL-UNNAMED, -Dio.netty.allocator.maxOrder=11]
```