### PR TITLE
Continue to test against jdk 17 for 8.19

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -62,10 +62,16 @@ steps:
         options:
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
+          - label: "Adoptium JDK 17 (Eclipse Temurin)"
+            value: "adoptiumjdk_17"
           - label: "OpenJDK 21"
             value: "openjdk_21"
+          - label: "OpenJDK 17"
+            value: "openjdk_17"
           - label: "Zulu 21"
             value: "zulu_21"
+          - label: "Zulu 17"
+            value: "zulu_17"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -4,80 +4,12 @@
 #  - If image doesn't exist, review https://docs.elastic.dev/ingest-dev-docs/engineer-productivity/custom-ci-images
 
 env:
+  # Every run tests all supported JDKs on the default OS. To narrow or broaden a run, set
+  # MATRIX_OSES and/or MATRIX_JDKS (space-separated) in the build environment.
   DEFAULT_MATRIX_OS: "ubuntu-2204"
-  DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
-  # Scheduled and triggered runs skip the manual input step; they test every JDK on the default OS.
-  SCHEDULED_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
+  DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
 
 steps:
-  - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
-    fields:
-      - select: "Operating System"
-        key: "matrix-os"
-        hint: "The operating system variant(s) to run on:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_OS}"
-        options:
-          - label: "Ubuntu 24.04"
-            value: "ubuntu-2404"
-          - label: "Ubuntu 22.04"
-            value: "ubuntu-2204"
-          - label: "Ubuntu 20.04"
-            value: "ubuntu-2004"
-          - label: "Debian 13"
-            value: "debian-13"
-          - label: "Debian 12"
-            value: "debian-12"
-          - label: "Debian 11"
-            value: "debian-11"
-          - label: "RHEL 9"
-            value: "rhel-9"
-          - label: "RHEL 8"
-            value: "rhel-8"
-          - label: "Oracle Linux 9"
-            value: "oraclelinux-9"
-          - label: "Oracle Linux 8"
-            value: "oraclelinux-8"
-          - label: "Oracle Linux 7"
-            value: "oraclelinux-7"
-          - label: "Rocky Linux 8"
-            value: "rocky-linux-8"
-          - label: "Rocky Linux 9"
-            value: "rocky-linux-9"
-          - label: "Alma Linux 8"
-            value: "almalinux-8"
-          - label: "Alma Linux 9"
-            value: "almalinux-9"
-          - label: "Amazon Linux (2023)"
-            value: "amazonlinux-2023"
-          - label: "OpenSUSE Leap 15"
-            value: "opensuse-leap-15"
-
-      - select: "Java"
-        key: "matrix-jdk"
-        hint: "The JDK to test with:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_JDK}"
-        options:
-          - label: "Adoptium JDK 21 (Eclipse Temurin)"
-            value: "adoptiumjdk_21"
-          - label: "Adoptium JDK 17 (Eclipse Temurin)"
-            value: "adoptiumjdk_17"
-          - label: "OpenJDK 21"
-            value: "openjdk_21"
-          - label: "OpenJDK 17"
-            value: "openjdk_17"
-          - label: "Zulu 21"
-            value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
-
-  - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
-
   - command: |
       set -euo pipefail
 
