### PR TITLE
Pin resolv 0.7.2

### DIFF
--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,4 +43,4 @@ gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default
-gem "resolv", "~> 0.7.2" # Pins until JRuby ships the patched version
+gem "resolv", "~> 0.7.2" # Require resolv 0.7.x (>= 0.7.2) until JRuby ships the patched version

--- a/Gemfile.template
+++ b/Gemfile.template
@@ -43,3 +43,4 @@ gem "date", "= 3.3.3"
 gem "thwait"
 gem "bigdecimal", "~> 3.1"
 gem "jar-dependencies", "= 0.5.4" # Pin to avoid conflict with default
+gem "resolv", "~> 0.7.2" # Pins until JRuby ships the patched version


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?
The `resolv` gem ships as a default gem inside JRuby, and the version JRuby currently bundles (0.6.3) is older than the one Logstash needs.