### PR TITLE
Update concurrent-ruby gem

### DIFF
--- a/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
+++ b/logstash-core/lib/logstash/instrument/periodic_poller/base.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require "logstash/util"
+require "logstash/timer_task"
 require "concurrent"
 
 module LogStash module Instrument module PeriodicPoller
@@ -80,7 +81,7 @@ module LogStash module Instrument module PeriodicPoller
 
     protected
     def configure_task
-      @task = Concurrent::TimerTask.new { collect }
+      @task = LogStash::TimerTask.new { collect }
       @task.execution_interval = @options[:polling_interval]
       @task.timeout_interval = @options[:polling_timeout]
       @task.add_observer(self)

--- a/logstash-core/lib/logstash/timer_task.rb
+++ b/logstash-core/lib/logstash/timer_task.rb
@@ -1,0 +1,82 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "concurrent"
+
+module LogStash
+  # Runs a block every `execution_interval` seconds, notifying observers via
+  # `update(time, result, exception)`. If a run exceeds `timeout_interval` the
+  # observer receives a `Concurrent::TimeoutError` and scheduling continues.
+  #
+  # Replaces `Concurrent::TimerTask`, whose per-run timeout was removed in
+  # concurrent-ruby 1.1.10.
+  class TimerTask
+    attr_accessor :execution_interval, :timeout_interval
+
+    def initialize(opts = {}, &block)
+      raise ArgumentError, "no block given" unless block_given?
+
+      @execution_interval = opts[:execution_interval] || 60
+      @timeout_interval = opts[:timeout_interval]
+      @task = block
+      @observers = []
+      @observers_mutex = Mutex.new
+      @running = Concurrent::AtomicBoolean.new(false)
+    end
+
+    def add_observer(observer)
+      @observers_mutex.synchronize { @observers << observer }
+      observer
+    end
+
+    def execute
+      return self unless @running.make_true
+
+      @driver = Concurrent::TimerTask.new(:execution_interval => @execution_interval) { run_once }
+      @driver.execute
+      self
+    end
+
+    def shutdown
+      return false unless @running.make_false
+
+      @driver.shutdown if @driver
+      true
+    end
+
+    private
+
+    def run_once
+      future = Concurrent::Future.execute(&@task)
+      future.wait(@timeout_interval)
+
+      if !future.complete?
+        notify_observers(Time.now, nil, Concurrent::TimeoutError.new)
+      elsif future.rejected?
+        notify_observers(Time.now, nil, future.reason)
+      else
+        notify_observers(Time.now, future.value, nil)
+      end
+    end
+
+    def notify_observers(time, result, exception)
+      @observers_mutex.synchronize { @observers.dup }.each do |observer|
+        observer.update(time, result, exception)
+      end
+    end
+  end
+end

--- a/logstash-core/lib/logstash/timer_task.rb
+++ b/logstash-core/lib/logstash/timer_task.rb
@@ -20,7 +20,9 @@ require "concurrent"
 module LogStash
   # Runs a block every `execution_interval` seconds, notifying observers via
   # `update(time, result, exception)`. If a run exceeds `timeout_interval` the
-  # observer receives a `Concurrent::TimeoutError` and scheduling continues.
+  # observer receives a `Concurrent::TimeoutError`. A timed-out run is abandoned
+  # rather than killed; while it is still executing no new run is started, so at
+  # most one run is ever in flight.
   #
   # Replaces `Concurrent::TimerTask`, whose per-run timeout was removed in
   # concurrent-ruby 1.1.10.
@@ -36,6 +38,7 @@ module LogStash
       @observers = []
       @observers_mutex = Mutex.new
       @running = Concurrent::AtomicBoolean.new(false)
+      @in_flight = nil
     end
 
     def add_observer(observer)
@@ -61,7 +64,15 @@ module LogStash
     private
 
     def run_once
+      # A prior run timed out and is still executing: keep signalling the timeout
+      # but don't pile up a second concurrent run.
+      if @in_flight && !@in_flight.complete?
+        notify_observers(Time.now, nil, Concurrent::TimeoutError.new)
+        return
+      end
+
       future = Concurrent::Future.execute(&@task)
