### PR TITLE
Pin jruby-openssl on main

### DIFF
--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -82,6 +82,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "elasticsearch", '>= 8', '< 10'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 
+  # TODO: EVALUTE PIN: Pinned to the 0.16 line to avoid the 0.19 beta which breaks observabilitySRE distro
+  gem.add_runtime_dependency "jruby-openssl", "~> 0.16.2"
+
   # xpack geoip database service
   gem.add_development_dependency 'logstash-filter-geoip', '>= 7.2.1' # breaking change of DatabaseManager
   gem.add_dependency 'down', '~> 5.2.0' #(MIT license)


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
For the main branch of logstash no lockfile is maintained so we get the latest gems. The 0.19.0 beta release of jruby-openssl breaks our https://github.com/jruby/jruby-openssl/commit/c7972ee33b9fee5d7beddeda42720c1a9d7e3479 observabilitySRE fips distribution. Pin to 0.16 series until that stabilizes and we can evaluate taking up. The release has been designated beta for now.

Example failure:
```

2026-07-29 20:05:16 UTC | java.lang.NoSuchFieldError: Class org.bouncycastle.asn1.nist.NISTObjectIdentifiers does not have member field 'org.bouncycastle.asn1.ASN1ObjectIdentifier id_Kmac128'
-- | --
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jcajce.provider.digest.SHA3$Mappings.configure(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider.loadServiceClass(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider.setup(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
  | 2026-07-29 20:05:16 UTC | at org.bouncycastle.jce.provider.BouncyCastleProvider.<init>(Unknown Source)
  | 2026-07-29 20:05:16 UTC | at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
  | 2026-07-29 20:05:16 UTC | at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
  | 2026-07-29 20:05:16 UTC | at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
  | 2026-07-29 20:05:16 UTC | at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:304)
  | 2026-07-29 20:05:16 UTC | at java.base/java.lang.Class.newInstance(Class.java:727)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.SecurityHelper.newBouncyCastleProvider(SecurityHelper.java:197)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.SecurityHelper.setBouncyCastleProvider(SecurityHelper.java:132)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.SecurityHelper.initSecurityProvider(SecurityHelper.java:111)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.SecurityHelper.getSecurityProvider(SecurityHelper.java:86)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.SecurityHelper.getCertificateFactory(SecurityHelper.java:254)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.PEMInputOutput.getX509CertificateFactory(PEMInputOutput.java:1482)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.PEMInputOutput.readAuxCertificate(PEMInputOutput.java:1309)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.PEMInputOutput.readPEM(PEMInputOutput.java:227)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Lookup.loadCertificateOrCRLFile(Lookup.java:307)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Lookup$ByFile.call(Lookup.java:484)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Lookup$ByFile.call(Lookup.java:463)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Lookup.control(Lookup.java:134)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Lookup.loadFile(Lookup.java:103)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.x509store.Store.setDefaultPaths(Store.java:325)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.X509Store.set_default_paths(X509Store.java:211)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ext.openssl.X509Store$INVOKER$i$0$0$set_default_paths.call(X509Store$INVOKER$i$0$0$set_default_paths.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:456)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:352)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.interpretFrameScope(Interpreter.java:174)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_CLASS(Interpreter.java:127)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.instructions.DefineClassInstr.interpret(DefineClassInstr.java:74)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.processOtherOp(StartupInterpreterEngine.java:155)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:98)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.interpretFrameScope(Interpreter.java:174)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_MODULE(Interpreter.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.instructions.DefineModuleInstr.interpret(DefineModuleInstr.java:68)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.processOtherOp(StartupInterpreterEngine.java:155)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:98)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.interpretFrameScope(Interpreter.java:174)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_MODULE(Interpreter.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.instructions.DefineModuleInstr.interpret(DefineModuleInstr.java:68)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.processOtherOp(StartupInterpreterEngine.java:155)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:98)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1773)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2391)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.vendor.jruby.lib.ruby.stdlib.bundled_gems.️❤ {} replace_require #0(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/bundled_gems.rb:81)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:466)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:244)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:320)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1773)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2391)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.vendor.jruby.lib.ruby.stdlib.bundled_gems.️❤ {} replace_require #0(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/bundled_gems.rb:81)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:466)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:244)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:320)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1773)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2391)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.vendor.jruby.lib.ruby.stdlib.bundled_gems.️❤ {} replace_require #0(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/bundled_gems.rb:81)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:466)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:244)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:320)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneBlock.call(JavaMethod.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:146)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:644)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1815)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2401)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$send.call(RubyKernel$INVOKER$s$send.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:797)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.vendor.jruby.lib.ruby.stdlib.bundled_gems.️❤ {} replace_require #0(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/vendor/jruby/lib/ruby/stdlib/bundled_gems.rb:81)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.CompiledIRBlockBody.callDirect(CompiledIRBlockBody.java:141)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.callDirect(MixedModeIRBlockBody.java:105)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:466)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:244)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:320)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1773)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2391)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$send.call(RubyKernel$INVOKER$s$send.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrTwoOrNBlock.call(JavaMethod.java:443)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:291)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:330)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:120)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:138)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:68)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:225)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:466)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:244)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:320)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_ROOT(Interpreter.java:100)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:85)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.execute(Interpreter.java:35)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.IRTranslator.execute(IRTranslator.java:42)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runInterpreter(Ruby.java:1242)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.loadFile(Ruby.java:3046)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$ResourceLibrary.load(LibrarySearcher.java:945)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LibrarySearcher$FoundLibrary.load(LibrarySearcher.java:903)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.tryLoadingLibraryOrScript(LoadService.java:675)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.lambda$smartLoadInternal$0(LoadService.java:577)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.executeAndClearLock(LoadService.java:516)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService$RequireLocks.lock(LoadService.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.smartLoadInternal(LoadService.java:563)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.load.LoadService.require(LoadService.java:414)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.requireCommon(RubyKernel.java:1200)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.require(RubyKernel.java:1195)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$1$0$require.call(RubyKernel$INVOKER$s$1$0$require.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:131)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyClass.finvokeWithRefinements(RubyClass.java:660)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyBasicObject.send(RubyBasicObject.java:1773)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel.send(RubyKernel.java:2391)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyKernel$INVOKER$s$send.call(RubyKernel$INVOKER$s$send.gen)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrTwoOrNBlock.call(JavaMethod.java:443)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:476)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:293)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:330)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:120)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:138)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:68)
  | 2026-07-29 20:05:16 UTC | at org.jruby.runtime.Block.call(Block.java:154)
  | 2026-07-29 20:05:16 UTC | at org.jruby.RubyProc.call(RubyProc.java:417)
  | 2026-07-29 20:05:16 UTC | at org.jruby.internal.runtime.methods.ProcMethod.call(ProcMethod.java:62)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.targets.indy.InvokeSite.performIndirectCall(InvokeSite.java:893)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:820)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.lib.bootstrap.environment.️❤ script(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/lib/bootstrap/environment.rb:88)
  | 2026-07-29 20:05:16 UTC | at logstash.build.qa_minus_fixture.logstash_minus_9_dot_6_dot_0_minus_SNAPSHOT.lib.bootstrap.environment.run(/logstash/build/qa-fixture/logstash-9.6.0-SNAPSHOT/lib/bootstrap/environment.rb)
  | 2026-07-29 20:05:16 UTC | at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
  | 2026-07-29 20:05:16 UTC | at org.jruby.ir.Compiler$1.load(Compiler.java:114)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runScript(Ruby.java:1229)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runNormally(Ruby.java:1141)
  | 2026-07-29 20:05:16 UTC | at org.jruby.Ruby.runFromMain(Ruby.java:986)
  | 2026-07-29 20:05:16 UTC | at org.logstash.Logstash.run(Logstash.java:185)
  | 2026-07-29 20:05:16 UTC | at org.logstash.Logstash.main(Logstash.java:93)
  | 2026-07-29 20:05:16 UTC | Failed (


```