### PR TITLE
Revert addition of `logstash.jdk.force` setting

### DIFF
--- a/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
+++ b/.buildkite/scripts/jdk-matrix-tests/generate-steps.py
@@ -190,8 +190,6 @@ class LinuxJobs(Jobs):
 
     def prepare_shell(self) -> str:
         jdk_dir = f"/opt/buildkite-agent/.java/{self.jdk}"
-        # JDK 17 is below the supported minimum (21); force Logstash to boot so we can still test it
-        force_opts = '\nexport LS_JAVA_OPTS="-Dlogstash.jdk.force=true ${LS_JAVA_OPTS:-}"' if self.jdk.endswith("_17") else ""
         return f"""#!/usr/bin/env bash
 set -euo pipefail
 
@@ -201,7 +199,7 @@ unset JAVA_HOME
 # LS env vars for JDK matrix tests
 export BUILD_JAVA_HOME={jdk_dir}
 export RUNTIME_JAVA_HOME={jdk_dir}
-export LS_JAVA_HOME={jdk_dir}{force_opts}
+export LS_JAVA_HOME={jdk_dir}
 
 export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
 eval "$(rbenv init -)"

--- a/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
+++ b/.buildkite/scripts/jdk-matrix-tests/launch-command.ps1
@@ -28,11 +28,6 @@ $env:BUILD_JAVA_HOME = $JAVA_CUSTOM_DIR
 $env:RUNTIME_JAVA_HOME = $JAVA_CUSTOM_DIR
 $env:LS_JAVA_HOME = $JAVA_CUSTOM_DIR
 
-# JDK 17 is below the supported minimum (21); force Logstash to boot so we can still test it
-if ($JDK -like "*_17") {
-    $env:LS_JAVA_OPTS = "-Dlogstash.jdk.force=true $($env:LS_JAVA_OPTS)"
-}
-
 Write-Host "--- Running test: $CIScript"
 try {
     Invoke-Expression $CIScript

--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,6 @@ allprojects {
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.util=ALL-UNNAMED"
     ]
-    // On JDK < 21 (below LogStash's supported minimum) let in-process specs that boot
-    // LogStash::Runner start instead of aborting (see runner.rb JDK check).
-    if (JavaVersion.current() < JavaVersion.VERSION_21) {
-      jvmArgs += "-Dlogstash.jdk.force=true"
-    }
     maxHeapSize = "2g"
     //https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
     testLogging {

--- a/config/jvm.options
+++ b/config/jvm.options
@@ -88,8 +88,3 @@
 # Sets the maximum nesting depth. The depth is a count of objects and arrays that have not
 # been closed, `{` and `[` respectively.
 #-Dlogstash.jackson.stream-read-constraints.max-nesting-depth=1000
-
-# Bypass JDK version check
-#
-# Setting this to true permit to run Logstash with an unsupported JDK version.
-#-Dlogstash.jdk.force=true

--- a/logstash-core/lib/logstash/runner.rb
+++ b/logstash-core/lib/logstash/runner.rb
@@ -331,7 +331,6 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated msg
     end
 
-    jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     if JavaVersion::CURRENT < JavaVersion::JAVA_11
       logger.warn I18n.t("logstash.runner.java.version",
                                              :java_home => java.lang.System.getProperty("java.home"))
@@ -339,16 +338,8 @@ class LogStash::Runner < Clamp::StrictCommand
       deprecation_logger.deprecated I18n.t("logstash.runner.java.version_17_minimum",
                                            :java_home => java.lang.System.getProperty("java.home"))
     elsif JavaVersion::CURRENT < JavaVersion::JAVA_21
-      if force_jdk_check(jvmArgs)
-        logger.warn I18n.t("logstash.runner.java.version_below_21_force",
-                           :java_home => java.lang.System.getProperty("java.home"),
-                           :java_version => JavaVersion::CURRENT)
-      else
-        logger.error I18n.t("logstash.runner.java.version_21_minimum",
-                            :java_home => java.lang.System.getProperty("java.home"), 
-                            :java_version => JavaVersion::CURRENT)
-        return 1
-      end
+      deprecation_logger.deprecated I18n.t("logstash.runner.java.version_21_minimum",
+                                           :java_home => java.lang.System.getProperty("java.home"))
     end
 
     logger.warn I18n.t("logstash.runner.java.home") if ENV["JAVA_HOME"]
@@ -359,6 +350,7 @@ class LogStash::Runner < Clamp::StrictCommand
     end
 
     logger.info("Starting Logstash", "logstash.version" => LOGSTASH_VERSION, "jruby.version" => RUBY_DESCRIPTION)
+    jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments()
     logger.info "JVM bootstrap flags: #{jvmArgs}"
 
     # Add local modules to the registry before everything else
@@ -658,8 +650,4 @@ class LogStash::Runner < Clamp::StrictCommand
     end
   end
 
-  def force_jdk_check(jvm_args_list)
-    jvm_args_list.include? "-Dlogstash.jdk.force=true"
-  end
-  private :force_jdk_check
 end

--- a/logstash-core/locales/en.yml
+++ b/logstash-core/locales/en.yml
@@ -453,15 +453,8 @@ en:
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
         version_21_minimum: >-
-          Starting from Logstash 8.19.19 the minimum required version of Java is 21;
-          your Java version from `%{java_home}` is `%{java_version}` and does not meet this requirement.
-          Running Logstash with the bundled JDK is recommended.
-          The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
-          If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.
-        version_below_21_force: >-
-          Starting from Logstash 8.19.19 the minimum required version of Java is 21;
-          your Java version from `%{java_home}` is `%{java_version}` and does not meet this requirement.
-          You have selected to force the execution with unsupported Java version, and could generate unexpected malfunctions.
+          Java 17 is deprecated and in a future release the minimum required version of Java will be Java 21;
+          your Java version from `%{java_home}` does not meet this requirement.
           Running Logstash with the bundled JDK is recommended.
           The bundled JDK has been verified to work with each specific version of Logstash, and generally provides best performance and reliability.
           If you have compelling reasons for using your own JDK (organizational-specific compliance requirements, for example), the version you supply with LS_JAVA_HOME must meet the minimum requirements.

--- a/logstash-core/spec/logstash/runner_spec.rb
+++ b/logstash-core/spec/logstash/runner_spec.rb
@@ -29,7 +29,6 @@ require "json"
 require "webmock/rspec"
 require_relative "../support/helpers"
 require_relative "../support/matchers"
-java_import 'org.logstash.util.JavaVersion'
 
 describe LogStash::Runner do
   subject(:runner) { LogStash::Runner }
@@ -707,36 +706,6 @@ describe LogStash::Runner do
         it "should show help" do
           expect { subject.run(args) }.to raise_error(Clamp::HelpWanted)
         end
-      end
-    end
-  end
-
-  describe "JDK 17 compatibility" do
-    subject { LogStash::Runner.new("") }
-    let(:args) { ["-e", "input {} output {}"] }
-    let(:deprecation_logger_stub) { double("DeprecationLogger").as_null_object }
-
-    before(:each) do
-      skip "Test requires JDK 17, found #{JavaVersion::CURRENT}" unless JavaVersion::CURRENT.compare_to(JavaVersion::JAVA_17) == 0
-      allow(runner).to receive(:deprecation_logger).and_return(deprecation_logger_stub)
-      allow(logger).to receive(:error)
-      allow(subject).to receive(:force_jdk_check).and_return(mock_force_jdk_check)
-    end
-
-    context "without -Dlogstash.jdk.force=true" do
-      let(:mock_force_jdk_check) { false }
-      it "logs an error about minimum required Java version 21 and returns exit code 1" do
-        expect(logger).to receive(:error).with(a_string_including("minimum required version of Java is 21"))
-        expect(subject.run(args)).to eq(1)
-      end
-    end
-
-    context "with -Dlogstash.jdk.force=true" do
-      let(:mock_force_jdk_check) { true }
-
-      it "logs a warning about forced execution with unsupported Java version" do
-        expect(logger).to receive(:warn).with(a_string_including("force the execution with unsupported Java version"))
-        subject.run(args)
       end
     end
   end

--- a/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
+++ b/logstash-core/src/main/java/org/logstash/util/JavaVersion.java
@@ -22,7 +22,6 @@ package org.logstash.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Helper class to compare current version of JVM with a target version.
@@ -84,10 +83,5 @@ public class JavaVersion implements Comparable<JavaVersion> {
     @Override
     public int compareTo(JavaVersion other) {
         return compare(this, other);
-    }
-
-    @Override
-    public String toString() {
-        return version.stream().map(Object::toString).collect(Collectors.joining("."));
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Reverts addition of `logstash.jdk.force` and all references to it while we figure out the best ergonomics and deprecation path. The behavior should remain the same as in 8.19.19 whereby if a custom jdk 17 is detected a deprecation will be logged and logstash will continue to run normally.  


Reverts #19311 #19361