### PR TITLE
[CI] Removed deprecated JDK from Logstash JDK test matrix

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -62,14 +62,10 @@ steps:
         options:
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
-          - label: "Adoptium JDK 17 (Eclipse Temurin)"
-            value: "adoptiumjdk_17"
           - label: "OpenJDK 21"
             value: "openjdk_21"
           - label: "Zulu 21"
             value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -33,16 +33,10 @@ steps:
         options:
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
-          - label: "Adoptium JDK 17 (Eclipse Temurin)"
-            value: "adoptiumjdk_17"
           - label: "OpenJDK 21"
             value: "openjdk_21"
-          - label: "OpenJDK 17"
-            value: "openjdk_17"
           - label: "Zulu 21"
             value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?

Updates CI matrices definition to exclude deprecated JDKs in Logstashì