### PR TITLE
[docs] Warn not to use Cloud ID over AWS PrivateLink

### DIFF
--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -25,7 +25,7 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 {{ess-leadin-short}}
 
 :::{warning}
-If you connect over AWS PrivateLink, you can't use `cloud_id` or `cloud_auth`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id` or `cloud_auth`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 `output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }`
 :::

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -28,6 +28,23 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 
 {{ls}} uses the Cloud ID, found in the Elastic Cloud web console, to build the Elasticsearch and Kibana hosts settings. It is a base64 encoded text value of about 120 characters made up of upper and lower case letters and numbers. If you have several Cloud IDs, you can add a label, which is ignored internally, to help you tell them apart. To add a label, prefix your Cloud ID with a label and a `:` separator in this format "<label>:<cloud-id>".
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud_id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `hosts` to the private URL for your deployment. Don't also set `cloud_id`.
+
+```ruby
+output {
+  elasticsearch {
+    hosts => ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+    user => "elastic"
+    password => "YOUR_PASSWORD"
+  }
+}
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## Cloud Auth [cloud-auth]
 

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -29,22 +29,12 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 {{ls}} uses the Cloud ID, found in the Elastic Cloud web console, to build the Elasticsearch and Kibana hosts settings. It is a base64 encoded text value of about 120 characters made up of upper and lower case letters and numbers. If you have several Cloud IDs, you can add a label, which is ignored internally, to help you tell them apart. To add a label, prefix your Cloud ID with a label and a `:` separator in this format "<label>:<cloud-id>".
 
 :::{warning}
-If you connect over AWS PrivateLink, don't set `cloud_id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `hosts` to the private URL for your deployment. Don't also set `cloud_id`.
+If you connect over AWS PrivateLink, don't set `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 ```ruby
-output {
-  elasticsearch {
-    hosts => ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-    user => "elastic"
-    password => "YOUR_PASSWORD"
-  }
-}
+output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }
 ```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+:::
 
 ## Cloud Auth [cloud-auth]
 

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -25,7 +25,7 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 {{ess-leadin-short}}
 
 :::{warning}
-If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, whose hostname does not match the AWS PrivateLink TLS certificate. Copy the private {{es}} endpoint URL from the deployment overview page, then connect using `hosts` and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 `output {elasticsearch { hosts => ["ELASTICSEARCH_ENDPOINT_URL"] api_key => "<api key>" } }`
 :::

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -25,7 +25,7 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 {{ess-leadin-short}}
 
 :::{warning}
-If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. [Find the private {{es}} URL](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link), then connect using that URL and an API key:
 
 `output {elasticsearch { hosts => ["ELASTICSEARCH_ENDPOINT_URL"] api_key => "<api key>" } }`
 :::

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -31,9 +31,7 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 :::{warning}
 If you connect over AWS PrivateLink, don't set `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
-```ruby
-output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }
-```
+`output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }`
 :::
 
 ## Cloud Auth [cloud-auth]

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -25,9 +25,9 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 {{ess-leadin-short}}
 
 :::{warning}
-If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id` or `cloud_auth`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, whose hostname does not match the AWS PrivateLink TLS certificate. Copy the private {{es}} endpoint URL from the deployment overview page, then connect using `hosts` and an API key:
 
-`output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }`
+`output {elasticsearch { hosts => ["ELASTICSEARCH_ENDPOINT_URL"] api_key => "<api key>" } }`
 :::
 
 ## Cloud ID [cloud-id]

--- a/docs/reference/connecting-to-cloud.md
+++ b/docs/reference/connecting-to-cloud.md
@@ -24,15 +24,15 @@ Note that the value of the [`api_key` option](logstash-docs-md://lsr/plugins-out
 
 {{ess-leadin-short}}
 
-## Cloud ID [cloud-id]
-
-{{ls}} uses the Cloud ID, found in the Elastic Cloud web console, to build the Elasticsearch and Kibana hosts settings. It is a base64 encoded text value of about 120 characters made up of upper and lower case letters and numbers. If you have several Cloud IDs, you can add a label, which is ignored internally, to help you tell them apart. To add a label, prefix your Cloud ID with a label and a `:` separator in this format "<label>:<cloud-id>".
-
 :::{warning}
-If you connect over AWS PrivateLink, don't set `cloud_id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If you connect over AWS PrivateLink, you can't use `cloud_id` or `cloud_auth`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 `output {elasticsearch { hosts => "ELASTICSEARCH_ENDPOINT_URL" api_key => "<api key>" } }`
 :::
+
+## Cloud ID [cloud-id]
+
+{{ls}} uses the Cloud ID, found in the Elastic Cloud web console, to build the Elasticsearch and Kibana hosts settings. It is a base64 encoded text value of about 120 characters made up of upper and lower case letters and numbers. If you have several Cloud IDs, you can add a label, which is ignored internally, to help you tell them apart. To add a label, prefix your Cloud ID with a label and a `:` separator in this format "<label>:<cloud-id>".
 
 ## Cloud Auth [cloud-auth]
 


### PR DESCRIPTION
## Summary

Cloud ID encodes the public Elasticsearch endpoint. If an Elastic Cloud Hosted deployment is protected by an AWS PrivateLink VPC filter, that public endpoint is not available, so `cloud_id` fails.

This adds a warning on the Elastic Cloud Hosted connection page. The workaround is in the warning: copy the private Elasticsearch endpoint from the deployment overview, then connect with the same `hosts` plus API key pattern used for serverless.

Existing Cloud ID instructions are unchanged. This is AWS PrivateLink VPC filters only.

## Context

- [Private connectivity with AWS PrivateLink](https://www.elastic.co/docs/deploy-manage/security/private-connectivity-aws)
- [KB: avoid Cloud ID for PrivateLink deployments](https://ela.st/avoid-using-cloudid-for-privatelink-deployment)
- Companion Beats PR: https://github.com/elastic/beats/pull/52845
- Related hosted-docs PR: https://github.com/elastic/docs-content/pull/8034