### PR TITLE
Update JDK matrix to make it possible to test against JDK 25

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -60,10 +60,16 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_JDK}"
         options:
+          - label: "Adoptium JDK 25 (Eclipse Temurin)"
+            value: "adoptiumjdk_25"
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
+          - label: "OpenJDK 25"
+            value: "openjdk_25"  
           - label: "OpenJDK 21"
             value: "openjdk_21"
+          - label: "Zulu 25"
+            value: "zulu_25"  
           - label: "Zulu 21"
             value: "zulu_21"
 

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -10,6 +10,74 @@ env:
   DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 openjdk_21 zulu_21"
 
 steps:
+  - input: "Test Parameters"
+    if: build.source != "schedule" && build.source != "trigger_job"
+    fields:
+      - select: "Operating System"
+        key: "matrix-os"
+        hint: "The operating system variant(s) to run on:"
+        required: true
+        multiple: true
+        default: "${DEFAULT_MATRIX_OS}"
+        options:
+          - label: "Ubuntu 24.04"
+            value: "ubuntu-2404"
+          - label: "Ubuntu 22.04"
+            value: "ubuntu-2204"
+          - label: "Ubuntu 20.04"
+            value: "ubuntu-2004"
+          - label: "Debian 13"
+            value: "debian-13"
+          - label: "Debian 12"
+            value: "debian-12"
+          - label: "Debian 11"
+            value: "debian-11"
+          - label: "RHEL 9"
+            value: "rhel-9"
+          - label: "RHEL 8"
+            value: "rhel-8"
+          - label: "Oracle Linux 9"
+            value: "oraclelinux-9"
+          - label: "Oracle Linux 8"
+            value: "oraclelinux-8"
+          - label: "Oracle Linux 7"
+            value: "oraclelinux-7"
+          - label: "Rocky Linux 8"
+            value: "rocky-linux-8"
+          - label: "Rocky Linux 9"
+            value: "rocky-linux-9"
+          - label: "Alma Linux 8"
+            value: "almalinux-8"
+          - label: "Alma Linux 9"
+            value: "almalinux-9"
+          - label: "Amazon Linux (2023)"
+            value: "amazonlinux-2023"
+          - label: "OpenSUSE Leap 15"
+            value: "opensuse-leap-15"
+
+      - select: "Java"
+        key: "matrix-jdk"
+        hint: "The JDK to test with:"
+        required: true
+        multiple: true
+        default: "${DEFAULT_MATRIX_JDK}"
+        options:
+          - label: "Adoptium JDK 25 (Eclipse Temurin)"
+            value: "adoptiumjdk_25"
+          - label: "Adoptium JDK 21 (Eclipse Temurin)"
+            value: "adoptiumjdk_21"
+          - label: "OpenJDK 25"
+            value: "openjdk_25"  
+          - label: "OpenJDK 21"
+            value: "openjdk_21"
+          - label: "Zulu 25"
+            value: "zulu_25"  
+          - label: "Zulu 21"
+            value: "zulu_21"
+
+  - wait: ~
+    if: build.source != "schedule" && build.source != "trigger_job"
+
   - command: |
       set -euo pipefail
 

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -31,10 +31,16 @@ steps:
         multiple: true
         default: "${DEFAULT_MATRIX_JDK}"
         options:
+          - label: "Adoptium JDK 25 (Eclipse Temurin)"
+            value: "adoptiumjdk_25"
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
+          - label: "OpenJDK 25"
+            value: "openjdk_25"
           - label: "OpenJDK 21"
             value: "openjdk_21"
+          - label: "Zulu 25"
+            value: "zulu_25"
           - label: "Zulu 21"
             value: "zulu_21"
 

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -7,6 +7,48 @@ env:
   DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 openjdk_21 zulu_21"
 
 steps:
+  - input: "Test Parameters"
+    if: build.source != "schedule" && build.source != "trigger_job"
+    fields:
+      - select: "Operating System"
+        key: "matrix-os"
+        hint: "The operating system variant(s) to run on:"
+        required: true
+        multiple: true
+        default: "${DEFAULT_MATRIX_OS}"
+        options:
+          - label: "Windows 2025"
+            value: "windows-2025"
+          - label: "Windows 2022"
+            value: "windows-2022"
+          - label: "Windows 2019"
+            value: "windows-2019"
+          - label: "Windows 2016"
+            value: "windows-2016"
+
+      - select: "Java"
+        key: "matrix-jdk"
+        hint: "The JDK to test with:"
+        required: true
+        multiple: true
+        default: "${DEFAULT_MATRIX_JDK}"
+        options:
+          - label: "Adoptium JDK 25 (Eclipse Temurin)"
+            value: "adoptiumjdk_25"
+          - label: "Adoptium JDK 21 (Eclipse Temurin)"
+            value: "adoptiumjdk_21"
+          - label: "OpenJDK 25"
+            value: "openjdk_25"
+          - label: "OpenJDK 21"
+            value: "openjdk_21"
+          - label: "Zulu 25"
+            value: "zulu_25"
+          - label: "Zulu 21"
+            value: "zulu_21"
+
+  - wait: ~
+    if: build.source != "schedule" && build.source != "trigger_job"
+
   - command: |
       set -euo pipefail
 


### PR DESCRIPTION
## Release notes
[rn:skip] 

## What does this PR do?
Update Buildkite matrix test to include also JDK 25.