### PR TITLE
[Docs] Lumberjack input plugin should not be used

### DIFF
--- a/docs/reference/logstash-to-logstash-communications.md
+++ b/docs/reference/logstash-to-logstash-communications.md
@@ -34,6 +34,7 @@ $$$lumberjack-considerations$$$**Lumberjack-Beats considerations**
 
 Lumberjack output to Beats input has been our standard approach for {{ls}}-to-{{ls}} communication, but our recommended approach is now [Logstash-to-Logstash: Output to Input](/reference/ls-to-ls-native.md). Before you implement the Lumberjack to Beats configuration, keep these points in mind:
 
+* The Lumberjack input plugin is not maintained or supported and should not be used.
 * Lumberjack to Beats provides high availability, but does not provide load balancing. The Lumberjack output plugin allows defining multiple output hosts for high availability, but instead of load-balancing between all output hosts, it falls back to one host on the list in the case of failure.
 * If you need a proxy between the Logstash instances, TCP proxy is the only option.
 * There’s no explicit way to exert back pressure back to the beats input.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Docs: Avoid using lumberjack plugin in LS to LS communication

## What does this PR do?
Sends a message to users to avoid using lumberjack plugin.

## Why is it important/What is the impact to the user?


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
