### PR TITLE
Update jdk matrix tests with improvements from 8.19

### DIFF
--- a/.buildkite/linux_jdk_matrix_pipeline.yml
+++ b/.buildkite/linux_jdk_matrix_pipeline.yml
@@ -4,72 +4,12 @@
 #  - If image doesn't exist, review https://docs.elastic.dev/ingest-dev-docs/engineer-productivity/custom-ci-images
 
 env:
+  # Every run tests all supported JDKs on the default OS. To narrow or broaden a run, set
+  # MATRIX_OSES and/or MATRIX_JDKS (space-separated) in the build environment.
   DEFAULT_MATRIX_OS: "ubuntu-2204"
-  DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
+  DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 openjdk_21 zulu_21"
 
 steps:
-  - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job"
-    fields:
-      - select: "Operating System"
-        key: "matrix-os"
-        hint: "The operating system variant(s) to run on:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_OS}"
-        options:
-          - label: "Ubuntu 24.04"
-            value: "ubuntu-2404"
-          - label: "Ubuntu 22.04"
-            value: "ubuntu-2204"
-          - label: "Ubuntu 20.04"
-            value: "ubuntu-2004"
-          - label: "Debian 13"
-            value: "debian-13"
-          - label: "Debian 12"
-            value: "debian-12"
-          - label: "Debian 11"
-            value: "debian-11"
-          - label: "RHEL 9"
-            value: "rhel-9"
-          - label: "RHEL 8"
-            value: "rhel-8"
-          - label: "Oracle Linux 9"
-            value: "oraclelinux-9"
-          - label: "Oracle Linux 8"
-            value: "oraclelinux-8"
-          - label: "Oracle Linux 7"
-            value: "oraclelinux-7"
-          - label: "Rocky Linux 8"
-            value: "rocky-linux-8"
-          - label: "Rocky Linux 9"
-            value: "rocky-linux-9"
-          - label: "Alma Linux 8"
-            value: "almalinux-8"
-          - label: "Alma Linux 9"
-            value: "almalinux-9"
-          - label: "Amazon Linux (2023)"
-            value: "amazonlinux-2023"
-          - label: "OpenSUSE Leap 15"
-            value: "opensuse-leap-15"
-
-      - select: "Java"
-        key: "matrix-jdk"
-        hint: "The JDK to test with:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_JDK}"
-        options:
-          - label: "Adoptium JDK 21 (Eclipse Temurin)"
-            value: "adoptiumjdk_21"
-          - label: "OpenJDK 21"
-            value: "openjdk_21"
-          - label: "Zulu 21"
-            value: "zulu_21"
-
-  - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job"
-
   - command: |
       set -euo pipefail
 
@@ -77,8 +17,8 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-      export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      export MATRIX_JDKS="${MATRIX_JDKS:-$DEFAULT_MATRIX_JDKS}"
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then

--- a/.buildkite/windows_jdk_matrix_pipeline.yml
+++ b/.buildkite/windows_jdk_matrix_pipeline.yml
@@ -1,46 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
+  # Every run tests all supported JDKs on the default OS. To narrow or broaden a run, set
+  # MATRIX_OSES and/or MATRIX_JDKS (space-separated) in the build environment.
   DEFAULT_MATRIX_OS: "windows-2022"
-  DEFAULT_MATRIX_JDK: "adoptiumjdk_21"
+  DEFAULT_MATRIX_JDKS: "adoptiumjdk_21 openjdk_21 zulu_21"
 
 steps:
-  - input: "Test Parameters"
-    if: build.source != "schedule" && build.source != "trigger_job"
-    fields:
-      - select: "Operating System"
-        key: "matrix-os"
-        hint: "The operating system variant(s) to run on:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_OS}"
-        options:
-          - label: "Windows 2025"
-            value: "windows-2025"
-          - label: "Windows 2022"
-            value: "windows-2022"
-          - label: "Windows 2019"
-            value: "windows-2019"
-          - label: "Windows 2016"
-            value: "windows-2016"
-
-      - select: "Java"
-        key: "matrix-jdk"
-        hint: "The JDK to test with:"
-        required: true
-        multiple: true
-        default: "${DEFAULT_MATRIX_JDK}"
-        options:
-          - label: "Adoptium JDK 21 (Eclipse Temurin)"
-            value: "adoptiumjdk_21"
-          - label: "OpenJDK 21"
-            value: "openjdk_21"
-          - label: "Zulu 21"
-            value: "zulu_21"
-
-  - wait: ~
-    if: build.source != "schedule" && build.source != "trigger_job"
-
   - command: |
       set -euo pipefail
 
@@ -48,8 +14,8 @@ steps:
       python3 -m pip install ruamel.yaml
 
       echo "--- Printing generated dynamic steps"
-      export MATRIX_OSES="$(buildkite-agent meta-data get matrix-os --default=${DEFAULT_MATRIX_OS})"
-      export MATRIX_JDKS="$(buildkite-agent meta-data get matrix-jdk --default=${DEFAULT_MATRIX_JDK})"
+      export MATRIX_OSES="${MATRIX_OSES:-$DEFAULT_MATRIX_OS}"
+      export MATRIX_JDKS="${MATRIX_JDKS:-$DEFAULT_MATRIX_JDKS}"
       set +eo pipefail
       python3 .buildkite/scripts/jdk-matrix-tests/generate-steps.py >pipeline_steps.yml
       if [[ $$? -ne 0 ]]; then


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
Refactor the jdk matrix tests to run the full matrix on a schedule. This was originally devloped in https://github.com/elastic/logstash/pull/19352 where jdk 17 is being tested. for main, we only have jdk 21 for now (though 25 will likely come soon). This PR updates the jdk tests to follow the improved pattern in 8.19.