@@ -85,17 +17,8 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      if [[ -n "${MATRIX_JDKS:-}" ]]; then
-        # Matrix supplied via build env vars (e.g. the UI "Environment Variables" field); skip the input step.
-        export MATRIX_JDKS
-        export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
-      elif [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
-        export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
-        export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
-      else
-        export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-        export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
-      fi
+      export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      export MATRIX_JDKS="${MATRIX_JDKS:-$DEFAULT_MATRIX_JDKS}"
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -6,6 +6,8 @@
 env:
   DEFAULT_MATRIX_OS: "ubuntu-2204"
   DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
+  # Scheduled and triggered runs skip the manual input step; they test every JDK on the default OS.
+  SCHEDULED_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
 
 steps:
   - input: "Test Parameters"
@@ -83,8 +85,13 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-      export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      if [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
+        export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
+        export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
+      else
+        export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
+        export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      fi
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then

--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -11,7 +11,7 @@ env:
 
 steps:
   - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job"
+    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
     fields:
       - select: "Operating System"
         key: "matrix-os"
@@ -76,7 +76,7 @@ steps:
             value: "zulu_17"
 
   - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job"
+    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
 
   - command: |
       set -euo pipefail
@@ -85,7 +85,11 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      if [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
+      if [[ -n "${MATRIX_JDKS:-}" ]]; then
+        # Matrix supplied via build env vars (e.g. the UI "Environment Variables" field); skip the input step.
+        export MATRIX_JDKS
+        export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      elif [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
         export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
         export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
       else

--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -190,6 +190,8 @@ class LinuxJobs(Jobs):
 
     def prepare_shell(self) -> str:
         jdk_dir = f"/opt/buildkite-agent/.java/{self.jdk}"
+        # JDK 17 is below the supported minimum (21); force Logstash to boot so we can still test it
+        force_opts = '\nexport LS_JAVA_OPTS="-Dlogstash.jdk.force=true ${LS_JAVA_OPTS:-}"' if self.jdk.endswith("_17") else ""
         return f"""#!/usr/bin/env bash
 set -euo pipefail
 
@@ -199,7 +201,7 @@ unset JAVA_HOME
 # LS env vars for JDK matrix tests
 export BUILD_JAVA_HOME={jdk_dir}
 export RUNTIME_JAVA_HOME={jdk_dir}
-export LS_JAVA_HOME={jdk_dir}
+export LS_JAVA_HOME={jdk_dir}{force_opts}
 
 export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
 eval "$(rbenv init -)"

--- a/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
+++ b/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
@@ -28,6 +28,11 @@ $env:BUILD_JAVA_HOME = $JAVA_CUSTOM_DIR
 $env:RUNTIME_JAVA_HOME = $JAVA_CUSTOM_DIR
 $env:LS_JAVA_HOME = $JAVA_CUSTOM_DIR
 
+# JDK 17 is below the supported minimum (21); force Logstash to boot so we can still test it
+if ($JDK -like "*_17") {
+    $env:LS_JAVA_OPTS = "-Dlogstash.jdk.force=true $($env:LS_JAVA_OPTS)"
+}
+
 Write-Host "--- Running test: $CIScript"
 try {
     Invoke-Expression $CIScript

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -8,7 +8,7 @@ env:
 
 steps:
   - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job"
+    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
     fields:
       - select: "Operating System"
         key: "matrix-os"
@@ -47,7 +47,7 @@ steps:
             value: "zulu_17"
 
   - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job"
+    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
 
   - command: |
       set -euo pipefail
@@ -56,7 +56,11 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      if [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
+      if [[ -n "${MATRIX_JDKS:-}" ]]; then
+        # Matrix supplied via build env vars (e.g. the UI "Environment Variables" field); skip the input step.
+        export MATRIX_JDKS
+        export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      elif [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
         export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
         export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
       else

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -3,6 +3,8 @@
 env:
   DEFAULT_MATRIX_OS: "windows-2022"
   DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
+  # Scheduled and triggered runs skip the manual input step; they test every JDK on the default OS.
+  SCHEDULED_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
 
 steps:
   - input: "Test Parameters"
@@ -54,8 +56,13 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-      export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      if [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
+        export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
+        export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
+      else
+        export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
+        export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      fi
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -1,54 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
+  # Every run tests all supported JDKs on the default OS. To narrow or broaden a run, set
+  # MATRIX_OSES and/or MATRIX_JDKS (space-separated) in the build environment.
   DEFAULT_MATRIX_OS: "windows-2022"
-  DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
-  # Scheduled and triggered runs skip the manual input step; they test every JDK on the default OS.
-  SCHEDULED_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
+  DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 adoptiumjdk_17 openjdk_21 openjdk_17 zulu_21 zulu_17"
 
 steps:
-  - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
-    fields:
-      - select: "Operating System"
-        key: "matrix-os"
-        hint: "The operating system variant(s) to run on:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_OS}"
-        options:
-          - label: "Windows 2025"
-            value: "windows-2025"
-          - label: "Windows 2022"
-            value: "windows-2022"
-          - label: "Windows 2019"
-            value: "windows-2019"
-          - label: "Windows 2016"
-            value: "windows-2016"
-
-      - select: "Java"
-        key: "matrix-jdk"
-        hint: "The JDK to test with:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_JDK}"
-        options:
-          - label: "Adoptium JDK 21 (Eclipse Temurin)"
-            value: "adoptiumjdk_21"
-          - label: "Adoptium JDK 17 (Eclipse Temurin)"
-            value: "adoptiumjdk_17"
-          - label: "OpenJDK 21"
-            value: "openjdk_21"
-          - label: "OpenJDK 17"
-            value: "openjdk_17"
-          - label: "Zulu 21"
-            value: "zulu_21"
-          - label: "Zulu 17"
-            value: "zulu_17"
-
-  - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job" && build.env("MATRIX_JDKS") == null
-
   - command: |
       set -euo pipefail
 
@@ -56,17 +14,8 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      if [[ -n "${MATRIX_JDKS:-}" ]]; then
-        # Matrix supplied via build env vars (e.g. the UI "Environment Variables" field); skip the input step.
-        export MATRIX_JDKS
-        export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
-      elif [[ "${BUILDKITE_SOURCE}" == "schedule" || "${BUILDKITE_SOURCE}" == "trigger_job" ]]; then
-        export MATRIX_OSES="${DEFAULT_MATRIX_OS}"
-        export MATRIX_JDKS="${SCHEDULED_MATRIX_JDKS}"
-      else
-        export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-        export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
-      fi
+      export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      export MATRIX_JDKS="${MATRIX_JDKS:-$DEFAULT_MATRIX_JDKS}"
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -33,10 +33,16 @@ steps:
         options:
           - label: "Adoptium JDK 21 (Eclipse Temurin)"
             value: "adoptiumjdk_21"
+          - label: "Adoptium JDK 17 (Eclipse Temurin)"
+            value: "adoptiumjdk_17"
           - label: "OpenJDK 21"
             value: "openjdk_21"
+          - label: "OpenJDK 17"
+            value: "openjdk_17"
           - label: "Zulu 21"
             value: "zulu_21"
+          - label: "Zulu 17"
+            value: "zulu_17"
 
   - wait: ~
     if: build.source != "schedule" && build.source != "trigger_job"

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,11 @@ allprojects {
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.util=ALL-UNNAMED"
     ]
+    // On JDK < 21 (below LogStash's supported minimum) let in-process specs that boot
+    // LogStash::Runner start instead of aborting (see runner.rb JDK check).
+    if (JavaVersion.current() < JavaVersion.VERSION_21) {
+      jvmArgs += "-Dlogstash.jdk.force=true"
+    }
     maxHeapSize = "2g"
     //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
     testLogging {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Ensure 8.19 is tested against a matrix of jdk versions. Previously there was not a matrix run on a schedule and doing it via the UI was very tedious. Now there is a single entrypoint for the full matrix. If we agree on this I will apply to to main/9.x as well. 

The outcome here is that on a schedule now 8.19 will run against a matrix of jdk/OS while we continue to support jdk 17. 


- Relates #19317