### PR TITLE
Set 9.5 release track to 9.current

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -5,7 +5,7 @@ logstash-core: 9.5.1
 logstash-core-plugin-api: 2.1.16
 # Logstash release track corresponding to keys in https://github.com/logstash-plugins/.ci/blob/1.x/logstash-versions.yml
 # For example 9.current, 9.previous, etc
-logstash-release-track: 9.next
+logstash-release-track: 9.current
 
 bundled_jdk:
   # for AdoptOpenJDK/OpenJDK jdk-14.0.1+7.1, the revision is 14.0.1 while the build is 7.1


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Point to 9.current in .ci/versions.yml to test against 9.5 series. 