+      @in_flight = future
       future.wait(@timeout_interval)
 
       if !future.complete?

--- a/logstash-core/lib/logstash/timer_task.rb
+++ b/logstash-core/lib/logstash/timer_task.rb
@@ -38,7 +38,7 @@ module LogStash
       @observers = []
       @observers_mutex = Mutex.new
       @running = Concurrent::AtomicBoolean.new(false)
-      @in_flight = nil
+      @in_flight = nil # Future reference to executing block
     end
 
     def add_observer(observer)

--- a/logstash-core/logstash-core.gemspec
+++ b/logstash-core/logstash-core.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "clamp", "~> 1", ">= 1.3.3" #(MIT license) for command line args/flags
   gem.add_runtime_dependency "filesize", "~> 0.2" #(MIT license) for :bytes config validator
   gem.add_runtime_dependency "gems", "~> 1"  #(MIT license)
-  gem.add_runtime_dependency "concurrent-ruby", "~> 1", "< 1.1.10" # pinned until https://github.com/elastic/logstash/issues/13956
+  gem.add_runtime_dependency "concurrent-ruby", "~> 1.3"
   gem.add_runtime_dependency "rack", '~> 3'
   gem.add_runtime_dependency "sinatra", '~> 4'
   gem.add_runtime_dependency 'puma', '~> 8.0'
@@ -78,7 +78,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "jrjackson", "= #{ALL_VERSIONS.fetch('jrjackson')}" #(Apache 2.0 license)
 
-  gem.add_runtime_dependency "multi_json", "~> 1.19.1" # pinned until concurrent-ruby pin is lifted, multi_json 1.20.0-java requires concurrent-ruby ~> 1.2
+  gem.add_runtime_dependency "multi_json", "~> 1.20"
   gem.add_runtime_dependency "elasticsearch", '>= 8', '< 10'
   gem.add_runtime_dependency "manticore", '~> 0.6'
 

--- a/logstash-core/spec/logstash/timer_task_spec.rb
+++ b/logstash-core/spec/logstash/timer_task_spec.rb
@@ -78,11 +78,14 @@ describe LogStash::TimerTask do
   end
 
   context "when the task exceeds the timeout" do
+    let(:release) { Concurrent::CountDownLatch.new }
+
     subject do
-      described_class.new(:execution_interval => 0.1, :timeout_interval => 0.1) { sleep(30) }
+      latch = release
+      described_class.new(:execution_interval => 0.1, :timeout_interval => 0.1) { latch.wait }
     end
 
-    after { subject.shutdown }
+    after { release.count_down; subject.shutdown }
 
     it "notifies observers with a Concurrent::TimeoutError" do
       subject.add_observer(observer)
@@ -91,6 +94,19 @@ describe LogStash::TimerTask do
       _time, result, exception = wait_for_notification
       expect(result).to be_nil
       expect(exception).to be_a(Concurrent::TimeoutError)
+    end
+
+    it "does not start a second run while one is still in flight" do
+      runs = Concurrent::AtomicFixnum.new(0)
+      latch = release
+      task = described_class.new(:execution_interval => 0.1, :timeout_interval => 0.1) do
+        runs.increment
+        latch.wait
+      end
+      task.execute
+      sleep(0.6)
+      task.shutdown
+      expect(runs.value).to eq(1)
     end
   end
 

