### PR TITLE
Handles no such file exception if happens during the oldest segment resolution

### DIFF
--- a/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
+++ b/logstash-core/src/main/java/org/logstash/common/io/DeadLetterQueueUtils.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
@@ -84,8 +85,17 @@ Finds the max segment ID between the `.log` file segments using OS-level glob fi
             for (Path p : stream) {
                 int id = extractSegmentId(p);
                 if (id < oldestId) {
-                    if (minFileSize > 0 && Files.size(p) <= minFileSize) {
-                        continue;
+                    if (minFileSize > 0) {
+                        long size;
+                        try {
+                            size = Files.size(p);
+                        } catch (NoSuchFileException e) {
+                            logger.debug("Segment file {} was removed concurrently, skipping", p);
+                            continue;
+                        }
+                        if (size <= minFileSize) {
+                            continue;
+                        }
                     }
                     oldestId = id;
                     oldest = p;


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Fix: when the DLQ is active, a `NoSuchFileException` bug may occur while extracting the oldest segment file.

## What does this PR do?
Handles the no such file exception which may happen during the oldest file segment extraction, which means file might be removed by reader pipeline or DLQ clean up when reaches `dead_letter_queue.max_bytes`. 

## Why is it important/What is the impact to the user?
Users will no longer face pipeline crash experience if no such file exception occurs.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [ ]

## How to test this PR locally

I have setup intensive DLQ write and read pipeline but no luck to reproduce the issue so far.
It looks like it is hard to reproduce the case as origin #19377 issue states 1d+ set up required (`clean_consumed: true, retain.age: 3d`). 


## Related issues

- Closes #19377 

## Use cases


## Screenshots


## Logs
