### PR TITLE
ci: add main-branch DRA check for minor version-bump workflow

### DIFF
--- a/.buildkite/version_bump_pipeline.yml
+++ b/.buildkite/version_bump_pipeline.yml
@@ -74,3 +74,50 @@ steps:
           field: ".version"
           expected_value: "${NEW_VERSION}-SNAPSHOT"
           polling_interval: "30"
+
+  - label: "Generate Fetch master DRA Artifacts step"
+    key: generate-master-dra-check
+    if: build.env("WORKFLOW") == "minor"
+    depends_on: fetch-dra-artifacts
+    agents:
+      image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
+      cpu: 250m
+      memory: 512Mi
+      ephemeralStorage: 1Gi
+    command: |
+      IFS='.' read -r major minor patch <<EOF
+      $${NEW_VERSION}
+      EOF
+      for part in "$$major" "$$minor" "$$patch"; do
+        case "$$part" in
+          ''|*[!0-9]*) echo "ERROR: NEW_VERSION must be MAJOR.MINOR.PATCH, got $${NEW_VERSION}" >&2; exit 1 ;;
+        esac
+      done
+      next_main="$$major.$$((minor + 1)).0"
+      echo "Waiting for $$next_main-SNAPSHOT on master"
+      cat <<EOF | buildkite-agent pipeline upload
+      steps:
+        - label: "Fetch master DRA Artifacts"
+          key: fetch-master-dra-artifacts
+          depends_on: generate-master-dra-check
+          agents:
+            image: docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest
+            cpu: 250m
+            memory: 512Mi
+            ephemeralStorage: 1Gi
+          command:
+            - echo "Polling $$next_main-SNAPSHOT on master..."
+          timeout_in_minutes: 240
+          retry:
+            automatic:
+              - exit_status: "*"
+                limit: 2
+            manual:
+              permit_on_passed: true
+          plugins:
+            - elastic/json-watcher#v1.0.0:
+                url: "https://storage.googleapis.com/elastic-artifacts-snapshot/logstash/latest/master.json"
+                field: ".version"
+                expected_value: "$$next_main-SNAPSHOT"
+                polling_interval: "30"
+      EOF


### PR DESCRIPTION
### Description

During the recent minor version bump (9.5), each team's version-bump pipeline advanced `main` to the next dev minor (`9.6.0-SNAPSHOT`) in addition to cutting the release branch. The version-bump pipelines currently verify only that the release-branch DRA artifacts landed (staging + snapshot for `${BRANCH}.json`) — they do not verify that main's DRA snapshot actually published at the new version.

This means a minor bump can report success even if main's DRA pipeline never picked up `9.6.0-SNAPSHOT`. The gap was identified during the `9.5` feature freeze. Only ml-cpp and kibana had a main-branch check; this brings the remaining repos up to the same standard.

Tracking: elastic/platform-engineering-productivity#3012

### What

Adds a two-step sequence, gated on `WORKFLOW=minor`:

1. **`generate-master-dra-check`** — runs after `fetch-dra-artifacts`. Computes the next dev minor from `NEW_VERSION` (e.g. `9.5.0` → `9.6.0`) and dynamically uploads a child step via `buildkite-agent pipeline upload`.
2. **`fetch-master-dra-artifacts`** (uploaded at runtime) — polls `master.json` on GCS with `elastic/json-watcher` until `.version` equals `${next_minor}-SNAPSHOT`.

Patch and major bumps are unaffected — the `if: build.env("WORKFLOW") == "minor"` guard means neither step is uploaded.

### Notes

- The GCS alias for main's DRA artifacts is `master.json` (not `main.json`).
- The next minor is derived from `NEW_VERSION`, not `BRANCH`.
