### PR TITLE
Aligns dependency bump workflow on run branch.

### DIFF
--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -35,7 +35,7 @@ jobs:
       INPUTS_BUMP: "${{ inputs.bump }}"
       INPUTS_EXTRA_GEMS_MINOR: "${{ inputs.extra_gems_minor }}"
       INPUTS_EXTRA_GEMS_MAJOR: "${{ inputs.extra_gems_major }}"
-      BACKPORT_LABEL: "backport-${{ inputs.branch }}"
+      BACKPORT_LABEL: "backport-${{ github.ref_name }}"
     steps:
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/version_bumps.yml
+++ b/.github/workflows/version_bumps.yml
@@ -2,11 +2,6 @@ name: Bump dependencies
 on:
   workflow_dispatch:
    inputs:
-      branch:
-        description: 'Release Branch'     
-        required: true
-        default: '9.4'
-        type: string
       bump:
         description: 'Bump type'     
         required: true
@@ -36,7 +31,7 @@ jobs:
     name: Bump versions
     runs-on: ubuntu-latest
     env:
-      INPUTS_BRANCH: "${{ inputs.branch }}"
+      INPUTS_BRANCH: "${{ github.ref_name }}"
       INPUTS_BUMP: "${{ inputs.bump }}"
       INPUTS_EXTRA_GEMS_MINOR: "${{ inputs.extra_gems_minor }}"
       INPUTS_EXTRA_GEMS_MAJOR: "${{ inputs.extra_gems_major }}"


### PR DESCRIPTION
removes a separate branch input and uses workflow branch instead. This removes confusion of which workflow branch needs to be selected and what branch input needs to be inserted - ideally they both are the same.