### PR TITLE
Make BufferedTokenizer thread safe

### DIFF
--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerConcurrentConsumptionBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerConcurrentConsumptionBenchmark.java
@@ -23,6 +23,7 @@ import org.logstash.common.BufferedTokenizer;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
 import org.openjdk.jmh.annotations.GroupThreads;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
@@ -34,35 +35,73 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
 
 @Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 1, jvmArgsAppend = {"-Xmx8g", "-Xms8g"})
-@BenchmarkMode(Mode.SingleShotTime)
+@Measurement(iterations = 60, time = 3000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xmx4g", "-Xms4g"})
+@BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@State(Scope.Thread)
-public class BufferedTokenizerConsumptionBenchmark {
+@State(Scope.Group)
+public class BufferedTokenizerConcurrentConsumptionBenchmark {
 
+    public static final String SOME_NEW_TOKEN = "Some new token\n";
     private BufferedTokenizer sut;
-    private Iterator<String> iterator;
-    private String singleTokenPerFragment;
 
     @Setup(Level.Iteration)
-    public void setUp() {
-        sut = new BufferedTokenizer();
-        singleTokenPerFragment = "a".repeat(20) + "\n";
-        iterator = sut.extract(singleTokenPerFragment).iterator();
-        for (int i = 0; i < 10_000_000; i++) {
-            sut.extract(singleTokenPerFragment);
-        }
+    public void prepare() {
+        sut = new BufferedTokenizer("\n", 50);
+    }
+    
+    // ---- multiple writers - single reader
+    
+    @Benchmark
+    @Group("multi_writers_single_reader")
+    @GroupThreads(8)
+    public void mwsr_multipleWriters() {
+        sut.extract("Some new token\n");
     }
 
-    @Measurement(iterations = 120, batchSize = 10_000_000)
     @Benchmark
+    @Group("multi_writers_single_reader")
     @GroupThreads(1)
-    public final void repeatedExtractInvocations(Blackhole blackhole) {
-        blackhole.consume(iterator.next());
+    public void mwsr_singleReader(Blackhole blackhole) {
+        String token = sut.extract("\n").iterator().next();
+        blackhole.consume(token);
+    }
+
+    // ---- single writer - single reader
+
+    @Benchmark
+    @Group("single_writer_single_reader")
+    @GroupThreads(1)
+    public void swsr_singleWriter() {
+        sut.extract(SOME_NEW_TOKEN);
+    }
+
+    @Benchmark
+    @Group("single_writer_single_reader")
+    @GroupThreads(1)
+    public void swsr_singleReader(Blackhole blackhole) {
+        String token = sut.extract("\n").iterator().next();
+        blackhole.consume(token);
+    }
+
+    // ---- single writer - multiple reader
+
+    @Benchmark
+    @Group("single_writer_multi_reader")
+    @GroupThreads(1)
+    public void swmr_singleWriter() {
+        sut.extract(SOME_NEW_TOKEN);
+    }
+
+    @Benchmark
+    @Group("single_writer_multi_reader")
+    @GroupThreads(8)
+    public void swmr_multiReader(Blackhole blackhole) {
+        String token = sut.extract("\n").iterator().next();
+        blackhole.consume(token);
     }
 }

--- a/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerConsumptionBenchmark.java
+++ b/logstash-core/benchmarks/src/main/java/org/logstash/benchmark/BufferedTokenizerConsumptionBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.benchmark;
+
+import org.logstash.common.BufferedTokenizer;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+
+@Warmup(iterations = 3, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xmx8g", "-Xms8g"})
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class BufferedTokenizerConsumptionBenchmark {
+
+    private BufferedTokenizer sut;
+    private Iterator<String> iterator;
+    private String singleTokenPerFragment;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+        sut = new BufferedTokenizer();
+        singleTokenPerFragment = "a".repeat(20) + "\n";
+        iterator = sut.extract(singleTokenPerFragment).iterator();
+        for (int i = 0; i < 10_000_000; i++) {
+            sut.extract(singleTokenPerFragment);
+        }
+    }
+
+    @Measurement(iterations = 120, batchSize = 10_000_000)
+    @Benchmark
+    @GroupThreads(1)
+    public final void repeatedExtractInvocations(Blackhole blackhole) {
+        blackhole.consume(iterator.next());
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/common/BufferedTokenizer.java
+++ b/logstash-core/src/main/java/org/logstash/common/BufferedTokenizer.java
@@ -110,7 +110,7 @@ public class BufferedTokenizer {
             currentIdx = 0;
         }
 
-        public void append(String data) {
+        public synchronized void append(String data) {
             if (isSizeLimitSet()) {
                 if (!data.contains(separator) && lastFragmentSize > sizeLimit) {
                     // stop accumulating if last fragments already reached the sizeLimit
@@ -139,7 +139,7 @@ public class BufferedTokenizer {
             return sizeLimit != Integer.MIN_VALUE;
         }
 
-        public String flush() {
+        public synchronized String flush() {
             if (isSizeLimitSet()) {
                 if (droppedBytesCount > 0) {
                     logger.warn("Input buffer exceeded the sizeLimit of {} and dropped {} bytes from an oversized token", sizeLimit,  droppedBytesCount);

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
@@ -20,6 +20,7 @@
 package org.logstash.common;
 
 
+import org.apache.commons.lang3.stream.Streams;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,10 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.logstash.common.BufferedTokenizerTest.toList;
 
 public final class BufferedTokenizerWithSizeLimitTest {
@@ -196,14 +194,24 @@ public final class BufferedTokenizerWithSizeLimitTest {
         
         AtomicInteger tokenCounter = new AtomicInteger(0);
 
-        int tokensToUse = 1_000_000;
-        Thread producer = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse));
+        int tokensToUse = 10_000;
+        Thread producer1 = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse / 4));
+        Thread producer2 = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse / 4));
+        Thread producer3 = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse / 4));
+        Thread producer4 = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse / 4));
         Thread consumer = new Thread(() -> consumerBufferedTokenizer(sut, tokensToUse, tokenCounter));
-        
-        producer.start();
+
+        Streams.of(producer1, producer2, producer3, producer4).forEach(Thread::start);
         consumer.start();
         
-        producer.join(5_000);
+        Streams.of(producer1, producer2, producer3, producer4).forEach(t -> {
+            try {
+                t.join(5_000);
+            } catch (InterruptedException e) {
+                fail("Can't join " + t.getName() + " in 5 seconds");
+                Thread.currentThread().interrupt();
+            }
+        });
         consumer.join(5_000);
         
         // verify consumer status

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
@@ -26,12 +26,12 @@ import org.junit.Test;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -188,5 +188,53 @@ public final class BufferedTokenizerWithSizeLimitTest {
 
     private static String generate(int length, String fillChar) {
         return fillChar.repeat(length);
+    }
+    
+    @Test
+    public void givenOneProducerAndOneConsumerWhenExecutedConcurrentlyThenNoRaceHappens() throws InterruptedException {
+        initSUTWithSizeLimit(50); // must contain the string "Token with index 1_000_000"
+        
+        AtomicInteger tokenCounter = new AtomicInteger(0);
+
+        int tokensToUse = 1_000_000;
+        Thread producer = new Thread(() -> fulfillBufferedTokenizer(sut, tokensToUse));
+        Thread consumer = new Thread(() -> consumerBufferedTokenizer(sut, tokensToUse, tokenCounter));
+        
+        producer.start();
+        consumer.start();
+        
+        producer.join(5_000);
+        consumer.join(5_000);
+        
+        // verify consumer status
+        assertEquals(tokensToUse, tokenCounter.get());
+    }
+
+    private static void consumerBufferedTokenizer(BufferedTokenizer tokenizer, int maxTokensToExpect, AtomicInteger counter) {
+        long startWait = Long.MAX_VALUE;
+        // invoke extract just to obtain the iterator
+        Iterator<String> tokens = tokenizer.extract("Pill data\n").iterator();
+        while (counter.get() < maxTokensToExpect) {
+            if (tokens.hasNext()) {
+                tokens.next();
+                counter.incrementAndGet();
+            } else {
+                if (startWait == Long.MAX_VALUE) {
+                    // start spinning
+                    startWait = System.currentTimeMillis();
+                } else {
+                    // spinning max for 5 seconds, then break the loop
+                    if (System.currentTimeMillis() - startWait > 5_000) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void fulfillBufferedTokenizer(BufferedTokenizer tokenizer, int maxTokensToFill) {
+        for (int i = 0; i < maxTokensToFill; i++) {
+            tokenizer.extract("Token with index " + i + "\n");
+        }
     }
 }

--- a/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
+++ b/logstash-core/src/test/java/org/logstash/common/BufferedTokenizerWithSizeLimitTest.java
@@ -33,7 +33,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.logstash.common.BufferedTokenizerTest.toList;
 
 public final class BufferedTokenizerWithSizeLimitTest {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Update BufferedTokenizer used to dice input streams of characters to make it thread safe and usable in multithreaded contexts.


## What does this PR do?

This PR make the `DataSplitter` used by `BufferedTokenizer` thread safe adding the missed `synchronized`  keyword to remaining public methods, `append` and `flush`. 
It adds a unit test to verify the correctness and a JMH benchmark to assess eventual performance drops.
The benchmark prefill a tokenizer with 1M tokens, and measure the consumption side, here are the results:

**Without synchronized**
```
Benchmark                                                         Mode  Cnt      Score      Error  Units
BufferedTokenizerConsumptionBenchmark.repeatedExtractInvocations    ss  120  84974.340 ± 3250.754  us/op
```

**With synchronized**
```
Benchmark                                                         Mode  Cnt      Score      Error  Units
BufferedTokenizerConsumptionBenchmark.repeatedExtractInvocations    ss  120  88900.587 ± 3639.065  us/op
```

The thread safe one has a penalty of 5ms/op (each op correspond to a 1M tokens read) that correspond to 4.6 % drop, with an error around ~4% on the measures.

A benchmark that stress the concurrency part has also been added in `org.logstash.benchmark.BufferedTokenizerConcurrentConsumptionBenchmark`

```
Benchmark                                                                                          Mode  Cnt   Score   Error   Units
BufferedTokenizerConcurrentConsumptionBenchmark.multi_writers_single_reader                       thrpt   60  23.273 ± 2.057  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.multi_writers_single_reader:mwsr_multipleWriters  thrpt   60  22.005 ± 2.046  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.multi_writers_single_reader:mwsr_singleReader     thrpt   60   1.268 ± 0.067  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_multi_reader                        thrpt   60  15.295 ± 1.156  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_multi_reader:swmr_multiReader       thrpt   60  12.057 ± 0.691  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_multi_reader:swmr_singleWriter      thrpt   60   3.238 ± 0.688  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_single_reader                       thrpt   60  16.781 ± 0.654  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_single_reader:swsr_singleReader     thrpt   60   4.433 ± 0.204  ops/us
BufferedTokenizerConcurrentConsumptionBenchmark.single_writer_single_reader:swsr_singleWriter     thrpt   60  12.348 ± 0.730  ops/us
```

Comparing the read use case we have 88900 microsec / op, considering that each op in this case is not one token read from the tokenizer but the 1M pull, which corresponds to 11.24 ops/us which is in the same order of the multithreaded use case.
One thing to note is that in the multi threaded use case, we don't know if the buffer always provides some token or if it's empty. So the discrepancies in numbers could be related to that, but the key point is that they are mostly on the same order of magnitude.


## Why is it important/What is the impact to the user?
BufferedTokenizer is always used insingle thread, as the code is today, but given that is half synchronised, it's suboptimal and error prone. So this PR close the gap, showing that there isn't appreciable performance loss.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
```shell
./gradlew jmh -Pinclude="org.logstash.benchmark.BufferedTokenizerConsumptionBenchmark"
./gradlew jmh -Pinclude="org.logstash.benchmark.BufferedTokenizerConcurrentConsumptionBenchmark"
```

OR you can use a script to verify that effectively there is no concurrent access, and consequent malformed JSON drops, with:

https://gist.github.com/andsel/c0e1e6cc68ec15ab079c4dc8586fe0ac

Run it with 
```shell
jbang TestConcurrentHTTPRequests.java --file "a_fixture_of_json_lines_to_send.ndjson" --logstash-api http://localhost:9600 --loops 50 --concurrency 16 http://localhost:8080
```

Run Logstash with the pipeline:
```
input {
  http {
    port => 8080
    additional_codecs => { "application/json" => "json_lines" }
    threads => 8
  }
}

output {
  sink {}
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #19337 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