--- a/logstash-core/spec/logstash/timer_task_spec.rb
+++ b/logstash-core/spec/logstash/timer_task_spec.rb
@@ -1,0 +1,108 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require "logstash/timer_task"
+
+describe LogStash::TimerTask do
+  class RecordingObserver
+    attr_reader :notifications
+
+    def initialize
+      @notifications = Concurrent::Array.new
+    end
+
+    def update(time, result, exception)
+      @notifications << [time, result, exception]
+    end
+  end
+
+  let(:observer) { RecordingObserver.new }
+
+  def wait_for_notification(timeout = 5)
+    deadline = Time.now + timeout
+    sleep(0.05) while observer.notifications.empty? && Time.now < deadline
+    observer.notifications.first
+  end
+
+  it "raises when constructed without a block" do
+    expect { described_class.new }.to raise_error(ArgumentError)
+  end
+
+  context "when the task completes within the timeout" do
+    subject do
+      described_class.new(:execution_interval => 0.1, :timeout_interval => 5) { :done }
+    end
+
+    after { subject.shutdown }
+
+    it "notifies observers with the result and no exception" do
+      subject.add_observer(observer)
+      subject.execute
+
+      _time, result, exception = wait_for_notification
+      expect(result).to eq(:done)
+      expect(exception).to be_nil
+    end
+  end
+
+  context "when the task raises" do
+    subject do
+      described_class.new(:execution_interval => 0.1, :timeout_interval => 5) { raise "boom" }
+    end
+
+    after { subject.shutdown }
+
+    it "notifies observers with the exception" do
+      subject.add_observer(observer)
+      subject.execute
+
+      _time, result, exception = wait_for_notification
+      expect(result).to be_nil
+      expect(exception).to be_a(RuntimeError)
+      expect(exception.message).to eq("boom")
+    end
+  end
+
+  context "when the task exceeds the timeout" do
+    subject do
+      described_class.new(:execution_interval => 0.1, :timeout_interval => 0.1) { sleep(30) }
+    end
+
+    after { subject.shutdown }
+
+    it "notifies observers with a Concurrent::TimeoutError" do
+      subject.add_observer(observer)
+      subject.execute
+
+      _time, result, exception = wait_for_notification
+      expect(result).to be_nil
+      expect(exception).to be_a(Concurrent::TimeoutError)
+    end
+  end
+
+  describe "#shutdown" do
+    subject do
+      described_class.new(:execution_interval => 0.1, :timeout_interval => 5) { :done }
+    end
+
+    it "returns true the first time and false afterwards" do
+      subject.execute
+      expect(subject.shutdown).to be(true)
+      expect(subject.shutdown).to be(false)
+    end
+  end
+end

--- a/logstash-core/spec/logstash/timer_task_spec.rb
+++ b/logstash-core/spec/logstash/timer_task_spec.rb
@@ -106,6 +106,7 @@ describe LogStash::TimerTask do
       task.execute
       sleep(0.6)
       task.shutdown
+      release.count_down
       expect(runs.value).to eq(1)
     end
   end

--- a/x-pack/lib/monitoring/inputs/metrics.rb
+++ b/x-pack/lib/monitoring/inputs/metrics.rb
@@ -4,6 +4,7 @@
 
 require "logstash/inputs/base"
 require "logstash/instrument/collector"
+require "logstash/timer_task"
 require 'helpers/elasticsearch_options'
 require "concurrent"
 require "thread"
@@ -55,7 +56,7 @@ module LogStash module Inputs
     end
 
     def configure_snapshot_poller
-      @timer_task = Concurrent::TimerTask.new({
+      @timer_task = LogStash::TimerTask.new({
         :execution_interval => @collection_interval,
         :timeout_interval => @collection_timeout_interval
       }) do


### PR DESCRIPTION

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Update to the latest concurrent-ruby gem

## What does this PR do?

Unpin concurrent-ruby (~> 1.3, plus multi_json ~> 1.20), which was held back only by the removal of `TimerTask#timeout_interval` in 1.1.10. Use a new `LogStash::TimerTask` class  who's behavior-identical to the old `Concurrent::TimerTask`:
- fixed-delay scheduling
- per-run timeout surfaced to observers as Concurrent::TimeoutError
- timed-out task abandoned rather than killed 
-  built only on primitives upstream still supports (Future, AtomicBoolean, TimerTask without timeout) 
-  idempotent execute/shutdown

It's done in Ruby because the callsites are Ruby, so a pure-Ruby swap unblocks the upgrade immediately with no JRuby-boundary or ThreadContext plumbing (i also couldnt see how iinterrupt can't stop uninterruptible Ruby anyway which is the the reason upstream dropped it). 

Closes https://github.com/elastic/logstash/issues/19247