### PR TITLE
Add test to verify that force jdk works when running with JDK 17

### DIFF
--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -29,7 +29,6 @@ require "json"
 require "webmock/rspec"
 require_relative "../support/helpers"
 require_relative "../support/matchers"
-JAVA_SPEC_VERSION = java.lang.System.getProperty("java.specification.version")
 java_import 'org.logstash.util.JavaVersion'
 
 describe LogStash::Runner do

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -717,7 +717,6 @@ describe LogStash::Runner do
     let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
 
     before(:each) do
-      # skip "Test requires JDK 17, found #{JAVA_SPEC_VERSION}" unless JAVA_SPEC_VERSION == "17"
       skip "Test requires JDK 17, found #{JavaVersion::CURRENT}" unless JavaVersion::CURRENT.compare_to(JavaVersion::JAVA_17) == 0
       allow(runner).to receive(:deprecation_logger).and_return(deprecation_logger_stub)
       allow(logger).to receive(:error)

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -29,6 +29,8 @@ require "json"
 require "webmock/rspec"
 require_relative "../support/helpers"
 require_relative "../support/matchers"
+JAVA_SPEC_VERSION = java.lang.System.getProperty("java.specification.version")
+java_import 'org.logstash.util.JavaVersion'
 
 describe LogStash::Runner do
   subject(:runner) { LogStash::Runner }
@@ -706,6 +708,37 @@ describe LogStash::Runner do
         it "should show help" do
           expect { subject.run(args) }.to raise_error(Clamp::HelpWanted)
         end
+      end
+    end
+  end
+
+  describe "JDK 17 compatibility" do
+    subject { LogStash::Runner.new("") }
+    let(:args) { ["-e", "input {} output {}"] }
+    let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
+
+    before(:each) do
+      # skip "Test requires JDK 17, found #{JAVA_SPEC_VERSION}" unless JAVA_SPEC_VERSION == "17"
+      skip "Test requires JDK 17, found #{JavaVersion::CURRENT}" unless JavaVersion::CURRENT.compare_to(JavaVersion::JAVA_17) == 0
+      allow(runner).to receive(:deprecation_logger).and_return(deprecation_logger_stub)
+      allow(logger).to receive(:error)
+      allow(subject).to receive(:force_jdk_check).and_return(mock_force_jdk_check)
+    end
+
+    context "without -Dlogstash.jdk.force=true" do
+      let(:mock_force_jdk_check) { false }
+      it "logs an error about minimum required Java version 21 and returns exit code 1" do
+        expect(logger).to receive(:error).with(a_string_including("minimum required version of Java is 21"))
+        expect(subject.run(args)).to eq(1)
+      end
+    end
+
+    context "with -Dlogstash.jdk.force=true" do
+      let(:mock_force_jdk_check) { true }
+
+      it "logs a warning about forced execution with unsupported Java version" do
+        expect(logger).to receive(:warn).with(a_string_including("force the execution with unsupported Java version"))
+        subject.run(args)
       end
     end
   end


### PR DESCRIPTION
## Release notes
[rn:skip]


## What does this PR do?
Add a test to `runner_spec` to verify that Logstash can't start when JDK is. not forced and run on JDK 17, but also that start with a warn log line when it's forced.

## Why is it important/What is the impact to the user?

N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. set a JDK 17 in your shell like:
    ```
     sdk use java 17.0.19-tem
    ```
    
2. run the tests and chekc they are executed:
    ```
     SPEC_OPTS="-e 'LogStash::Runner JDK 17 compatibility'" ./gradlew clean :logstash-core:rubyTests --tests org.logstash.RSpecTests
    ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #19311

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
