### PR TITLE
[chore] add timestamp in health check API

### DIFF
--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -1699,6 +1699,11 @@ paths:
                       symptom:
                         type: string
                         example: "3 indicators are healthy"
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: The time at which this health report was generated, in ISO 8601 format with millisecond precision.
+                        example: "2026-08-12T10:30:45.123Z"
                       indicators:
                         description: Information about the health of Logstash indicators.
                         type: object
@@ -1798,6 +1803,7 @@ paths:
                 normalTerminatedCase:
                   description: "The pipeline has finished without errors or interruptions."
                   value:
+                    timestamp: "2026-08-12T10:30:45.123Z"
                     symptom: "1 indicator is concerning (`pipelines`)"
                     indicators:
                       pipelines:
@@ -1818,6 +1824,7 @@ paths:
                 abnormalTerminatedCase:
                   description: "The pipeline is terminated with errors."
                   value:
+                    timestamp: "2026-08-12T10:30:45.123Z"
                     status: "red"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:
@@ -1840,6 +1847,7 @@ paths:
                 backpressureCase:
                   description: "A pipeline is blocked by slow downstream processing."
                   value:
+                    timestamp: "2026-08-12T10:30:45.123Z"
                     status: "red"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:
@@ -1869,6 +1877,7 @@ paths:
                 recoveryCase:
                   description: "A pipeline has recently recovered from a crash"
                   value:
+                    timestamp: "2026-08-12T10:30:45.123Z"
                     status: "yellow"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:

--- a/docs/static/spec/openapi/logstash-api.yaml
+++ b/docs/static/spec/openapi/logstash-api.yaml
@@ -1703,7 +1703,7 @@ paths:
                         type: string
                         format: date-time
                         description: The time at which this health report was generated, in ISO 8601 format with millisecond precision.
-                        example: "2026-08-12T10:30:45.123Z"
+                        example: "2026-08-12T10:30:45.123456789Z"
                       indicators:
                         description: Information about the health of Logstash indicators.
                         type: object
@@ -1803,7 +1803,7 @@ paths:
                 normalTerminatedCase:
                   description: "The pipeline has finished without errors or interruptions."
                   value:
-                    timestamp: "2026-08-12T10:30:45.123Z"
+                    timestamp: "2026-08-12T10:30:45.123456789Z"
                     symptom: "1 indicator is concerning (`pipelines`)"
                     indicators:
                       pipelines:
@@ -1824,7 +1824,7 @@ paths:
                 abnormalTerminatedCase:
                   description: "The pipeline is terminated with errors."
                   value:
-                    timestamp: "2026-08-12T10:30:45.123Z"
+                    timestamp: "2026-08-12T10:30:45.123456789Z"
                     status: "red"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:
@@ -1847,7 +1847,7 @@ paths:
                 backpressureCase:
                   description: "A pipeline is blocked by slow downstream processing."
                   value:
-                    timestamp: "2026-08-12T10:30:45.123Z"
+                    timestamp: "2026-08-12T10:30:45.123456789Z"
                     status: "red"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:
@@ -1877,7 +1877,7 @@ paths:
                 recoveryCase:
                   description: "A pipeline has recently recovered from a crash"
                   value:
-                    timestamp: "2026-08-12T10:30:45.123Z"
+                    timestamp: "2026-08-12T10:30:45.123456789Z"
                     status: "yellow"
                     symptom: "1 indicator is unhealthy (`pipelines`)"
                     indicators:

--- a/logstash-core/lib/logstash/api/modules/health_report.rb
+++ b/logstash-core/lib/logstash/api/modules/health_report.rb
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'time'
-
 module LogStash
   module Api
     module Modules
@@ -30,7 +28,7 @@ module LogStash
               status:     health_report_pojo.status,
               symptom:    health_report_pojo.symptom,
               indicators: health_report_pojo.indicators,
-              timestamp:  Time.now.iso8601(3),
+              timestamp:  LogStash::Timestamp.now.to_iso8601,
             })
           end
 

