### PR TITLE
Use hyphenated input names in bump-logstash workflow

### DIFF
--- a/.buildkite/version_bump_pipeline.yml
+++ b/.buildkite/version_bump_pipeline.yml
@@ -31,8 +31,8 @@ steps:
           workflow-file: "bump-logstash.yml"
           workflow-ref: "main"
           workflow-inputs:
-            logstash_version: "${NEW_VERSION}"
-            logstash_branch: "${BRANCH}"
+            logstash-version: "${NEW_VERSION}"
+            logstash-branch: "${BRANCH}"
 
   - block: "Ready to fetch for DRA artifacts?"
     prompt: |

--- a/.github/workflows/bump-logstash.yml
+++ b/.github/workflows/bump-logstash.yml
@@ -3,15 +3,15 @@ name: bump-logstash-version
 on:
   workflow_dispatch:
     inputs:
-      logstash_version:
+      logstash-version:
         description: 'Logstash version to update TO (example: 9.1.4)'
         required: true
         type: string
-      logstash_branch:
+      logstash-branch:
         description: 'Logstash branch (example: 9.1)'
         required: true
         type: string
-      logstash_release_track:
+      logstash-release-track:
         description: 'Release track (example: 9.current, 9.previous, main). Optional; when omitted the release track in versions.yml is left unchanged.'
         required: false
         type: string
@@ -33,6 +33,6 @@ jobs:
           version-file: .updatecli-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOGSTASH_BRANCH: "${{ github.event.inputs.logstash_branch }}"
-          LOGSTASH_VERSION: "${{ github.event.inputs.logstash_version }}"
-          LOGSTASH_RELEASE_TRACK: "${{ github.event.inputs.logstash_release_track }}"
+          LOGSTASH_BRANCH: "${{ inputs.logstash-branch }}"
+          LOGSTASH_VERSION: "${{ inputs.logstash-version }}"
+          LOGSTASH_RELEASE_TRACK: "${{ inputs.logstash-release-track }}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- bug
## Release notes
[rn:skip] 

The unified-release-centralized-version-bump pipeline (and the elastic/gh-cli Buildkite plugin) dispatches inputs with hyphens (logstash-version, logstash-branch), but the workflow declared them with underscores (logstash_version, logstash_branch). GitHub rejects unrecognized input names.

## Changes
- Rename workflow inputs to use hyphens, matching what callers send
- Update env references to use the inputs context (required for hyphenated names)
- Align Buildkite workflow-inputs keys to use hyphens explicitly

[Error logs](https://buildkite.com/elastic/logstash-version-bump/builds/24#019fcca0-8a68-41ae-b753-7db6cedf7b66)