--- a/logstash-core/lib/logstash/api/modules/health_report.rb
+++ b/logstash-core/lib/logstash/api/modules/health_report.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'time'
+
 module LogStash
   module Api
     module Modules
@@ -28,6 +30,7 @@ module LogStash
               status:     health_report_pojo.status,
               symptom:    health_report_pojo.symptom,
               indicators: health_report_pojo.indicators,
+              timestamp:  Time.now.iso8601(3),
             })
           end
 

--- a/logstash-core/spec/logstash/api/modules/health_report_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/health_report_spec.rb
@@ -32,10 +32,10 @@ describe LogStash::Api::Modules::HealthReport do
       expect(last_response).to be_ok
     end
 
-    it "includes a timestamp in ISO 8601 format with millisecond precision" do
+    it "includes a timestamp in ISO 8601 format with microsecond precision" do
       body = JSON.parse(last_response.body)
       expect(body).to include("timestamp")
-      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:\d{2})\z/)
+      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z\z/)
     end
   end
 end

--- a/logstash-core/spec/logstash/api/modules/health_report_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/health_report_spec.rb
@@ -35,7 +35,7 @@ describe LogStash::Api::Modules::HealthReport do
     it "includes a timestamp in ISO 8601 format with millisecond precision" do
       body = JSON.parse(last_response.body)
       expect(body).to include("timestamp")
-      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}\z/)
+      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:\d{2})\z/)
     end
   end
 end

--- a/logstash-core/spec/logstash/api/modules/health_report_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/health_report_spec.rb
@@ -1,0 +1,41 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "spec_helper"
+
+require "sinatra"
+require "logstash/api/modules/health_report"
+
+describe LogStash::Api::Modules::HealthReport do
+  include_context "api setup"
+
+  include_examples "not found"
+
+  describe "GET /" do
+    before(:each) { get "/" }
+
+    it "returns 200" do
+      expect(last_response).to be_ok
+    end
+
+    it "includes a timestamp in ISO 8601 format with millisecond precision" do
+      body = JSON.parse(last_response.body)
+      expect(body).to include("timestamp")
+      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}\z/)
+    end
+  end
+end

--- a/logstash-core/spec/logstash/api/modules/health_report_spec.rb
+++ b/logstash-core/spec/logstash/api/modules/health_report_spec.rb
@@ -32,10 +32,10 @@ describe LogStash::Api::Modules::HealthReport do
       expect(last_response).to be_ok
     end
 
-    it "includes a timestamp in ISO 8601 format with microsecond precision" do
+    it "includes a timestamp in ISO 8601 format with sub-second precision" do
       body = JSON.parse(last_response.body)
       expect(body).to include("timestamp")
-      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z\z/)
+      expect(body["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(\d{3}(\d{3})?)?Z\z/)
     end
   end
 end

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -216,6 +216,8 @@ describe "Test Monitoring API" do
       expect(result).to be_a(Hash)
       expect(result).to include("status")
       expect(result["status"]).to match(/^(green|yellow|red)$/)
+      expect(result).to include("timestamp")
+      expect(result["timestamp"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/)
     end
   end
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Add Include timestamp in health report snapshot API response. The timestamp will be of ISO8601 format.

## What does this PR do?

Add `timestamp` field in the health API response. This PR also adds test cases for health API and updates the integration tests to check timestamp.

## Why is it important/What is the impact to the user?

Having timestamp makes it easy for the user to know how fresh the data is, especially when reports are captured, stored, or shared for later analysis..

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- Build the logstash `./gradlew assembleTarDistribution`
- Run it `bin/logstash -e 'input { stdin { } } output { stdout {} }'`
- Hit the `http://localhost:9600/_health_report` endpoint. You should see timestamp.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes https://github.com/elastic/logstash/issues/19245

## Screenshots

<img width="452" height="673" alt="Screenshot 2026-08-11 at 11 04 09 PM" src="https://github.com/user-attachments/assets/1421fc63-bd1c-40ee-ba95-8ecc39314dce" />


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
